### PR TITLE
Fix AWS SigV4 header whitespace canonicalization

### DIFF
--- a/internal/aws/sigv4.go
+++ b/internal/aws/sigv4.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/ryanfowler/fetch/internal/core"
 )
@@ -145,7 +146,7 @@ func getSignedHeaders(req *http.Request) []core.KeyVal[string] {
 			continue
 		}
 		key = strings.ToLower(strings.TrimSpace(key))
-		val := strings.TrimSpace(strings.Join(vals, ","))
+		val := canonicalHeaderValue(vals)
 		out = append(out, core.KeyVal[string]{Key: key, Val: val})
 	}
 	// Headers should be ordered by key.
@@ -153,6 +154,62 @@ func getSignedHeaders(req *http.Request) []core.KeyVal[string] {
 		return strings.Compare(a.Key, b.Key)
 	})
 	return out
+}
+
+func canonicalHeaderValue(vals []string) string {
+	if len(vals) == 0 {
+		return ""
+	}
+	if len(vals) == 1 && isCanonicalHeaderValue(vals[0]) {
+		return vals[0]
+	}
+
+	var buf strings.Builder
+	buf.Grow(len(vals) - 1)
+	for _, v := range vals {
+		buf.Grow(len(v))
+	}
+	for i, v := range vals {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		writeCanonicalHeaderValue(&buf, v)
+	}
+	return buf.String()
+}
+
+func isCanonicalHeaderValue(val string) bool {
+	inWhitespace := false
+	wroteValue := false
+	for _, r := range val {
+		if !unicode.IsSpace(r) {
+			inWhitespace = false
+			wroteValue = true
+			continue
+		}
+		if r != ' ' || inWhitespace || !wroteValue {
+			return false
+		}
+		inWhitespace = true
+	}
+	return !inWhitespace
+}
+
+func writeCanonicalHeaderValue(buf *strings.Builder, val string) {
+	inWhitespace := true
+	wroteValue := false
+	for _, r := range val {
+		if unicode.IsSpace(r) {
+			inWhitespace = true
+			continue
+		}
+		if inWhitespace && wroteValue {
+			buf.WriteByte(' ')
+		}
+		buf.WriteRune(r)
+		inWhitespace = false
+		wroteValue = true
+	}
 }
 
 func buildCanonicalRequest(req *http.Request, headers []core.KeyVal[string], payload string) []byte {

--- a/internal/aws/sigv4_test.go
+++ b/internal/aws/sigv4_test.go
@@ -107,3 +107,29 @@ func TestSign(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSignedHeadersCanonicalizesHeaderValues(t *testing.T) {
+	req, _ := http.NewRequest("GET", "https://example.com", nil)
+	req.Header["X-Foo"] = []string{"  a  ", "  b  "}
+	req.Header.Set("X-Bar", "  a\t \n b  ")
+
+	headers := getSignedHeaders(req)
+
+	tests := map[string]string{
+		"x-bar": "a b",
+		"x-foo": "a,b",
+	}
+	for key, want := range tests {
+		t.Run(key, func(t *testing.T) {
+			for _, header := range headers {
+				if header.Key == key {
+					if header.Val != want {
+						t.Fatalf("unexpected value: got %q, want %q", header.Val, want)
+					}
+					return
+				}
+			}
+			t.Fatalf("signed header %q not found", key)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Canonicalize each AWS SigV4 header value before signing
- Collapse internal whitespace runs to a single space and join multi-value headers with commas
- Avoid extra allocations for already-canonical single header values
- Add regression coverage for multi-value and internal-whitespace header cases

## Testing
- `go test -v ./internal/aws`
- `go test -v ./...`