### PR TITLE
Fix multipart filename leak

### DIFF
--- a/docs/request-bodies.md
+++ b/docs/request-bodies.md
@@ -176,6 +176,8 @@ fetch -F file=@document.pdf -m POST example.com/upload
 fetch -F avatar=@photo.jpg -F name=John -m POST example.com/profile
 ```
 
+When uploading a file by path, only the file's base name is sent in the multipart `filename` parameter.
+
 ### Multiple Files
 
 ```sh

--- a/internal/multipart/multipart.go
+++ b/internal/multipart/multipart.go
@@ -5,6 +5,7 @@ import (
 	"mime/multipart"
 	"net/textproto"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/ryanfowler/fetch/internal/core"
@@ -75,7 +76,7 @@ func writeFilePart(mpw *multipart.Writer, key, filename string) error {
 	}
 
 	headers := textproto.MIMEHeader{}
-	headers.Set("Content-Disposition", multipart.FileContentDisposition(key, filename))
+	headers.Set("Content-Disposition", multipart.FileContentDisposition(key, filepath.Base(filename)))
 	headers.Set("Content-Type", ct)
 
 	w, err := mpw.CreatePart(headers)

--- a/internal/multipart/multipart_test.go
+++ b/internal/multipart/multipart_test.go
@@ -5,6 +5,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ryanfowler/fetch/internal/core"
@@ -36,6 +37,9 @@ func TestMultipart(t *testing.T) {
 				t.Helper()
 
 				header := f.File["key1"][0]
+				if header.Filename != filepath.Base(header.Filename) {
+					t.Fatalf("multipart filename includes path: %q", header.Filename)
+				}
 				if ct := header.Header.Get("Content-Type"); ct != "application/json" {
 					t.Fatalf("unexpected content-type: %q", ct)
 				}
@@ -50,6 +54,34 @@ func TestMultipart(t *testing.T) {
 				buf.ReadFrom(file)
 				if buf.String() != `{"key":"val"}` {
 					t.Fatalf("unexpected file content: %q", buf.String())
+				}
+			},
+		},
+		{
+			name: "file uses base name in content disposition",
+			fnPre: func(t *testing.T) ([]core.KeyVal[string], func()) {
+				t.Helper()
+
+				dir := t.TempDir()
+				name := filepath.Join(dir, "secret", "report.pdf")
+				if err := os.MkdirAll(filepath.Dir(name), 0o755); err != nil {
+					t.Fatalf("unable to create temp dir: %s", err.Error())
+				}
+				if err := os.WriteFile(name, []byte("%PDF-1.7"), 0o644); err != nil {
+					t.Fatalf("unable to create temp file: %s", err.Error())
+				}
+
+				return []core.KeyVal[string]{{Key: "file", Val: "@" + name}}, nil
+			},
+			fnPost: func(t *testing.T, f *multipart.Form) {
+				t.Helper()
+
+				header := f.File["file"][0]
+				if header.Filename != "report.pdf" {
+					t.Fatalf("unexpected multipart filename: %q", header.Filename)
+				}
+				if ct := header.Header.Get("Content-Type"); ct != "application/pdf" {
+					t.Fatalf("unexpected content-type: %q", ct)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
- Send only `filepath.Base(...)` in multipart `Content-Disposition` filenames
- Keep full paths for opening files and MIME detection
- Add regression coverage for path-based uploads and update docs

## Testing
- `go test -v ./internal/multipart`
- `go test -v ./integration -run TestMain/multipart`