### PR TITLE
Fix orphaned temp files on atomic replace failure

### DIFF
--- a/internal/fetch/output.go
+++ b/internal/fetch/output.go
@@ -54,8 +54,11 @@ func writeOutputToFile(filename string, body io.Reader, size int64, p *core.Prin
 		return err
 	}
 
-	err = fileutil.AtomicReplaceFile(f.Name(), filename)
-	return err
+	if err = fileutil.AtomicReplaceFile(f.Name(), filename); err != nil {
+		os.Remove(f.Name())
+		return err
+	}
+	return nil
 
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -115,7 +115,11 @@ func (s *Session) Save() error {
 		return err
 	}
 
-	return fileutil.AtomicReplaceFile(tmpPath, s.path)
+	if err := fileutil.AtomicReplaceFile(tmpPath, s.path); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }
 
 // Jar returns an http.CookieJar that persists cookies to this session.


### PR DESCRIPTION
## Summary
- Remove download temp files when atomic replacement fails.
- Remove session temp files when atomic replacement fails.
- Preserve the original atomic replace error for callers.

## Testing
- `go test -v ./internal/fetch ./internal/session`
- `go test -v ./...`