### PR TITLE
Fix update lock retry backoff

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -535,7 +535,7 @@ func acquireLock(ctx context.Context, p *core.Printer, dir string, block bool) (
 			core.WriteWarningMsg(p, "waiting on lock to begin updating\n")
 		}
 
-		mult := time.Duration(min(i, 10))
+		mult := time.Duration(min(i+1, 10))
 		select {
 		case <-ctx.Done():
 			f.Close()


### PR DESCRIPTION
## Summary
- Start the update lock retry multiplier at 1 instead of 0.
- Prevent the first blocked retry from firing immediately with no backoff.

## Testing
- Not run (not requested)