### PR TITLE
Fix byte-range validation for range flags

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/ryanfowler/fetch/internal/aws"
@@ -674,6 +673,10 @@ func isValidRangeValue(value string) bool {
 	if value == "" {
 		return true
 	}
-	_, err := strconv.Atoi(value)
-	return err == nil
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -730,7 +730,11 @@ func (a *App) applyFromCurl(r *curl.Result) error {
 	}
 
 	// Ranges.
-	a.Range = r.Ranges
+	for _, rng := range r.Ranges {
+		if err := a.parseRangeFlag(rng); err != nil {
+			return err
+		}
+	}
 
 	// HTTP version.
 	switch r.HTTPVersion {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -171,6 +171,80 @@ func TestLongFlagExplicitEmptyValue(t *testing.T) {
 	})
 }
 
+func TestRangeFlag(t *testing.T) {
+	t.Run("accepts unsigned byte ranges", func(t *testing.T) {
+		tests := []struct {
+			name string
+			arg  string
+			want []string
+		}{
+			{name: "suffix", arg: "-1023", want: []string{"-1023"}},
+			{name: "open ended", arg: "1023-", want: []string{"1023-"}},
+			{name: "bounded", arg: "0-1023", want: []string{"0-1023"}},
+			{name: "trimmed", arg: " 5 - 10 ", want: []string{"5-10"}},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				app, err := Parse([]string{"--range", tt.arg})
+				if err != nil {
+					t.Fatalf("Parse() error = %v", err)
+				}
+				if len(app.Range) != len(tt.want) {
+					t.Fatalf("Range = %v, want %v", app.Range, tt.want)
+				}
+				for i := range tt.want {
+					if app.Range[i] != tt.want[i] {
+						t.Fatalf("Range = %v, want %v", app.Range, tt.want)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("rejects signed or malformed byte ranges", func(t *testing.T) {
+		tests := []string{
+			"bad",
+			"-",
+			"5--1",
+			"+5-10",
+			"5-+10",
+			"--1",
+			"-+1",
+		}
+
+		for _, arg := range tests {
+			t.Run(arg, func(t *testing.T) {
+				_, err := Parse([]string{"--range", arg})
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), "invalid") {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("validates ranges from curl commands", func(t *testing.T) {
+		app, err := Parse([]string{"--from-curl", "curl -r 0-1023 https://example.com/file"})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if len(app.Range) != 1 || app.Range[0] != "0-1023" {
+			t.Fatalf("Range = %v, want [0-1023]", app.Range)
+		}
+
+		_, err = Parse([]string{"--from-curl", "curl -r 5--1 https://example.com/file"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid range end") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestGRPCDiscoveryFlags(t *testing.T) {
 	t.Run("grpc list parses", func(t *testing.T) {
 		app, err := Parse([]string{"--grpc-list", "localhost:50051"})


### PR DESCRIPTION
## Summary
- Reject signed or otherwise non-digit byte-range components
- Route `--from-curl` range values through the same validation path
- Add CLI tests for valid suffix/open-ended ranges and invalid signed inputs

## Testing
- `go test -v ./internal/cli`
- `go test -v ./integration -run "TestMain/range request"`
- `go test -v ./...`