### PR TITLE
Fix response body leak on decoder setup failures

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -538,23 +538,36 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	ce := getContentEncoding(resp.Header)
 	if encodingRequested(req) && resp.Body != nil {
 		if strings.EqualFold(ce, "gzip") {
-			gz, err := newGZIPReader(resp.Body)
+			err := decodeResponseBody(resp, "gzip", func(rc io.ReadCloser) (io.ReadCloser, error) {
+				return newGZIPReader(rc)
+			})
 			if err != nil {
-				return nil, fmt.Errorf("gzip: %w", err)
+				return nil, err
 			}
-			resp.Body = gz
-			resp.ContentLength = -1
 		} else if strings.EqualFold(ce, "zstd") {
-			zs, err := newZSTDReader(resp.Body)
+			err := decodeResponseBody(resp, "zstd", func(rc io.ReadCloser) (io.ReadCloser, error) {
+				return newZSTDReader(rc)
+			})
 			if err != nil {
-				return nil, fmt.Errorf("zstd: %w", err)
+				return nil, err
 			}
-			resp.Body = zs
-			resp.ContentLength = -1
 		}
 	}
 
 	return resp, nil
+}
+
+type responseBodyDecoder func(io.ReadCloser) (io.ReadCloser, error)
+
+func decodeResponseBody(resp *http.Response, name string, decoder responseBodyDecoder) error {
+	body, err := decoder(resp.Body)
+	if err != nil {
+		resp.Body.Close()
+		return fmt.Errorf("%s: %w", name, err)
+	}
+	resp.Body = body
+	resp.ContentLength = -1
+	return nil
 }
 
 func getContentEncoding(h http.Header) string {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,6 +1,14 @@
 package client
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
 
 func TestIsLoopback(t *testing.T) {
 	tests := []struct {
@@ -36,4 +44,101 @@ func TestIsLoopback(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDoClosesResponseBodyWhenDecoderConstructionFails(t *testing.T) {
+	body := &trackingReadCloser{
+		Reader: bytes.NewReader([]byte("not a valid compressed body")),
+	}
+	c := &Client{
+		c: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Encoding": []string{"gzip"},
+					},
+					Body:    body,
+					Request: req,
+				}, nil
+			}),
+		},
+	}
+	req, err := http.NewRequestWithContext(
+		context.WithValue(context.Background(), ctxEncodingRequestedKey, true),
+		http.MethodGet,
+		"https://example.com",
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := c.Do(req)
+	if err == nil {
+		t.Fatal("expected decoder construction error")
+	}
+	if resp != nil {
+		t.Fatalf("response = %v, want nil", resp)
+	}
+	if !strings.Contains(err.Error(), "gzip:") {
+		t.Fatalf("error = %q, want prefix containing %q", err, "gzip:")
+	}
+	if !body.closed {
+		t.Fatal("response body was not closed")
+	}
+}
+
+func TestDecodeResponseBodyClosesResponseBodyWhenDecoderConstructionFails(t *testing.T) {
+	decoderErr := errors.New("bad header")
+	tests := []struct {
+		encoding string
+	}{
+		{encoding: "gzip"},
+		{encoding: "zstd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.encoding, func(t *testing.T) {
+			body := &trackingReadCloser{
+				Reader: bytes.NewReader([]byte("not a valid compressed body")),
+			}
+			resp := &http.Response{
+				Body:          body,
+				ContentLength: 123,
+			}
+
+			err := decodeResponseBody(resp, tt.encoding, func(io.ReadCloser) (io.ReadCloser, error) {
+				return nil, decoderErr
+			})
+			if err == nil {
+				t.Fatal("expected decoder construction error")
+			}
+			if !errors.Is(err, decoderErr) {
+				t.Fatalf("error = %v, want wrapped %v", err, decoderErr)
+			}
+			if !strings.Contains(err.Error(), tt.encoding+":") {
+				t.Fatalf("error = %q, want prefix containing %q", err, tt.encoding+":")
+			}
+			if !body.closed {
+				t.Fatal("response body was not closed")
+			}
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingReadCloser struct {
+	*bytes.Reader
+	closed bool
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
 }


### PR DESCRIPTION
**Summary**
- Close the original response body when gzip or zstd decoder construction fails.
- Factor decoder installation into a shared helper that preserves error wrapping and content length handling.
- Add regression tests for body closure on decoder setup errors.

**Testing**
- `go test -v ./internal/client`