### PR TITLE
Close file handles immediately in @file data value loop

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -599,10 +599,10 @@ func (a *App) applyFromCurl(r *curl.Result) error {
 				if err != nil {
 					return err
 				}
-				if c, ok := reader.(io.Closer); ok {
-					defer c.Close()
-				}
 				b, err := io.ReadAll(reader)
+				if c, ok := reader.(io.Closer); ok {
+					c.Close()
+				}
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Avoid deferring Close() inside a loop, which keeps all file handles open until the function returns. Instead, close each handle right after reading.