### PR TITLE
Fix curl -G data expansion for file-backed payloads

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -609,12 +609,17 @@ func (a *App) applyFromCurl(r *curl.Result) error {
 				parts = append(parts, string(b))
 			}
 		}
-		a.Data = strings.NewReader(strings.Join(parts, "&"))
-		a.dataSet = true
+		data := strings.Join(parts, "&")
+		if r.GetFlag {
+			appendRawQuery(a.URL, data)
+		} else {
+			a.Data = strings.NewReader(data)
+			a.dataSet = true
 
-		// Set default content type for -d data if not explicitly set.
-		if !r.HasContentType {
-			a.ContentType = "application/x-www-form-urlencoded"
+			// Set default content type for -d data if not explicitly set.
+			if !r.HasContentType {
+				a.ContentType = "application/x-www-form-urlencoded"
+			}
 		}
 	}
 
@@ -826,4 +831,15 @@ func readFileForURLEncode(path string) (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+func appendRawQuery(u *url.URL, query string) {
+	if query == "" {
+		return
+	}
+	if u.RawQuery == "" {
+		u.RawQuery = query
+		return
+	}
+	u.RawQuery += "&" + query
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -84,6 +84,49 @@ func TestFromCurlDataUrlencode(t *testing.T) {
 	})
 }
 
+func TestFromCurlGetData(t *testing.T) {
+	t.Run("-d @file expands contents into query", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "payload.txt")
+		os.WriteFile(path, []byte("q=search&limit=10"), 0o644)
+
+		app, err := Parse([]string{
+			"--from-curl",
+			`curl -G -d '@` + path + `' https://example.com`,
+		})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if app.Data != nil {
+			t.Fatal("expected no request body for curl -G")
+		}
+		if app.URL.RawQuery != "q=search&limit=10" {
+			t.Fatalf("RawQuery = %q, want %q", app.URL.RawQuery, "q=search&limit=10")
+		}
+	})
+
+	t.Run("--data-urlencode name@file expands and encodes contents into query", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "data.txt")
+		os.WriteFile(path, []byte("value with spaces&x=1"), 0o644)
+
+		app, err := Parse([]string{
+			"--from-curl",
+			`curl -G --data-urlencode 'field@` + path + `' https://example.com?existing=1`,
+		})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if app.Data != nil {
+			t.Fatal("expected no request body for curl -G")
+		}
+		want := "existing=1&field=value+with+spaces%26x%3D1"
+		if app.URL.RawQuery != want {
+			t.Fatalf("RawQuery = %q, want %q", app.URL.RawQuery, want)
+		}
+	})
+}
+
 func TestFromCurlDataFileClose(t *testing.T) {
 	// Verify that file descriptors are properly closed after reading.
 	dir := t.TempDir()

--- a/internal/curl/curl.go
+++ b/internal/curl/curl.go
@@ -92,24 +92,10 @@ func Parse(command string) (*Result, error) {
 }
 
 func postProcess(r *Result) error {
-	// -G flag: move data to query string.
-	if r.GetFlag && len(r.DataValues) > 0 {
-		parts := make([]string, len(r.DataValues))
-		for i, dv := range r.DataValues {
-			parts[i] = dv.Value
-		}
-		data := strings.Join(parts, "&")
-		if r.URL != "" {
-			sep := "?"
-			if strings.Contains(r.URL, "?") {
-				sep = "&"
-			}
-			r.URL = r.URL + sep + data
-		}
-		r.DataValues = nil
-		if r.Method == "" {
-			r.Method = "GET"
-		}
+	// -G flag: data values are moved to the query string after
+	// applyFromCurl expands @file and --data-urlencode file forms.
+	if r.GetFlag && r.Method == "" {
+		r.Method = "GET"
 	}
 
 	// Reject conflicting body sources.

--- a/internal/curl/curl_test.go
+++ b/internal/curl/curl_test.go
@@ -225,17 +225,16 @@ func TestParseSimple(t *testing.T) {
 			input: `curl -G -d "q=search" https://example.com`,
 			check: func(t *testing.T, r *Result) {
 				assertEqual(t, "Method", r.Method, "GET")
-				assertEqual(t, "URL", r.URL, "https://example.com?q=search")
-				if len(r.DataValues) != 0 {
-					t.Fatalf("expected DataValues to be cleared, got %v", r.DataValues)
-				}
+				assertEqual(t, "URL", r.URL, "https://example.com")
+				assertDataValues(t, "DataValues", r.DataValues, []DataValue{{Value: "q=search"}})
 			},
 		},
 		{
 			name:  "GET flag with data and existing query",
 			input: `curl -G -d "b=2" "https://example.com?a=1"`,
 			check: func(t *testing.T, r *Result) {
-				assertEqual(t, "URL", r.URL, "https://example.com?a=1&b=2")
+				assertEqual(t, "URL", r.URL, "https://example.com?a=1")
+				assertDataValues(t, "DataValues", r.DataValues, []DataValue{{Value: "b=2"}})
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Preserve `--from-curl` data values when `-G` is present so file-backed forms are expanded before becoming query parameters.
- Move `-G` query assembly into CLI mapping, after `@file` and `--data-urlencode name@file` handling runs.
- Update parser expectations so `curl.Parse` keeps `DataValues` intact under `-G`.

## Testing
- Added focused unit coverage for `-G -d @file` and `-G --data-urlencode field@file` in `internal/cli`.
- Updated `internal/curl` parser tests for the revised `-G` behavior.
- Verified with the full Go test suite and formatting checks.