### PR TITLE
Add debug verbosity with DNS/TLS tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ fetch --image native example.com
 
 Increase verbosity of the output to stderr; use multiple times for extra verbosity.
 
-One `-v` outputs response headers. Two `-v`s outputs request headers as well.
+One `-v` outputs response headers. Two `-v`s outputs request headers as well. Three `-v`s prints DNS and TLS details as they occur.
 
 ```sh
 fetch -vv example.com
@@ -402,6 +402,10 @@ timeout = 30s
 tls = 1.3
 
 # Specify the verbosity level. Must be 0 or greater.
+# 0 = normal
+# 1 = verbose
+# 2 = extra verbose
+# 3 = debug
 verbosity = 2
 
 # Domain-specific settings that take precedence over global options.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -102,6 +102,10 @@ func TestMain(t *testing.T) {
 		assertBufContains(t, res.stderr, "user-agent")
 		assertBufContains(t, res.stderr, "x-custom-header")
 		assertBufEquals(t, res.stdout, "hello")
+
+		res = runFetch(t, fetchPath, server.URL, "-vvv")
+		assertExitCode(t, 0, res)
+		assertBufContains(t, res.stderr, "GET / HTTP/1.1")
 	})
 
 	t.Run("aws-sigv4 auth", func(t *testing.T) {

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -17,6 +17,7 @@ import (
 type File struct {
 	Global *Config
 	Hosts  map[string]*Config
+	Path   string
 }
 
 // GetFile returns a config File, or nil if one cannot be found.
@@ -89,7 +90,7 @@ func readFile(path string) (string, []byte, error) {
 
 // parseFile parses the provided File, returning any error encountered.
 func parseFile(path, s string) (*File, error) {
-	f := File{Global: &Config{isFile: true}}
+	f := File{Global: &Config{isFile: true}, Path: path}
 
 	config := f.Global
 	for num, line := range lines(s) {

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -28,6 +28,7 @@ func TestParseFile(t *testing.T) {
 					Timeout: core.PointerTo(10 * time.Second),
 					TLS:     core.PointerTo(uint16(tls.VersionTLS13)),
 				},
+				Path: "test/config",
 			},
 		},
 		{
@@ -58,6 +59,7 @@ func TestParseFile(t *testing.T) {
 						IgnoreStatus: core.PointerTo(true),
 					},
 				},
+				Path: "test/config",
 			},
 		},
 		{

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -47,6 +47,7 @@ const (
 	VNormal
 	VVerbose
 	VExtraVerbose
+	LDebug
 )
 
 // KeyVal represents a generic key & value struct.

--- a/internal/fetch/debug.go
+++ b/internal/fetch/debug.go
@@ -1,0 +1,53 @@
+package fetch
+
+import (
+	"crypto/tls"
+	"net/http/httptrace"
+
+	"github.com/ryanfowler/fetch/internal/core"
+)
+
+func newDebugTrace(p *core.Printer) *httptrace.ClientTrace {
+	var host string
+	return &httptrace.ClientTrace{
+		DNSStart: func(info httptrace.DNSStartInfo) { host = info.Host },
+		DNSDone: func(info httptrace.DNSDoneInfo) {
+			if info.Err != nil {
+				return
+			}
+
+			p.Set(core.Bold)
+			p.Set(core.Cyan)
+			p.WriteString("DNS")
+			p.Reset()
+			p.WriteString(": ")
+			if host != "" {
+				p.WriteString(host)
+				p.WriteString("\n")
+			}
+			for _, addr := range info.Addrs {
+				p.WriteString("  -> ")
+				p.Set(core.Italic)
+				p.WriteString(addr.String())
+				p.Reset()
+				p.WriteString("\n")
+			}
+			p.WriteString("\n")
+			p.Flush()
+		},
+		TLSHandshakeDone: func(cs tls.ConnectionState, err error) {
+			if err != nil {
+				return
+			}
+
+			p.Set(core.Bold)
+			p.Set(core.Blue)
+			p.WriteString(tls.VersionName(cs.Version))
+			p.Reset()
+			p.WriteString(": ")
+			p.WriteString(tls.CipherSuiteName(cs.CipherSuite))
+			p.WriteString("\n\n")
+			p.Flush()
+		},
+	}
+}

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 	"os"
 	"os/exec"
@@ -162,6 +163,11 @@ func fetch(ctx context.Context, r *Request) (int, error) {
 }
 
 func makeRequest(ctx context.Context, r *Request, c *client.Client, req *http.Request) (int, error) {
+	if r.Verbosity >= core.LDebug {
+		trace := newDebugTrace(r.PrinterHandle.Stderr())
+		req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	}
+
 	resp, err := c.Do(req)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Summary
- add new verbosity level `LDebug` to print DNS and TLS data
- implement httptrace debugging hooks for DNS and TLS
- document third level of `-v` in README and config
- extend verbosity integration test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68449462358083259b470f5f27e8c700