### PR TITLE
chore: bump Go to 1.24.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
 
 env:
-  GO_VERSION: "1.24.5"
+  GO_VERSION: "1.24.6"
 
 jobs:
   check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  GO_VERSION: "1.24.5"
+  GO_VERSION: "1.24.6"
 
 jobs:
   release:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ryanfowler/fetch
 
-go 1.24.5
+go 1.24.6
 
 require (
 	golang.org/x/image v0.29.0


### PR DESCRIPTION
## Summary
- update module go version to 1.24.6
- use Go 1.24.6 in CI and release workflows

## Testing
- `gofmt -w $(git ls-files '*.go')`
- `go mod tidy`
- `go mod verify`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893d683e2408325a824e4fba090084b