### PR TITLE
Fix explicit empty long-flag values

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -203,7 +203,7 @@ func parseLongFlag(arg string, args []string, long map[string]Flag) ([]string, e
 		return nil, flagNoArgsError("--" + name)
 	}
 
-	if flag.Args != "" && value == "" {
+	if flag.Args != "" && !ok {
 		if len(args) == 0 {
 			return nil, argRequiredError("--" + name)
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -134,6 +134,43 @@ func TestCLI(t *testing.T) {
 	}
 }
 
+func TestLongFlagExplicitEmptyValue(t *testing.T) {
+	t.Run("does not consume following URL", func(t *testing.T) {
+		app, err := Parse([]string{"--output=", "example.com"})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if app.Output != "" {
+			t.Fatalf("Output = %q, want empty string", app.Output)
+		}
+		if app.URL == nil {
+			t.Fatal("expected URL to be parsed")
+		}
+		if app.URL.Host != "example.com" {
+			t.Fatalf("URL host = %q, want %q", app.URL.Host, "example.com")
+		}
+	})
+
+	t.Run("passes empty value to flag", func(t *testing.T) {
+		app, err := Parse([]string{"--form=", "example.com"})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if len(app.Form) != 1 {
+			t.Fatalf("len(Form) = %d, want 1", len(app.Form))
+		}
+		if app.Form[0].Key != "" || app.Form[0].Val != "" {
+			t.Fatalf("Form[0] = %#v, want empty key/value", app.Form[0])
+		}
+		if app.URL == nil {
+			t.Fatal("expected URL to be parsed")
+		}
+		if app.URL.Host != "example.com" {
+			t.Fatalf("URL host = %q, want %q", app.URL.Host, "example.com")
+		}
+	})
+}
+
 func TestGRPCDiscoveryFlags(t *testing.T) {
 	t.Run("grpc list parses", func(t *testing.T) {
 		app, err := Parse([]string{"--grpc-list", "localhost:50051"})


### PR DESCRIPTION
## Summary
- Treat `--flag=` as an explicit empty value instead of consuming the next token
- Preserve the following argument as the URL when a long flag is passed with `=` but no value
- Add regression coverage for `--output=` and empty-valued long flags

## Testing
- `go test -v ./internal/cli`
- `go test -v ./...`