### PR TITLE
Preserve host-only cookie scope in session persistence

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -28,6 +28,7 @@ type SessionCookie struct {
 	Name     string    `json:"name"`
 	Value    string    `json:"value"`
 	Domain   string    `json:"domain"`
+	HostOnly bool      `json:"host_only,omitzero"`
 	Path     string    `json:"path,omitzero"`
 	Expires  time.Time `json:"expires,omitzero"`
 	Secure   bool      `json:"secure,omitzero"`
@@ -137,11 +138,13 @@ func (s *Session) Jar() http.CookieJar {
 		hc := &http.Cookie{
 			Name:     c.Name,
 			Value:    c.Value,
-			Domain:   c.Domain,
 			Path:     c.Path,
 			Expires:  c.Expires,
 			Secure:   c.Secure,
 			HttpOnly: c.HttpOnly,
+		}
+		if !c.HostOnly {
+			hc.Domain = c.Domain
 		}
 		switch c.SameSite {
 		case "lax":
@@ -180,6 +183,7 @@ func (j *sessionJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
 			Name:     c.Name,
 			Value:    c.Value,
 			Domain:   c.Domain,
+			HostOnly: c.Domain == "",
 			Path:     c.Path,
 			Expires:  cookieExpires(c, now),
 			Secure:   c.Secure,

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -224,6 +224,63 @@ func TestSessionJar(t *testing.T) {
 	}
 }
 
+func TestSessionJarReloadPreservesHostOnlyCookies(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("FETCH_INTERNAL_SESSIONS_DIR", dir)
+
+	sess, err := Load("host-only-test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	origin, _ := url.Parse("https://example.com/")
+	subdomain, _ := url.Parse("https://api.example.com/")
+	jar := sess.Jar()
+	jar.SetCookies(origin, []*http.Cookie{
+		{Name: "host", Value: "only"},
+		{Name: "domain", Value: "wide", Domain: "example.com"},
+	})
+
+	if len(sess.Cookies) != 2 {
+		t.Fatalf("expected 2 session cookies, got %d", len(sess.Cookies))
+	}
+	for _, c := range sess.Cookies {
+		switch c.Name {
+		case "host":
+			if !c.HostOnly {
+				t.Fatalf("host-only cookie was not marked host-only: %+v", c)
+			}
+		case "domain":
+			if c.HostOnly {
+				t.Fatalf("domain cookie was marked host-only: %+v", c)
+			}
+		}
+	}
+
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	reloaded, err := Load("host-only-test")
+	if err != nil {
+		t.Fatalf("reload failed: %v", err)
+	}
+	jar = reloaded.Jar()
+
+	originCookies := cookieNames(jar.Cookies(origin))
+	if !originCookies["host"] || !originCookies["domain"] {
+		t.Fatalf("origin cookies = %v, want host and domain cookies", originCookies)
+	}
+
+	subdomainCookies := cookieNames(jar.Cookies(subdomain))
+	if subdomainCookies["host"] {
+		t.Fatalf("subdomain received host-only cookie after reload: %v", subdomainCookies)
+	}
+	if !subdomainCookies["domain"] {
+		t.Fatalf("subdomain cookies = %v, want domain cookie", subdomainCookies)
+	}
+}
+
 func TestSessionJarUpdatesExisting(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("FETCH_INTERNAL_SESSIONS_DIR", dir)
@@ -254,6 +311,14 @@ func TestSessionJarUpdatesExisting(t *testing.T) {
 	if sess.Cookies[0].Value != "new" {
 		t.Fatalf("expected updated value, got %s", sess.Cookies[0].Value)
 	}
+}
+
+func cookieNames(cookies []*http.Cookie) map[string]bool {
+	names := make(map[string]bool, len(cookies))
+	for _, c := range cookies {
+		names[c.Name] = true
+	}
+	return names
 }
 
 func TestSessionJarPersistsMaxAgeAsExpiry(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a persisted `HostOnly` flag to session cookies so reloads can distinguish host-only cookies from domain cookies.
- Rebuild the jar without setting `Cookie.Domain` for host-only entries, preventing subdomain leakage after reload.
- Add a regression test that saves and reloads host-only and domain cookies, then verifies subdomains only receive the domain cookie.

## Testing
- Added unit coverage in `internal/session/session_test.go` for host-only reload behavior.
- `go test -v ./internal/session`
- Formatting and diff checks passed.