### PR TITLE
Fix usage handling in ValueError.Error

### DIFF
--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -43,7 +43,7 @@ func (err *ValueError) Error() string {
 		option = "--" + option
 	}
 	msg := fmt.Sprintf("invalid value '%s' for option '%s'", err.value, option)
-	if err.usage == "" {
+	if err.usage != "" {
 		msg = fmt.Sprintf("%s: %s", msg, err.usage)
 	}
 	return msg


### PR DESCRIPTION
## Summary
- correct ValueError error message when a usage string is provided

## Testing
- `go test ./...` *(fails: could not download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68438f4eb418832588ff65b74cc2f2dd