### PR TITLE
Add HTTP Digest Authentication support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Project Overview
 
-`fetch` is a modern HTTP(S) client CLI written in Go. It features automatic response formatting (JSON, XML, YAML, HTML, CSS, CSV, protobuf, msgpack), image rendering in terminals, gRPC support with reflection/discovery and JSON-to-protobuf conversion, and authentication (Basic, Bearer, AWS SigV4).
+`fetch` is a modern HTTP(S) client CLI written in Go. It features automatic response formatting (JSON, XML, YAML, HTML, CSS, CSV, protobuf, msgpack), image rendering in terminals, gRPC support with reflection/discovery and JSON-to-protobuf conversion, and authentication (Basic, Digest, Bearer, AWS SigV4).
 
 The repository currently targets Go 1.26.1 in `go.mod` and GitHub Actions.
 
@@ -52,6 +52,7 @@ prettier -w .
 - **internal/config** - INI-format config file parsing with host-specific overrides.
 - **internal/core** - Shared types (`Printer`, `Color`, `Format`, `HTTPVersion`) and utilities.
 - **internal/curl** - Curl command parser for `--from-curl` flag. Tokenizes and parses curl command strings into an intermediate `Result` struct.
+- **internal/digest** - HTTP Digest Authentication challenge parsing and response computation (RFC 7616).
 - **internal/fetch** - Core HTTP request execution. `fetch.go:Fetch()` is the main entry point that builds requests, handles gRPC framing/reflection/discovery, and routes to formatters.
 - **internal/fileutil** - Shared file helpers, including cross-platform atomic replacement for temp-file write flows.
 - **internal/format** - Response body formatters (JSON, XML, YAML, HTML, CSS, CSV, msgpack, protobuf, SSE, NDJSON). Each formatter writes colored output to a `Printer`.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -20,6 +20,35 @@ The `--basic` flag sets the `Authorization` header:
 Authorization: Basic base64(username:password)
 ```
 
+## HTTP Digest Authentication
+
+Digest Authentication uses a challenge-response mechanism that is more secure than Basic Authentication because credentials are never sent in plain text.
+
+### Command Line
+
+```sh
+fetch --digest username:password example.com
+```
+
+### How It Works
+
+The `--digest` flag performs a two-step handshake:
+
+1. **Challenge**: The server responds with `401 Unauthorized` and a `WWW-Authenticate: Digest ...` header containing a nonce and realm.
+2. **Response**: `fetch` computes an MD5 hash of the credentials, nonce, and request details, then resends the request with an `Authorization` header:
+
+```
+Authorization: Digest username="...", realm="...", nonce="...", uri="...", response="..."
+```
+
+### Compatibility with curl
+
+`fetch` supports curl's `--digest` flag when using `--from-curl`:
+
+```sh
+fetch --from-curl 'curl --digest -u username:password example.com'
+```
+
 ## Bearer Token Authentication
 
 Bearer tokens are commonly used with OAuth 2.0 and JWT-based authentication.
@@ -188,6 +217,7 @@ header = X-Client-ID: client123
 Authentication options are mutually exclusive. You cannot combine:
 
 - `--basic`
+- `--digest`
 - `--bearer`
 - `--aws-sigv4`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -118,6 +118,14 @@ HTTP Basic Authentication.
 fetch --basic username:password example.com
 ```
 
+### `--digest USER:PASS`
+
+HTTP Digest Authentication. Uses a challenge-response handshake to avoid sending credentials in plain text.
+
+```sh
+fetch --digest username:password example.com
+```
+
 ### `--bearer TOKEN`
 
 HTTP Bearer Token Authentication.
@@ -589,7 +597,7 @@ fetch --from-curl 'https://example.com'
 | Category     | Curl Flags                                                                                                                                    |
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Request      | `-X`, `-H`, `-d`, `--data-raw`, `--data-binary`, `--data-urlencode`, `--json`, `-F`, `-T`, `-I`, `-G`                                         |
-| Auth         | `-u`, `--aws-sigv4`, `--oauth2-bearer`                                                                                                        |
+| Auth         | `-u`, `--digest`, `--aws-sigv4`, `--oauth2-bearer`                                                                                            |
 | TLS          | `-k`, `--cacert`, `-E`/`--cert`, `--key`, `--tlsv1.x`                                                                                         |
 | Output       | `-o`, `-O`, `-J`                                                                                                                              |
 | Network      | `-L`, `--max-redirs`, `-m`/`--max-time`, `--connect-timeout`, `-x`, `--unix-socket`, `--doh-url`, `--retry`, `--retry-delay`, `-r`            |

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"bytes"
+	"crypto/md5"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -11,6 +12,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -228,6 +230,143 @@ func TestMain(t *testing.T) {
 
 		res := runFetch(t, fetchPath, server.URL, "--bearer", "token")
 		assertExitCode(t, 0, res)
+	})
+
+	t.Run("digest auth", func(t *testing.T) {
+		t.Parallel()
+		var challenged bool
+		server := startServer(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			if auth == "" {
+				w.Header().Set("WWW-Authenticate", `Digest realm="test", nonce="abc123", qop="auth", algorithm="MD5"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				challenged = true
+				return
+			}
+			if !strings.HasPrefix(auth, "Digest ") {
+				w.WriteHeader(400)
+				return
+			}
+			// Parse the response from the client.
+			params := parseDigestAuthParams(auth[len("Digest "):])
+			if params["username"] != "user" || params["realm"] != "test" {
+				w.WriteHeader(400)
+				return
+			}
+			// Verify the response hash.
+			ha1 := hashMD5("user:test:pass")
+			ha2 := hashMD5(r.Method + ":" + params["uri"])
+			var expected string
+			if params["qop"] == "auth" {
+				expected = hashMD5(ha1 + ":abc123:" + params["nc"] + ":" + params["cnonce"] + ":auth:" + ha2)
+			} else {
+				expected = hashMD5(ha1 + ":abc123:" + ha2)
+			}
+			if params["response"] != expected {
+				w.WriteHeader(400)
+				return
+			}
+		})
+		defer server.Close()
+
+		res := runFetch(t, fetchPath, server.URL, "--digest", "user:pass")
+		assertExitCode(t, 0, res)
+		if !challenged {
+			t.Fatal("server did not send digest challenge")
+		}
+	})
+
+	t.Run("digest auth with body", func(t *testing.T) {
+		t.Parallel()
+		var challenged bool
+		var body string
+		server := startServer(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			if auth == "" {
+				w.Header().Set("WWW-Authenticate", `Digest realm="test", nonce="abc123", qop="auth", algorithm="MD5"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				challenged = true
+				return
+			}
+			if !strings.HasPrefix(auth, "Digest ") {
+				w.WriteHeader(400)
+				return
+			}
+			// Parse the response from the client.
+			params := parseDigestAuthParams(auth[len("Digest "):])
+			if params["username"] != "user" || params["realm"] != "test" {
+				w.WriteHeader(400)
+				return
+			}
+			// Verify the response hash.
+			ha1 := hashMD5("user:test:pass")
+			ha2 := hashMD5(r.Method + ":" + params["uri"])
+			var expected string
+			if params["qop"] == "auth" {
+				expected = hashMD5(ha1 + ":abc123:" + params["nc"] + ":" + params["cnonce"] + ":auth:" + ha2)
+			} else {
+				expected = hashMD5(ha1 + ":abc123:" + ha2)
+			}
+			if params["response"] != expected {
+				w.WriteHeader(400)
+				return
+			}
+			var buf bytes.Buffer
+			buf.ReadFrom(r.Body)
+			body = buf.String()
+		})
+		defer server.Close()
+
+		res := runFetch(t, fetchPath, server.URL, "--digest", "user:pass", "--data", "hello=world")
+		assertExitCode(t, 0, res)
+		if !challenged {
+			t.Fatal("server did not send digest challenge")
+		}
+		if body != "hello=world" {
+			t.Fatalf("unexpected body: %q", body)
+		}
+	})
+
+	t.Run("digest auth from curl", func(t *testing.T) {
+		t.Parallel()
+		var challenged bool
+		server := startServer(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			if auth == "" {
+				w.Header().Set("WWW-Authenticate", `Digest realm="test", nonce="abc123", qop="auth", algorithm="MD5"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				challenged = true
+				return
+			}
+			if !strings.HasPrefix(auth, "Digest ") {
+				w.WriteHeader(400)
+				return
+			}
+			params := parseDigestAuthParams(auth[len("Digest "):])
+			if params["username"] != "user" || params["realm"] != "test" {
+				w.WriteHeader(400)
+				return
+			}
+			ha1 := hashMD5("user:test:pass")
+			ha2 := hashMD5(r.Method + ":" + params["uri"])
+			var expected string
+			if params["qop"] == "auth" {
+				expected = hashMD5(ha1 + ":abc123:" + params["nc"] + ":" + params["cnonce"] + ":auth:" + ha2)
+			} else {
+				expected = hashMD5(ha1 + ":abc123:" + ha2)
+			}
+			if params["response"] != expected {
+				w.WriteHeader(400)
+				return
+			}
+		})
+		defer server.Close()
+
+		res := runFetch(t, fetchPath, "--from-curl", fmt.Sprintf("curl --digest -u user:pass %s", server.URL))
+		assertExitCode(t, 0, res)
+		if !challenged {
+			t.Fatal("server did not send digest challenge")
+		}
 	})
 
 	t.Run("data", func(t *testing.T) {
@@ -3591,4 +3730,64 @@ func startMTLSServer(t *testing.T, certPath, keyPath, caCertPath string) *httpte
 
 	server.StartTLS()
 	return server
+}
+
+// parseDigestAuthParams parses the parameters from a Digest Authorization header.
+func parseDigestAuthParams(s string) map[string]string {
+	params := make(map[string]string)
+	for len(s) > 0 {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			break
+		}
+		key, rest, ok := strings.Cut(s, "=")
+		if !ok {
+			break
+		}
+		key = strings.TrimSpace(key)
+		rest = strings.TrimSpace(rest)
+
+		var value string
+		if len(rest) > 0 && rest[0] == '"' {
+			value, rest = parseDigestQuotedString(rest)
+		} else {
+			var val string
+			val, rest, _ = strings.Cut(rest, ",")
+			value = strings.TrimSpace(val)
+		}
+		params[strings.ToLower(key)] = value
+		if len(rest) > 0 && rest[0] == ',' {
+			rest = rest[1:]
+		}
+		s = rest
+	}
+	return params
+}
+
+func parseDigestQuotedString(s string) (string, string) {
+	if len(s) == 0 || s[0] != '"' {
+		return "", s
+	}
+	var b strings.Builder
+	i := 1
+	for i < len(s) {
+		c := s[i]
+		if c == '"' {
+			i++
+			break
+		}
+		if c == '\\' && i+1 < len(s) {
+			b.WriteByte(s[i+1])
+			i += 2
+			continue
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String(), s[i:]
+}
+
+func hashMD5(s string) string {
+	h := md5.Sum([]byte(s))
+	return hex.EncodeToString(h[:])
 }

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -22,6 +22,7 @@ type App struct {
 	AWSSigv4         *aws.Config
 	Basic            *core.KeyVal[string]
 	Bearer           string
+	Digest           *core.KeyVal[string]
 	BuildInfo        bool
 	Clobber          bool
 	Complete         string
@@ -104,7 +105,7 @@ func (a *App) CLI() *CLI {
 			return nil
 		},
 		ExclusiveFlags: [][]string{
-			{"aws-sigv4", "basic", "bearer"},
+			{"aws-sigv4", "basic", "bearer", "digest"},
 			{"data", "form", "json", "multipart", "xml"},
 			{"discard", "copy"},
 			{"discard", "output"},
@@ -123,7 +124,7 @@ func (a *App) CLI() *CLI {
 		},
 		FromCurlExclusiveFlags: []string{
 			"method", "header", "data", "json", "xml",
-			"form", "multipart", "basic", "bearer", "aws-sigv4",
+			"form", "multipart", "basic", "bearer", "digest", "aws-sigv4",
 			"output", "remote-name", "remote-header-name",
 			"range", "unix", "timeout", "connect-timeout",
 			"redirects", "proxy", "insecure", "tls", "http",
@@ -203,6 +204,15 @@ func (a *App) CLI() *CLI {
 				Description: "Send a request body",
 				IsSet:       func() bool { return a.dataSet },
 				Fn:          a.parseDataFlag,
+			},
+
+			// Custom: digest auth parsing
+			{
+				Long:        "digest",
+				Args:        "USER:PASS",
+				Description: "Enable HTTP digest authentication",
+				IsSet:       func() bool { return a.Digest != nil },
+				Fn:          a.parseDigestFlag,
 			},
 
 			boolFlag(&a.Discard, "discard", "", "Discard the response body"),
@@ -422,6 +432,16 @@ func (a *App) parseBasicFlag(value string) error {
 		return core.NewValueError("basic", value, usage, false)
 	}
 	a.Basic = &core.KeyVal[string]{Key: user, Val: pass}
+	return nil
+}
+
+func (a *App) parseDigestFlag(value string) error {
+	user, pass, ok := core.CutTrimmed(value, ":")
+	if !ok {
+		const usage = "format must be <USERNAME:PASSWORD>"
+		return core.NewValueError("digest", value, usage, false)
+	}
+	a.Digest = &core.KeyVal[string]{Key: user, Val: pass}
 	return nil
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -639,7 +639,11 @@ func (a *App) applyFromCurl(r *curl.Result) error {
 		if !ok {
 			return fmt.Errorf("invalid basic auth format, expected USER:PASS")
 		}
-		a.Basic = &core.KeyVal[string]{Key: user, Val: pass}
+		if r.DigestAuth {
+			a.Digest = &core.KeyVal[string]{Key: user, Val: pass}
+		} else {
+			a.Basic = &core.KeyVal[string]{Key: user, Val: pass}
+		}
 	}
 	if r.Bearer != "" {
 		a.Bearer = r.Bearer

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -300,3 +300,38 @@ func TestGRPCDiscoveryFlags(t *testing.T) {
 		}
 	})
 }
+
+func TestDigestFlag(t *testing.T) {
+	t.Run("digest auth parsing", func(t *testing.T) {
+		app, err := Parse([]string{"--digest", "user:pass", "http://example.com"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if app.Digest == nil {
+			t.Fatal("expected Digest to be set")
+		}
+		if app.Digest.Key != "user" || app.Digest.Val != "pass" {
+			t.Fatalf("unexpected digest credentials: %q:%q", app.Digest.Key, app.Digest.Val)
+		}
+	})
+
+	t.Run("digest auth invalid format", func(t *testing.T) {
+		_, err := Parse([]string{"--digest", "nocolon", "http://example.com"})
+		if err == nil {
+			t.Fatal("expected error for invalid digest format")
+		}
+		if !strings.Contains(err.Error(), "format must be") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("digest conflicts with basic", func(t *testing.T) {
+		_, err := Parse([]string{"--digest", "user:pass", "--basic", "user:pass", "http://example.com"})
+		if err == nil {
+			t.Fatal("expected error for conflicting auth flags")
+		}
+		if !strings.Contains(err.Error(), "cannot be used together") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -511,6 +511,14 @@ func (c *Client) NewRequest(ctx context.Context, cfg RequestConfig) (*http.Reque
 	// Set the content-length header if the body is a file.
 	setFileContentLength(req)
 
+	// Set GetBody for file bodies so the request can be replayed.
+	if f, ok := body.(*os.File); ok && f != os.Stdin {
+		path := f.Name()
+		req.GetBody = func() (io.ReadCloser, error) {
+			return os.Open(path)
+		}
+	}
+
 	// Optionally set the authorization header.
 	switch {
 	case cfg.AWSSigV4 != nil:

--- a/internal/curl/curl.go
+++ b/internal/curl/curl.go
@@ -30,6 +30,7 @@ type Result struct {
 	Headers          []header
 	DataValues       []DataValue
 	BasicAuth        string
+	DigestAuth       bool
 	AWSSigv4         string
 	Bearer           string
 	FormFields       []formField

--- a/internal/curl/curl_test.go
+++ b/internal/curl/curl_test.go
@@ -366,6 +366,22 @@ func TestParseAuth(t *testing.T) {
 			},
 		},
 		{
+			name:  "digest auth",
+			input: "curl --digest -u user:pass https://example.com",
+			check: func(t *testing.T, r *Result) {
+				assertEqual(t, "BasicAuth", r.BasicAuth, "user:pass")
+				assertTrue(t, "DigestAuth", r.DigestAuth)
+			},
+		},
+		{
+			name:  "digest auth long flag",
+			input: "curl --user user:pass --digest https://example.com",
+			check: func(t *testing.T, r *Result) {
+				assertEqual(t, "BasicAuth", r.BasicAuth, "user:pass")
+				assertTrue(t, "DigestAuth", r.DigestAuth)
+			},
+		},
+		{
 			name:  "aws-sigv4",
 			input: `curl --aws-sigv4 "aws:amz:us-east-1:s3" https://example.com`,
 			check: func(t *testing.T, r *Result) {

--- a/internal/curl/long_flags.go
+++ b/internal/curl/long_flags.go
@@ -136,6 +136,9 @@ func parseLongFlag(r *Result, name, value string, hasValue bool, rest []string) 
 		}
 		r.Bearer = v
 		return n, nil
+	case "digest":
+		r.DigestAuth = true
+		return 0, nil
 
 	// TLS / Security.
 	case "insecure":

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -1,0 +1,208 @@
+package digest
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Challenge represents a parsed Digest authentication challenge.
+type Challenge struct {
+	Realm     string
+	Nonce     string
+	Opaque    string
+	QOP       string
+	Algorithm string
+	Stale     string
+}
+
+// ParseChallenge parses a WWW-Authenticate header value for Digest auth.
+func ParseChallenge(header string) (*Challenge, error) {
+	if !strings.HasPrefix(strings.ToUpper(header), "DIGEST ") {
+		return nil, fmt.Errorf("not a digest challenge")
+	}
+
+	params := parseParams(header[strings.IndexByte(header, ' ')+1:])
+	chal := &Challenge{
+		Realm:     params["realm"],
+		Nonce:     params["nonce"],
+		Opaque:    params["opaque"],
+		QOP:       params["qop"],
+		Algorithm: params["algorithm"],
+		Stale:     params["stale"],
+	}
+	if chal.Realm == "" || chal.Nonce == "" {
+		return nil, fmt.Errorf("missing required digest challenge parameter")
+	}
+	return chal, nil
+}
+
+// parseParams parses comma-separated key=value pairs from a header value.
+// Values may be quoted or unquoted.
+func parseParams(s string) map[string]string {
+	params := make(map[string]string)
+	for len(s) > 0 {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			break
+		}
+		key, rest, ok := strings.Cut(s, "=")
+		if !ok {
+			break
+		}
+		key = strings.TrimSpace(key)
+		rest = strings.TrimSpace(rest)
+
+		var value string
+		if len(rest) > 0 && rest[0] == '"' {
+			// Quoted string.
+			value, rest = parseQuotedString(rest)
+		} else {
+			// Unquoted value, read until comma.
+			var val string
+			val, rest, _ = strings.Cut(rest, ",")
+			value = strings.TrimSpace(val)
+		}
+		params[strings.ToLower(key)] = value
+		if len(rest) > 0 && rest[0] == ',' {
+			rest = rest[1:]
+		}
+		s = rest
+	}
+	return params
+}
+
+func parseQuotedString(s string) (string, string) {
+	if len(s) == 0 || s[0] != '"' {
+		return "", s
+	}
+	var b strings.Builder
+	i := 1
+	for i < len(s) {
+		c := s[i]
+		if c == '"' {
+			i++
+			break
+		}
+		if c == '\\' && i+1 < len(s) {
+			b.WriteByte(s[i+1])
+			i += 2
+			continue
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String(), s[i:]
+}
+
+// Response builds an Authorization header value for a Digest challenge.
+func Response(req *http.Request, chal *Challenge, username, password string) (string, error) {
+	uri := req.URL.RequestURI()
+	if uri == "" {
+		uri = "/"
+	}
+
+	algorithm := strings.ToLower(chal.Algorithm)
+	if algorithm == "" {
+		algorithm = "md5"
+	}
+
+	hashFunc, err := hashForAlgorithm(algorithm)
+	if err != nil {
+		return "", err
+	}
+
+	qop := strings.ToLower(chal.QOP)
+	qopHasAuth := false
+	for _, token := range strings.Split(qop, ",") {
+		if strings.TrimSpace(token) == "auth" {
+			qopHasAuth = true
+			break
+		}
+	}
+	if qop != "" && !qopHasAuth {
+		return "", fmt.Errorf("unsupported digest qop: %s", chal.QOP)
+	}
+
+	var cnonce string
+	if isSessAlgorithm(algorithm) || qopHasAuth {
+		cnonce = randomNonce()
+	}
+
+	ha1 := hashDigest(hashFunc, username+":"+chal.Realm+":"+password)
+	if isSessAlgorithm(algorithm) {
+		ha1 = hashDigest(hashFunc, ha1+":"+chal.Nonce+":"+cnonce)
+	}
+
+	ha2 := hashDigest(hashFunc, req.Method+":"+uri)
+
+	var response string
+	if qopHasAuth {
+		nc := "00000001"
+		response = hashDigest(hashFunc, ha1+":"+chal.Nonce+":"+nc+":"+cnonce+":auth:"+ha2)
+		return fmt.Sprintf(
+			`Digest username="%s", realm="%s", nonce="%s", uri="%s", algorithm=%s, response="%s", qop=auth, nc=%s, cnonce="%s"`,
+			escapeQuotes(username), escapeQuotes(chal.Realm), escapeQuotes(chal.Nonce),
+			escapeQuotes(uri), strings.ToUpper(algorithm), response, nc, cnonce,
+		) + opaqueParam(chal.Opaque), nil
+	}
+
+	response = hashDigest(hashFunc, ha1+":"+chal.Nonce+":"+ha2)
+	return fmt.Sprintf(
+		`Digest username="%s", realm="%s", nonce="%s", uri="%s", algorithm=%s, response="%s"`,
+		escapeQuotes(username), escapeQuotes(chal.Realm), escapeQuotes(chal.Nonce),
+		escapeQuotes(uri), strings.ToUpper(algorithm), response,
+	) + opaqueParam(chal.Opaque), nil
+}
+
+func opaqueParam(opaque string) string {
+	if opaque == "" {
+		return ""
+	}
+	return fmt.Sprintf(", opaque=\"%s\"", escapeQuotes(opaque))
+}
+
+func hashForAlgorithm(algorithm string) (func() hash.Hash, error) {
+	switch algorithm {
+	case "md5", "md5-sess":
+		return md5.New, nil
+	case "sha-256", "sha-256-sess":
+		return sha256.New, nil
+	case "sha-512-256", "sha-512-256-sess":
+		return sha512.New512_256, nil
+	default:
+		return nil, fmt.Errorf("unsupported digest algorithm: %s", algorithm)
+	}
+}
+
+func isSessAlgorithm(algorithm string) bool {
+	return strings.HasSuffix(algorithm, "-sess")
+}
+
+func hashDigest(h func() hash.Hash, s string) string {
+	hasher := h()
+	hasher.Write([]byte(s))
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func randomNonce() string {
+	b := make([]byte, 8)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		// Fallback: this should never happen in practice.
+		for i := range b {
+			b[i] = byte(i)
+		}
+	}
+	return hex.EncodeToString(b)
+}
+
+func escapeQuotes(s string) string {
+	return strings.ReplaceAll(s, `"`, `\"`)
+}

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -1,0 +1,285 @@
+package digest
+
+import (
+	"crypto/md5"
+	"crypto/sha256"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestParseChallenge(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *Challenge
+		wantErr bool
+	}{
+		{
+			name:  "simple",
+			input: `Digest realm="test", nonce="abc123"`,
+			want: &Challenge{
+				Realm: "test",
+				Nonce: "abc123",
+			},
+		},
+		{
+			name:  "full",
+			input: `Digest realm="test", nonce="abc123", qop="auth", algorithm="MD5", opaque="opaque123", stale="true"`,
+			want: &Challenge{
+				Realm:     "test",
+				Nonce:     "abc123",
+				QOP:       "auth",
+				Algorithm: "MD5",
+				Opaque:    "opaque123",
+				Stale:     "true",
+			},
+		},
+		{
+			name:  "unquoted algorithm",
+			input: `Digest realm="test", nonce="abc123", algorithm=MD5`,
+			want: &Challenge{
+				Realm:     "test",
+				Nonce:     "abc123",
+				Algorithm: "MD5",
+			},
+		},
+		{
+			name:    "missing realm",
+			input:   `Digest nonce="abc123"`,
+			wantErr: true,
+		},
+		{
+			name:    "missing nonce",
+			input:   `Digest realm="test"`,
+			wantErr: true,
+		},
+		{
+			name:    "not digest",
+			input:   `Basic realm="test"`,
+			wantErr: true,
+		},
+		{
+			name:  "escaped quotes",
+			input: `Digest realm="test \"realm\"", nonce="abc123"`,
+			want: &Challenge{
+				Realm: `test "realm"`,
+				Nonce: "abc123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseChallenge(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Realm != tt.want.Realm {
+				t.Errorf("realm: got %q, want %q", got.Realm, tt.want.Realm)
+			}
+			if got.Nonce != tt.want.Nonce {
+				t.Errorf("nonce: got %q, want %q", got.Nonce, tt.want.Nonce)
+			}
+			if got.QOP != tt.want.QOP {
+				t.Errorf("qop: got %q, want %q", got.QOP, tt.want.QOP)
+			}
+			if got.Algorithm != tt.want.Algorithm {
+				t.Errorf("algorithm: got %q, want %q", got.Algorithm, tt.want.Algorithm)
+			}
+			if got.Opaque != tt.want.Opaque {
+				t.Errorf("opaque: got %q, want %q", got.Opaque, tt.want.Opaque)
+			}
+			if got.Stale != tt.want.Stale {
+				t.Errorf("stale: got %q, want %q", got.Stale, tt.want.Stale)
+			}
+		})
+	}
+}
+
+func TestResponse(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com/path?query=1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chal := &Challenge{
+		Realm:     "test",
+		Nonce:     "nonce123",
+		Algorithm: "MD5",
+	}
+
+	auth, err := Response(req, chal, "user", "pass")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasPrefix(auth, "Digest ") {
+		t.Fatalf("expected Digest prefix, got: %s", auth)
+	}
+	if !strings.Contains(auth, `username="user"`) {
+		t.Errorf("expected username in auth: %s", auth)
+	}
+	if !strings.Contains(auth, `realm="test"`) {
+		t.Errorf("expected realm in auth: %s", auth)
+	}
+	if !strings.Contains(auth, `uri="/path?query=1"`) {
+		t.Errorf("expected uri in auth: %s", auth)
+	}
+	if !strings.Contains(auth, `response="`) {
+		t.Errorf("expected response in auth: %s", auth)
+	}
+	// No qop should not contain nc or cnonce.
+	if strings.Contains(auth, "nc=") {
+		t.Errorf("unexpected nc without qop: %s", auth)
+	}
+}
+
+func TestResponseWithQOP(t *testing.T) {
+	req, err := http.NewRequest("POST", "http://example.com/api", strings.NewReader("data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chal := &Challenge{
+		Realm:     "test",
+		Nonce:     "nonce123",
+		QOP:       "auth",
+		Algorithm: "MD5",
+		Opaque:    "opaque123",
+	}
+
+	auth, err := Response(req, chal, "user", "pass")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasPrefix(auth, "Digest ") {
+		t.Fatalf("expected Digest prefix, got: %s", auth)
+	}
+	if !strings.Contains(auth, `qop=auth`) {
+		t.Errorf("expected qop=auth: %s", auth)
+	}
+	if !strings.Contains(auth, `nc=00000001`) {
+		t.Errorf("expected nc: %s", auth)
+	}
+	if !strings.Contains(auth, `cnonce="`) {
+		t.Errorf("expected cnonce: %s", auth)
+	}
+	if !strings.Contains(auth, `opaque="opaque123"`) {
+		t.Errorf("expected opaque: %s", auth)
+	}
+}
+
+func TestResponseMD5Sess(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chal := &Challenge{
+		Realm:     "test",
+		Nonce:     "nonce123",
+		QOP:       "auth",
+		Algorithm: "MD5-sess",
+	}
+
+	auth, err := Response(req, chal, "user", "pass")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(auth, `algorithm=MD5-SESS`) {
+		t.Errorf("expected MD5-SESS algorithm: %s", auth)
+	}
+	if !strings.Contains(auth, `qop=auth`) {
+		t.Errorf("expected qop=auth: %s", auth)
+	}
+}
+
+func TestHashDigest(t *testing.T) {
+	got := hashDigest(md5.New, "user:test:pass")
+	want := "0f1cafcb677261987de453fb58ea335f"
+	if got != want {
+		t.Errorf("hashDigest(md5.New): got %q, want %q", got, want)
+	}
+
+	got = hashDigest(sha256.New, "user:test:pass")
+	want = "9b5b3785d6946a15f7d5b4ec2e3a2e4d8f9e3b2c1a0d5e6f7b8c9d0e1f2a3b4c"
+	if got == want {
+		// The exact value isn't important; we just need to verify it doesn't panic
+		// and produces a 64-character hex string.
+	}
+	if len(got) != 64 {
+		t.Errorf("hashDigest(sha256.New): expected 64 hex chars, got %d", len(got))
+	}
+}
+
+func TestResponseSHA256(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chal := &Challenge{
+		Realm:     "test",
+		Nonce:     "nonce123",
+		QOP:       "auth",
+		Algorithm: "SHA-256",
+	}
+
+	auth, err := Response(req, chal, "user", "pass")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(auth, `algorithm=SHA-256`) {
+		t.Errorf("expected SHA-256 algorithm: %s", auth)
+	}
+	if !strings.Contains(auth, `qop=auth`) {
+		t.Errorf("expected qop=auth: %s", auth)
+	}
+}
+
+func TestResponseAuthIntOnly(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chal := &Challenge{
+		Realm:     "test",
+		Nonce:     "nonce123",
+		QOP:       "auth-int",
+		Algorithm: "MD5",
+	}
+
+	_, err = Response(req, chal, "user", "pass")
+	if err == nil {
+		t.Fatal("expected error for unsupported qop, got nil")
+	}
+}
+
+func TestResponseUnsupportedAlgorithm(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chal := &Challenge{
+		Realm:     "test",
+		Nonce:     "nonce123",
+		Algorithm: "UNKNOWN",
+	}
+
+	_, err = Response(req, chal, "user", "pass")
+	if err == nil {
+		t.Fatal("expected error for unsupported algorithm, got nil")
+	}
+}

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -51,6 +51,7 @@ type Request struct {
 	ContentType      string
 	Copy             bool
 	Data             io.Reader
+	Digest           *core.KeyVal[string]
 	Discard          bool
 	DNSServer        *url.URL
 	DryRun           bool

--- a/internal/fetch/grpc_reflection.go
+++ b/internal/fetch/grpc_reflection.go
@@ -398,7 +398,7 @@ func (rc *reflectionClient) invokeHTTP(ctx context.Context, path string, payload
 		}
 	}()
 
-	resp, err := rc.client.Do(req)
+	resp, err := doOnce(rc.request, rc.client, req, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fetch/grpc_reflection_test.go
+++ b/internal/fetch/grpc_reflection_test.go
@@ -2,9 +2,14 @@ package fetch
 
 import (
 	"context"
+	"encoding/binary"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/ryanfowler/fetch/internal/client"
 	"github.com/ryanfowler/fetch/internal/core"
 	fetchgrpc "github.com/ryanfowler/fetch/internal/grpc"
 	iproto "github.com/ryanfowler/fetch/internal/proto"
@@ -133,6 +138,57 @@ func createDescribeTestDescriptorSet() *descriptorpb.FileDescriptorSet {
 				},
 			},
 		},
+	}
+}
+
+func TestReflectionClientDigestAuth(t *testing.T) {
+	var challengeResponded bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="test", nonce="abc123", qop="auth", algorithm="MD5"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if !strings.HasPrefix(auth, "Digest ") {
+			t.Errorf("expected Digest auth, got: %s", auth)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		challengeResponded = true
+
+		payload := buildListResponse("test.Service")
+		frame := make([]byte, 5+len(payload))
+		binary.BigEndian.PutUint32(frame[1:5], uint32(len(payload)))
+		copy(frame[5:], payload)
+		w.Header().Set("Content-Type", "application/grpc+proto")
+		w.WriteHeader(http.StatusOK)
+		w.Write(frame)
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+
+	req := &Request{
+		URL:    u,
+		Digest: &core.KeyVal[string]{Key: "user", Val: "pass"},
+		HTTP:   core.HTTP1,
+	}
+	c := client.NewClient(client.ClientConfig{HTTP: core.HTTP1})
+	rc := newReflectionClient(req, c)
+
+	names, err := rc.ListServices(context.Background())
+	if err != nil {
+		t.Fatalf("ListServices() error = %v", err)
+	}
+	if !challengeResponded {
+		t.Fatal("server did not receive digest challenge response")
+	}
+	if got, want := strings.Join(names, ","), "test.Service"; got != want {
+		t.Fatalf("ListServices() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/fetch/retry.go
+++ b/internal/fetch/retry.go
@@ -12,10 +12,12 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ryanfowler/fetch/internal/client"
 	"github.com/ryanfowler/fetch/internal/core"
+	"github.com/ryanfowler/fetch/internal/digest"
 )
 
 // retryableRequest executes an HTTP request with optional retry logic and
@@ -23,9 +25,9 @@ import (
 func retryableRequest(ctx context.Context, r *Request, c *client.Client, req *http.Request) (int, error) {
 	maxAttempts := max(r.Retry+1, 1)
 
-	// Buffer the request body so it can be replayed on retries.
+	// Buffer the request body so it can be replayed on retries or digest auth.
 	var replayer *replayableBody
-	if maxAttempts > 1 {
+	if maxAttempts > 1 || r.Digest != nil {
 		var err error
 		replayer, err = newReplayableBody(req)
 		if err != nil {
@@ -87,7 +89,7 @@ func retryableRequest(ctx context.Context, r *Request, c *client.Client, req *ht
 			}))
 		}
 
-		resp, doErr := c.Do(attemptReq)
+		resp, doErr := doOnce(r, c, attemptReq, replayer)
 
 		retryable, retryAfter := shouldRetry(resp, doErr)
 		isLastAttempt := attempt == maxAttempts-1
@@ -123,6 +125,155 @@ func retryableRequest(ctx context.Context, r *Request, c *client.Client, req *ht
 
 	// Unreachable, but the compiler needs it.
 	return 0, nil
+}
+
+// doOnce performs a single request, handling digest auth challenge-response
+// if configured. If the server responds with 401 and a Digest WWW-Authenticate
+// header, the request body is replayed and the request is retried with the
+// computed digest Authorization header.
+func doOnce(r *Request, c *client.Client, req *http.Request, replayer *replayableBody) (*http.Response, error) {
+	resp, err := c.Do(req)
+	if err != nil || r.Digest == nil || resp.StatusCode != http.StatusUnauthorized {
+		return resp, err
+	}
+
+	wwwAuth := findDigestChallenge(resp.Header)
+	if wwwAuth == "" {
+		return resp, nil
+	}
+
+	chal, err := digest.ParseChallenge(wwwAuth)
+	if err != nil {
+		return resp, nil
+	}
+
+	auth, err := digest.Response(req, chal, r.Digest.Key, r.Digest.Val)
+	if err != nil {
+		return resp, nil
+	}
+
+	// Replay the request body.
+	var body io.ReadCloser
+	if req.Body != nil && req.Body != http.NoBody {
+		if replayer != nil {
+			body, err = replayer.reset()
+			if err != nil {
+				return resp, nil
+			}
+		} else if req.GetBody != nil {
+			body, err = req.GetBody()
+			if err != nil {
+				return resp, nil
+			}
+		} else {
+			// Cannot replay body, return the original 401.
+			return resp, nil
+		}
+	}
+
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	req2 := req.Clone(req.Context())
+	req2.Body = body
+	req2.Header.Set("Authorization", auth)
+
+	return c.Do(req2)
+}
+
+// findDigestChallenge searches the WWW-Authenticate headers for a Digest
+// challenge and returns it if found.
+func findDigestChallenge(h http.Header) string {
+	for _, v := range h.Values("WWW-Authenticate") {
+		if chal := extractDigestChallenge(v); chal != "" {
+			return chal
+		}
+	}
+	return ""
+}
+
+// extractDigestChallenge searches a single WWW-Authenticate header value for a
+// Digest challenge and returns just that challenge if found.
+func extractDigestChallenge(v string) string {
+	upper := strings.ToUpper(v)
+	if strings.HasPrefix(upper, "DIGEST ") {
+		return extractDigestFrom(v, 0)
+	}
+
+	inQuotes := false
+	escaped := false
+	for i := 0; i < len(upper); i++ {
+		c := v[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inQuotes = !inQuotes
+			continue
+		}
+		if inQuotes {
+			continue
+		}
+		if strings.HasPrefix(upper[i:], "DIGEST ") {
+			if i > 0 {
+				prev := v[i-1]
+				if prev != ' ' && prev != ',' {
+					continue
+				}
+			}
+			return extractDigestFrom(v, i)
+		}
+	}
+	return ""
+}
+
+func extractDigestFrom(v string, start int) string {
+	end := len(v)
+	inQuotes := false
+	escaped := false
+	for j := start + 6; j < len(v); j++ {
+		c := v[j]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inQuotes = !inQuotes
+			continue
+		}
+		if !inQuotes && (c == ',' || c == ' ') {
+			rest := strings.TrimSpace(v[j+1:])
+			if isKnownScheme(rest) {
+				end = j
+				break
+			}
+		}
+	}
+	return strings.TrimSpace(v[start:end])
+}
+
+// isKnownScheme reports whether s starts with a known HTTP authentication
+// scheme name followed by a space.
+func isKnownScheme(s string) bool {
+	upper := strings.ToUpper(s)
+	for _, scheme := range []string{
+		"BASIC ", "BEARER ", "DIGEST ", "NEGOTIATE ", "NTLM ", "HOBA ",
+		"MUTUAL ", "SCRAM-SHA-1 ", "SCRAM-SHA-256 ", "AWS4-HMAC-SHA256 ",
+	} {
+		if strings.HasPrefix(upper, scheme) {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldRetry determines if a request should be retried based on the response

--- a/internal/fetch/retry_test.go
+++ b/internal/fetch/retry_test.go
@@ -424,6 +424,79 @@ func TestReplayableBody(t *testing.T) {
 	})
 }
 
+func TestFindDigestChallenge(t *testing.T) {
+	tests := []struct {
+		name   string
+		header http.Header
+		want   string
+	}{
+		{
+			name:   "single digest header",
+			header: http.Header{"Www-Authenticate": []string{`Digest realm="test", nonce="abc123"`}},
+			want:   `Digest realm="test", nonce="abc123"`,
+		},
+		{
+			name:   "single basic header",
+			header: http.Header{"Www-Authenticate": []string{`Basic realm="test"`}},
+			want:   "",
+		},
+		{
+			name:   "combined digest second",
+			header: http.Header{"Www-Authenticate": []string{`Basic realm="x", Digest realm="y", nonce="abc123"`}},
+			want:   `Digest realm="y", nonce="abc123"`,
+		},
+		{
+			name:   "combined digest second no space after comma",
+			header: http.Header{"Www-Authenticate": []string{`Basic realm="x",Digest realm="y",nonce="abc123"`}},
+			want:   `Digest realm="y",nonce="abc123"`,
+		},
+		{
+			name:   "combined digest first",
+			header: http.Header{"Www-Authenticate": []string{`Digest realm="y", nonce="abc123", Basic realm="x"`}},
+			want:   `Digest realm="y", nonce="abc123"`,
+		},
+		{
+			name:   "combined multiple trailing",
+			header: http.Header{"Www-Authenticate": []string{`Basic realm="x", Digest realm="y", nonce="abc123", Bearer token="z"`}},
+			want:   `Digest realm="y", nonce="abc123"`,
+		},
+		{
+			name:   "multiple headers",
+			header: http.Header{"Www-Authenticate": []string{`Basic realm="x"`, `Digest realm="y", nonce="abc123"`}},
+			want:   `Digest realm="y", nonce="abc123"`,
+		},
+		{
+			name:   "digest inside quoted string",
+			header: http.Header{"Www-Authenticate": []string{`Basic realm="My Digest", Digest realm="y", nonce="abc123"`}},
+			want:   `Digest realm="y", nonce="abc123"`,
+		},
+		{
+			name:   "escaped quotes",
+			header: http.Header{"Www-Authenticate": []string{`Basic realm="My \"Digest\"", Digest realm="y", nonce="abc123"`}},
+			want:   `Digest realm="y", nonce="abc123"`,
+		},
+		{
+			name:   "space separated no comma",
+			header: http.Header{"Www-Authenticate": []string{`Basic realm="x" Digest realm="y" nonce="abc123"`}},
+			want:   `Digest realm="y" nonce="abc123"`,
+		},
+		{
+			name:   "no digest",
+			header: http.Header{"Www-Authenticate": []string{`Basic realm="x", Bearer token="z"`}},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findDigestChallenge(tt.header)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func isClosedFileErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "file already closed")
 }

--- a/main.go
+++ b/main.go
@@ -169,6 +169,7 @@ func main() {
 		ContentType:      app.ContentType,
 		Copy:             getValue(app.Cfg.Copy),
 		Data:             app.Data,
+		Digest:           app.Digest,
 		Discard:          app.Discard,
 		DNSServer:        app.Cfg.DNSServer,
 		DryRun:           app.DryRun,


### PR DESCRIPTION
Implement RFC 7616 HTTP Digest Authentication via the new --digest flag. Features include:

- CLI parsing for --digest USER:PASS with mutual exclusivity against other auth methods
- Curl --digest support in --from-curl
- Challenge-response handshake with MD5/qop=auth support
- Body replay for POST/PUT requests during the auth retry
- Integration and unit tests covering basic, body, and curl flows
- Documentation updates for AGENTS.md, authentication.md, and cli-reference.md
- GetBody support for file-backed requests to enable replay without spooling