### PR TITLE
Fix authorization comment

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -203,7 +203,7 @@ func (c *Client) NewRequest(ctx context.Context, cfg RequestConfig) (*http.Reque
 	// Set the content-length header if the body is a file.
 	setFileContentLength(req)
 
-	// Optionally set the authohrization header.
+	// Optionally set the authorization header.
 	switch {
 	case cfg.AWSSigV4 != nil:
 		err = aws.Sign(req, *cfg.AWSSigV4, time.Now().UTC())


### PR DESCRIPTION
## Summary
- fix spelling in authorization header comment

## Testing
- `gofmt -w internal/client/client.go`


------
https://chatgpt.com/codex/tasks/task_e_6843913b33508325a1bf5b4b6824570e