### PR TITLE
Fix `--output` clobber handling

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -583,6 +583,47 @@ func TestMain(t *testing.T) {
 		}
 	})
 
+	t.Run("direct output file exists error", func(t *testing.T) {
+		t.Parallel()
+		const data = "new content"
+		server := startServer(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			io.WriteString(w, data)
+		})
+		defer server.Close()
+
+		dir := t.TempDir()
+
+		existingPath := filepath.Join(dir, "existing.txt")
+		if err := os.WriteFile(existingPath, []byte("old content"), 0644); err != nil {
+			t.Fatalf("unable to create existing file: %s", err.Error())
+		}
+
+		res := runFetch(t, fetchPath, server.URL, "-o", existingPath)
+		assertExitCode(t, 1, res)
+		assertBufContains(t, res.stderr, "already exists")
+		assertBufContains(t, res.stderr, "--clobber")
+
+		raw, err := os.ReadFile(existingPath)
+		if err != nil {
+			t.Fatalf("unable to read from existing file: %s", err.Error())
+		}
+		if string(raw) != "old content" {
+			t.Fatalf("existing file was modified: %s", raw)
+		}
+
+		res = runFetch(t, fetchPath, server.URL, "-o", existingPath, "--clobber")
+		assertExitCode(t, 0, res)
+
+		raw, err = os.ReadFile(existingPath)
+		if err != nil {
+			t.Fatalf("unable to read from existing file: %s", err.Error())
+		}
+		if string(raw) != data {
+			t.Fatalf("existing file was not overwritten: %s", raw)
+		}
+	})
+
 	t.Run("clobber overwrites existing file", func(t *testing.T) {
 		t.Parallel()
 		const data = "new content"

--- a/internal/fetch/output.go
+++ b/internal/fetch/output.go
@@ -65,6 +65,11 @@ func writeOutputToFile(filename string, body io.Reader, size int64, p *core.Prin
 func getOutputValue(r *Request, resp *http.Response) (string, error) {
 	if r.Output != "" {
 		// Output was provided directly via -o, return it without sanitization.
+		if r.Output != "-" {
+			if err := checkOutputFile(r.Output, r.Clobber); err != nil {
+				return "", err
+			}
+		}
 		return r.Output, nil
 	}
 	if !r.RemoteName {
@@ -113,17 +118,26 @@ func getOutputValue(r *Request, resp *http.Response) (string, error) {
 	}
 
 	// Check if file exists (unless --clobber is set).
-	if !r.Clobber {
-		_, err := os.Stat(filename)
-		if err == nil {
-			return "", errFileExists{path: filename}
-		}
-		if !os.IsNotExist(err) {
-			return "", errFileCheck{path: filename, err: err}
-		}
+	if err := checkOutputFile(filename, r.Clobber); err != nil {
+		return "", err
 	}
 
 	return filename, nil
+}
+
+func checkOutputFile(filename string, clobber bool) error {
+	if clobber {
+		return nil
+	}
+
+	_, err := os.Stat(filename)
+	if err == nil {
+		return errFileExists{path: filename}
+	}
+	if !os.IsNotExist(err) {
+		return errFileCheck{path: filename, err: err}
+	}
+	return nil
 }
 
 func sanitizeFilename(filename string) (string, error) {

--- a/internal/fetch/output_test.go
+++ b/internal/fetch/output_test.go
@@ -98,6 +98,62 @@ func TestSanitizeFilename(t *testing.T) {
 	}
 }
 
+func TestGetOutputValue_DirectOutputRequiresClobber(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.txt")
+
+	if err := os.WriteFile(path, []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	name, err := getOutputValue(&Request{Output: path}, nil)
+	if err == nil {
+		t.Fatal("getOutputValue succeeded for an existing output file without clobber")
+	}
+	if name != "" {
+		t.Fatalf("getOutputValue filename = %q, want empty string", name)
+	}
+	if _, ok := err.(errFileExists); !ok {
+		t.Fatalf("getOutputValue error = %T, want errFileExists", err)
+	}
+
+	name, err = getOutputValue(&Request{Output: path, Clobber: true}, nil)
+	if err != nil {
+		t.Fatalf("getOutputValue with clobber returned error: %v", err)
+	}
+	if name != path {
+		t.Fatalf("getOutputValue filename = %q, want %q", name, path)
+	}
+}
+
+func TestGetOutputValue_DirectStdoutSkipsFileCheck(t *testing.T) {
+	dir := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldwd); err != nil {
+			t.Fatalf("restore working directory: %v", err)
+		}
+	})
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("-", []byte("existing stdout sentinel"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	name, err := getOutputValue(&Request{Output: "-"}, nil)
+	if err != nil {
+		t.Fatalf("getOutputValue returned error: %v", err)
+	}
+	if name != "-" {
+		t.Fatalf("getOutputValue filename = %q, want %q", name, "-")
+	}
+}
+
 func TestWriteOutputToFile_OverwritesExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "download.txt")


### PR DESCRIPTION
## Summary
- Check explicit `-o/--output` paths for existing files before writing
- Preserve `-o -` as stdout without file existence checks
- Add unit and integration coverage for direct output clobber behavior

## Testing
- `go test -v ./internal/fetch`
- `go test -v ./integration`
- `go test -v ./...`