### PR TITLE
Include system roots when using --ca-cert

### DIFF
--- a/internal/client/tls.go
+++ b/internal/client/tls.go
@@ -32,7 +32,10 @@ func (c *TLSDialConfig) BuildTLSConfig() *tls.Config {
 		tlsConfig.InsecureSkipVerify = true
 	}
 	if len(c.CACerts) > 0 {
-		certPool := x509.NewCertPool()
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			certPool = x509.NewCertPool()
+		}
 		for _, cert := range c.CACerts {
 			certPool.AddCert(cert)
 		}


### PR DESCRIPTION
Previously --ca-cert created a fresh cert pool with only the custom CA, discarding system roots. This matches curl's behavior by starting from the system cert pool and appending the custom CAs on top.