### PR TITLE
Make host-specific config matching case-insensitive

### DIFF
--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -103,7 +103,7 @@ func parseFile(path, s string) (*File, error) {
 
 		// Parse out a hostname.
 		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			hostStr := strings.TrimSpace(line[1 : len(line)-1])
+			hostStr := strings.ToLower(strings.TrimSpace(line[1 : len(line)-1]))
 			if hostStr == "" {
 				return nil, newFileError(path, num, errors.New("hostname cannot be empty"))
 			}
@@ -188,6 +188,7 @@ func (f *File) HostConfig(hostname string) *Config {
 	if hostname == "" {
 		return nil
 	}
+	hostname = strings.ToLower(hostname)
 
 	// Exact match first.
 	if cfg, ok := f.Hosts[hostname]; ok {

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -19,7 +19,7 @@ func TestParseFile(t *testing.T) {
 	}{
 		{
 			name: "valid wildcard section",
-			config: `[*.example.com]
+			config: `[*.Example.com]
 				insecure = true`,
 			expFile: &File{
 				Global: &Config{isFile: true},
@@ -73,7 +73,7 @@ func TestParseFile(t *testing.T) {
 				color = off
 				no-pager = true
 				
-				[example.com]
+				[Example.com]
 				insecure = true
 
 				[anotherhost.com]
@@ -151,8 +151,18 @@ func TestFileHostConfig(t *testing.T) {
 			expected: exactCfg,
 		},
 		{
+			name:     "case-insensitive exact match",
+			hostname: "API.Example.com",
+			expected: exactCfg,
+		},
+		{
 			name:     "wildcard match",
 			hostname: "www.example.com",
+			expected: wildcardCfg,
+		},
+		{
+			name:     "case-insensitive wildcard match",
+			hostname: "WWW.Example.com",
 			expected: wildcardCfg,
 		},
 		{
@@ -168,6 +178,11 @@ func TestFileHostConfig(t *testing.T) {
 		{
 			name:     "most specific wildcard wins",
 			hostname: "v1.api.example.com",
+			expected: specificWildcardCfg,
+		},
+		{
+			name:     "case-insensitive most specific wildcard wins",
+			hostname: "V1.API.Example.com",
 			expected: specificWildcardCfg,
 		},
 		{


### PR DESCRIPTION
## Summary
- Normalize config section hostnames to lowercase when parsing so host-specific entries are stored canonically.
- Lowercase lookup hostnames in `HostConfig` so exact matches and wildcard matches work regardless of case.
- Extend config tests to cover mixed-case exact and wildcard host matching, including most-specific wildcard selection.

## Testing
- Not run (not requested)