### PR TITLE
Fix dropped WebSocket stdin messages

### DIFF
--- a/internal/ws/write.go
+++ b/internal/ws/write.go
@@ -3,6 +3,9 @@ package ws
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
+	"io"
 
 	"github.com/coder/websocket"
 )
@@ -10,21 +13,39 @@ import (
 // writeLoop reads lines from stdin and sends them as text messages over the
 // WebSocket connection. It does NOT call conn.Close — the caller handles
 // connection cleanup.
-func writeLoop(ctx context.Context, cfg Config) {
-	scanner := bufio.NewScanner(cfg.Stdin)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
+func writeLoop(ctx context.Context, cfg Config) error {
+	reader := bufio.NewReader(cfg.Stdin)
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			line = trimLineEnding(line)
+			if len(line) > 0 {
+				if err := ctx.Err(); err != nil {
+					return nil
+				}
+
+				err := cfg.Conn.Write(ctx, websocket.MessageText, line)
+				if err != nil {
+					return nil
+				}
+			}
 		}
 
-		if err := ctx.Err(); err != nil {
-			return
-		}
-
-		err := cfg.Conn.Write(ctx, websocket.MessageText, line)
-		if err != nil {
-			return
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("read WebSocket stdin: %w", readErr)
 		}
 	}
+}
+
+func trimLineEnding(line []byte) []byte {
+	if len(line) > 0 && line[len(line)-1] == '\n' {
+		line = line[:len(line)-1]
+	}
+	if len(line) > 0 && line[len(line)-1] == '\r' {
+		line = line[:len(line)-1]
+	}
+	return line
 }

--- a/internal/ws/ws.go
+++ b/internal/ws/ws.go
@@ -60,10 +60,9 @@ func runBidirectional(ctx context.Context, cfg Config) error {
 	defer cancel()
 
 	// Write stdin lines in a background goroutine.
-	stdinDone := make(chan struct{})
+	stdinDone := make(chan error, 1)
 	go func() {
-		defer close(stdinDone)
-		writeLoop(ctx, cfg)
+		stdinDone <- writeLoop(ctx, cfg)
 	}()
 
 	// Read server messages in a separate goroutine. This allows us to
@@ -80,7 +79,12 @@ func runBidirectional(ctx context.Context, cfg Config) error {
 		// reading from stdin and cannot be interrupted.
 		cancel()
 		return err
-	case <-stdinDone:
+	case err := <-stdinDone:
+		if err != nil {
+			cancel()
+			return err
+		}
+
 		// Piped stdin EOF. Give the server a brief window to send
 		// remaining messages (e.g. echo responses), then shut down.
 		drainCtx, drainCancel := context.WithTimeout(ctx, 2*time.Second)

--- a/internal/ws/ws_test.go
+++ b/internal/ws/ws_test.go
@@ -2,6 +2,7 @@ package ws
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -93,6 +94,75 @@ func TestEchoRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPipedStdinLongMessage(t *testing.T) {
+	message := strings.Repeat("x", 70*1024)
+	received := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		conn.SetReadLimit(int64(len(message) + 1024))
+
+		_, data, err := conn.Read(r.Context())
+		if err != nil {
+			return
+		}
+		received <- append([]byte(nil), data...)
+		conn.Write(r.Context(), websocket.MessageText, []byte("ack"))
+		conn.Close(websocket.StatusNormalClosure, "done")
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+
+	stdout := core.TestPrinter(false)
+	cfg := Config{
+		Conn:      conn,
+		Stdin:     strings.NewReader(message + "\n"),
+		Stderr:    core.TestPrinter(false),
+		Stdout:    stdout,
+		Format:    core.FormatOff,
+		Verbosity: core.VNormal,
+	}
+
+	err = Run(ctx, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := string(stdout.Bytes())
+	want := "ack\n"
+	if got != want {
+		t.Fatalf("expected ack output %q, got %q", want, got)
+	}
+
+	select {
+	case data := <-received:
+		if string(data) != message {
+			t.Fatalf("expected sent message length %d, got %d", len(message), len(data))
+		}
+	default:
+		t.Fatal("server did not receive long stdin message")
+	}
+}
+
+func TestWriteLoopReturnsStdinReadError(t *testing.T) {
+	readErr := errors.New("stdin failed")
+	err := writeLoop(context.Background(), Config{Stdin: errReader{err: readErr}})
+	if !errors.Is(err, readErr) {
+		t.Fatalf("expected stdin read error, got %v", err)
+	}
+}
+
 func TestInitialMessageEcho(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := websocket.Accept(w, r, nil)
@@ -134,6 +204,14 @@ func TestInitialMessageEcho(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read([]byte) (int, error) {
+	return 0, r.err
 }
 
 func TestServerCloseNormal(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace the WebSocket stdin scanner with a buffered reader so piped lines over 64 KiB are read and sent
- Propagate stdin read errors out of the bidirectional WebSocket loop instead of treating them as clean completion
- Add tests for a long piped stdin message and stdin read error handling

## Testing
- `go test -v ./internal/ws`
- `go test -v ./integration -run 'TestMain/websocket piped stdin'`
- `go test -v ./...`