### PR TITLE
Add DNS inspection mode with TTL-aware record rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ prettier -w .
 - `--grpc-list` and `--grpc-describe` provide grpcurl-style discovery using reflection or local descriptor files.
 - `--grpc` now automatically tries gRPC reflection when no local schema is supplied.
 - Plaintext loopback gRPC servers are supported via `h2c` for both calls and discovery.
+- `--inspect-dns` resolves the URL hostname without making an HTTP request, showing common DNS record types, resolver backend, duration, and per-record TTLs from direct UDP or DoH responses.
 5. HTTP client executes request
 6. Response formatted based on Content-Type and output to stdout (optionally via pager)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A modern HTTP(S) client for the command line.
 - **Authentication** - Built-in support for Basic Auth, Bearer Token, AWS Signature V4, and mTLS
 - **Compression** - Automatic gzip and zstd response body decompression
 - **TLS inspection** - Inspect TLS certificate chains, expiry, SANs, and OCSP status
+- **DNS inspection** - Inspect hostname resolution, record families, TTLs, and resolver timing
 - **Timing waterfall** - Visualize request timing phases (DNS, TCP, TLS, TTFB, transfer) with a waterfall chart
 - **Configuration** - Global and per-host configuration file support
 

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -38,6 +38,17 @@ fetch --dns-server https://dns.google/dns-query example.com
 fetch --dns-server https://dns.quad9.net/dns-query example.com
 ```
 
+### DNS Inspection
+
+`--inspect-dns` resolves the URL hostname and exits without making an HTTP request:
+
+```sh
+fetch --inspect-dns example.com
+fetch --inspect-dns --dns-server https://1.1.1.1/dns-query example.com
+```
+
+The output shows the resolver backend, A, AAAA, CNAME, TXT, MX, NS, SOA, SRV, CAA, SVCB, and HTTPS records when present, address count, record count, lookup duration, and per-record TTLs.
+
 ### Configuration File
 
 ```ini

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -353,6 +353,15 @@ fetch --dns-server 1.1.1.1:53 example.com
 fetch --dns-server https://1.1.1.1/dns-query example.com
 ```
 
+### `--inspect-dns`
+
+Inspect DNS resolution for the URL hostname only (no HTTP request is made). Displays the resolver backend, A, AAAA, CNAME, TXT, MX, NS, SOA, SRV, CAA, SVCB, and HTTPS records when present, along with per-record TTLs, address count, record count, and lookup duration.
+
+```sh
+fetch --inspect-dns example.com
+fetch --inspect-dns --dns-server https://1.1.1.1/dns-query example.com
+```
+
 ### `--proxy PROXY`
 
 Route request through a proxy.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -38,6 +38,7 @@ type App struct {
 	GRPCDescribe     string
 	GRPCList         bool
 	Help             bool
+	InspectDNS       bool
 	InspectTLS       bool
 	WS               bool // set when URL scheme is ws:// or wss://
 	Method           string
@@ -270,6 +271,7 @@ func (a *App) CLI() *CLI {
 				}),
 
 			ptrBoolFlag(&a.Cfg.Insecure, "insecure", "", "Accept invalid TLS certs (!)"),
+			boolFlag(&a.InspectDNS, "inspect-dns", "", "Inspect DNS resolution"),
 			boolFlag(&a.InspectTLS, "inspect-tls", "", "Inspect the TLS certificate chain"),
 
 			// Custom: JSON body

--- a/internal/dnsinspect/dnsinspect.go
+++ b/internal/dnsinspect/dnsinspect.go
@@ -1,0 +1,749 @@
+package dnsinspect
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ryanfowler/fetch/internal/core"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+const dnsTypeCAA dnsmessage.Type = 257
+
+var inspectTypes = []queryType{
+	{label: "A", dohType: "A", dnsType: dnsmessage.TypeA},
+	{label: "AAAA", dohType: "AAAA", dnsType: dnsmessage.TypeAAAA},
+	{label: "CNAME", dohType: "CNAME", dnsType: dnsmessage.TypeCNAME},
+	{label: "TXT", dohType: "TXT", dnsType: dnsmessage.TypeTXT},
+	{label: "MX", dohType: "MX", dnsType: dnsmessage.TypeMX},
+	{label: "NS", dohType: "NS", dnsType: dnsmessage.TypeNS},
+	{label: "SOA", dohType: "SOA", dnsType: dnsmessage.TypeSOA},
+	{label: "SRV", dohType: "SRV", dnsType: dnsmessage.TypeSRV},
+	{label: "CAA", dohType: "CAA", dnsType: dnsTypeCAA},
+	{label: "SVCB", dohType: "SVCB", dnsType: dnsmessage.TypeSVCB},
+	{label: "HTTPS", dohType: "HTTPS", dnsType: dnsmessage.TypeHTTPS},
+}
+
+// Config holds the parameters needed to perform a DNS inspection.
+type Config struct {
+	DNSServer *url.URL
+	Timeout   time.Duration
+	URL       *url.URL
+}
+
+type queryType struct {
+	label   string
+	dohType string
+	dnsType dnsmessage.Type
+}
+
+type record struct {
+	typ   string
+	value string
+	ttl   uint32
+}
+
+type result struct {
+	host     string
+	resolver string
+	records  map[string][]record
+	duration time.Duration
+}
+
+type queryResult struct {
+	records []record
+	err     error
+}
+
+// Inspect resolves the configured URL hostname and renders DNS information to
+// the printer. It returns a non-zero exit code on failure.
+func Inspect(ctx context.Context, p *core.Printer, cfg *Config) int {
+	host := cfg.URL.Hostname()
+	if host == "" {
+		writeDNSError(p, errors.New("--inspect-dns requires a hostname"))
+		return 1
+	}
+
+	if cfg.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cfg.Timeout)
+		defer cancel()
+	}
+
+	start := time.Now()
+	if ip := net.ParseIP(host); ip != nil {
+		resolver, _ := resolverTarget(cfg.DNSServer)
+		renderIPLiteral(p, host, ip, resolver, time.Since(start))
+		p.Flush()
+		return 0
+	}
+
+	res, err := lookup(ctx, cfg, host, start)
+	if err != nil {
+		writeDNSError(p, err)
+		return 1
+	}
+	render(p, res)
+	p.Flush()
+	return 0
+}
+
+func lookup(ctx context.Context, cfg *Config, host string, start time.Time) (*result, error) {
+	resolverLabel, udpAddr := resolverTarget(cfg.DNSServer)
+	out := &result{
+		host:     host,
+		resolver: resolverLabel,
+		records:  make(map[string][]record),
+	}
+
+	results := make([]queryResult, len(inspectTypes))
+	var wg sync.WaitGroup
+	for i, qt := range inspectTypes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if cfg.DNSServer != nil && cfg.DNSServer.Scheme != "" {
+				results[i].records, results[i].err = lookupDOHRecords(ctx, cfg.DNSServer, host, qt)
+				return
+			}
+			results[i].records, results[i].err = lookupUDPRecords(ctx, udpAddr, host, qt)
+		}()
+	}
+	wg.Wait()
+
+	var firstErr error
+	seen := make(map[string]int)
+	for _, result := range results {
+		if result.err != nil && firstErr == nil {
+			firstErr = result.err
+		}
+		for _, rec := range result.records {
+			key := rec.typ + "\x00" + rec.value
+			if idx, ok := seen[key]; ok {
+				records := out.records[rec.typ]
+				if rec.ttl < records[idx].ttl {
+					records[idx].ttl = rec.ttl
+				}
+				continue
+			}
+			seen[key] = len(out.records[rec.typ])
+			out.records[rec.typ] = append(out.records[rec.typ], rec)
+		}
+	}
+	out.duration = time.Since(start)
+
+	if recordCount(out) > 0 {
+		return out, nil
+	}
+	if firstErr != nil {
+		return nil, fmt.Errorf("lookup %s: %w", host, firstErr)
+	}
+	return nil, fmt.Errorf("lookup %s: no DNS records found", host)
+}
+
+func lookupDOHRecords(ctx context.Context, serverURL *url.URL, host string, qt queryType) ([]record, error) {
+	type answer struct {
+		Type int    `json:"type"`
+		Data string `json:"data"`
+		TTL  uint32 `json:"TTL"`
+	}
+	type response struct {
+		Status int      `json:"Status"`
+		Answer []answer `json:"Answer"`
+	}
+
+	u := *serverURL
+	q := u.Query()
+	q.Set("name", host)
+	q.Set("type", qt.dohType)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/dns-json")
+	req.Header.Set("User-Agent", core.UserAgent)
+
+	var client http.Client
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<14))
+		if err != nil {
+			return nil, fmt.Errorf("http response code: %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("%d: %s", resp.StatusCode, raw)
+	}
+
+	var res response
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, err
+	}
+	if res.Status != 0 {
+		name := rcodeName(res.Status)
+		if name == "" {
+			return nil, errors.New("no DNS records found")
+		}
+		return nil, fmt.Errorf("no DNS records found: %s", name)
+	}
+
+	records := make([]record, 0, len(res.Answer))
+	for _, answer := range res.Answer {
+		typ := dnsmessage.Type(answer.Type)
+		label := typeLabel(typ)
+		records = append(records, record{
+			typ:   label,
+			value: normalizeDOHValue(typ, answer.Data),
+			ttl:   answer.TTL,
+		})
+	}
+	return records, nil
+}
+
+func lookupUDPRecords(ctx context.Context, serverAddr, host string, qt queryType) ([]record, error) {
+	name, err := dnsmessage.NewName(absoluteName(host))
+	if err != nil {
+		return nil, err
+	}
+
+	id := uint16(time.Now().UnixNano())
+	msg := dnsmessage.Message{
+		Header: dnsmessage.Header{
+			ID:               id,
+			RecursionDesired: true,
+		},
+		Questions: []dnsmessage.Question{{
+			Name:  name,
+			Type:  qt.dnsType,
+			Class: dnsmessage.ClassINET,
+		}},
+	}
+	raw, err := msg.Pack()
+	if err != nil {
+		return nil, err
+	}
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "udp", serverAddr)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	if _, err := conn.Write(raw); err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	var res dnsmessage.Message
+	if err := res.Unpack(buf[:n]); err != nil {
+		return nil, err
+	}
+	if res.Header.ID != id {
+		return nil, errors.New("mismatched DNS response ID")
+	}
+	if res.Header.RCode != dnsmessage.RCodeSuccess {
+		return nil, fmt.Errorf("no DNS records found: %s", res.Header.RCode.String())
+	}
+	if res.Header.Truncated {
+		return nil, errors.New("DNS response was truncated")
+	}
+
+	records := make([]record, 0, len(res.Answers))
+	for _, answer := range res.Answers {
+		rec, ok := resourceRecord(answer)
+		if ok {
+			records = append(records, rec)
+		}
+	}
+	return records, nil
+}
+
+func resourceRecord(res dnsmessage.Resource) (record, bool) {
+	value, ok := resourceValue(res)
+	if !ok {
+		return record{}, false
+	}
+	return record{
+		typ:   typeLabel(res.Header.Type),
+		value: value,
+		ttl:   res.Header.TTL,
+	}, true
+}
+
+func resourceValue(res dnsmessage.Resource) (string, bool) {
+	switch body := res.Body.(type) {
+	case *dnsmessage.AResource:
+		return net.IP(body.A[:]).String(), true
+	case *dnsmessage.AAAAResource:
+		return net.IP(body.AAAA[:]).String(), true
+	case *dnsmessage.CNAMEResource:
+		return body.CNAME.String(), true
+	case *dnsmessage.TXTResource:
+		return strings.Join(body.TXT, " "), true
+	case *dnsmessage.MXResource:
+		return fmt.Sprintf("%d %s", body.Pref, body.MX.String()), true
+	case *dnsmessage.NSResource:
+		return body.NS.String(), true
+	case *dnsmessage.SOAResource:
+		return fmt.Sprintf("%s %s serial=%d refresh=%d retry=%d expire=%d minttl=%d",
+			body.NS.String(), body.MBox.String(), body.Serial, body.Refresh, body.Retry, body.Expire, body.MinTTL), true
+	case *dnsmessage.SRVResource:
+		return fmt.Sprintf("%d %d %d %s", body.Priority, body.Weight, body.Port, body.Target.String()), true
+	case *dnsmessage.SVCBResource:
+		return formatSVCB(body.Priority, body.Target, body.Params), true
+	case *dnsmessage.HTTPSResource:
+		return formatSVCB(body.Priority, body.Target, body.Params), true
+	case *dnsmessage.UnknownResource:
+		if res.Header.Type == dnsTypeCAA {
+			return formatCAA(body.Data), true
+		}
+		return "0x" + hex.EncodeToString(body.Data), true
+	default:
+		return "", false
+	}
+}
+
+func formatCAA(raw []byte) string {
+	if len(raw) < 2 {
+		return "0x" + hex.EncodeToString(raw)
+	}
+	tagLen := int(raw[1])
+	if len(raw) < 2+tagLen {
+		return "0x" + hex.EncodeToString(raw)
+	}
+	flags := raw[0]
+	tag := string(raw[2 : 2+tagLen])
+	value := string(raw[2+tagLen:])
+	return fmt.Sprintf("%d %s %q", flags, tag, value)
+}
+
+func formatSVCB(priority uint16, target dnsmessage.Name, params []dnsmessage.SVCParam) string {
+	return formatSVCBValue(priority, target.String(), params)
+}
+
+func formatSVCBValue(priority uint16, target string, params []dnsmessage.SVCParam) string {
+	parts := []string{fmt.Sprintf("%d", priority), target}
+	for _, param := range params {
+		parts = append(parts, formatSVCParam(param))
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatSVCParam(param dnsmessage.SVCParam) string {
+	switch param.Key {
+	case dnsmessage.SVCParamALPN:
+		var alpns []string
+		for i := 0; i < len(param.Value); {
+			ln := int(param.Value[i])
+			i++
+			if i+ln > len(param.Value) {
+				return fmt.Sprintf("%s=0x%s", param.Key.String(), hex.EncodeToString(param.Value))
+			}
+			alpns = append(alpns, string(param.Value[i:i+ln]))
+			i += ln
+		}
+		return param.Key.String() + "=" + strings.Join(alpns, ",")
+	case dnsmessage.SVCParamNoDefaultALPN:
+		return param.Key.String()
+	case dnsmessage.SVCParamPort:
+		if len(param.Value) != 2 {
+			return fmt.Sprintf("%s=0x%s", param.Key.String(), hex.EncodeToString(param.Value))
+		}
+		port := uint16(param.Value[0])<<8 | uint16(param.Value[1])
+		return fmt.Sprintf("%s=%d", param.Key.String(), port)
+	case dnsmessage.SVCParamIPv4Hint:
+		if len(param.Value)%4 != 0 {
+			return fmt.Sprintf("%s=0x%s", param.Key.String(), hex.EncodeToString(param.Value))
+		}
+		var ips []string
+		for i := 0; i < len(param.Value); i += 4 {
+			ips = append(ips, net.IP(param.Value[i:i+4]).String())
+		}
+		return param.Key.String() + "=" + strings.Join(ips, ",")
+	case dnsmessage.SVCParamIPv6Hint:
+		if len(param.Value)%16 != 0 {
+			return fmt.Sprintf("%s=0x%s", param.Key.String(), hex.EncodeToString(param.Value))
+		}
+		var ips []string
+		for i := 0; i < len(param.Value); i += 16 {
+			ips = append(ips, net.IP(param.Value[i:i+16]).String())
+		}
+		return param.Key.String() + "=" + strings.Join(ips, ",")
+	case dnsmessage.SVCParamDOHPath:
+		return param.Key.String() + "=" + strconv.Quote(string(param.Value))
+	default:
+		return fmt.Sprintf("%s=0x%s", param.Key.String(), hex.EncodeToString(param.Value))
+	}
+}
+
+func normalizeDOHValue(typ dnsmessage.Type, value string) string {
+	raw, ok := parseGenericRDATA(value)
+	if !ok {
+		return value
+	}
+
+	switch typ {
+	case dnsmessage.TypeSVCB, dnsmessage.TypeHTTPS:
+		if text, ok := parseSVCBRDATA(raw); ok {
+			return text
+		}
+	case dnsTypeCAA:
+		return formatCAA(raw)
+	}
+	return "0x" + hex.EncodeToString(raw)
+}
+
+func parseGenericRDATA(value string) ([]byte, bool) {
+	fields := strings.Fields(value)
+	if len(fields) < 3 || fields[0] != "\\#" {
+		return nil, false
+	}
+	wantLen, err := strconv.Atoi(fields[1])
+	if err != nil || wantLen < 0 {
+		return nil, false
+	}
+	raw, err := hex.DecodeString(strings.Join(fields[2:], ""))
+	if err != nil || len(raw) != wantLen {
+		return nil, false
+	}
+	return raw, true
+}
+
+func parseSVCBRDATA(raw []byte) (string, bool) {
+	if len(raw) < 3 {
+		return "", false
+	}
+	priority := uint16(raw[0])<<8 | uint16(raw[1])
+	target, off, ok := unpackDNSName(raw, 2)
+	if !ok {
+		return "", false
+	}
+
+	var params []dnsmessage.SVCParam
+	for off < len(raw) {
+		if off+4 > len(raw) {
+			return "", false
+		}
+		key := uint16(raw[off])<<8 | uint16(raw[off+1])
+		ln := int(raw[off+2])<<8 | int(raw[off+3])
+		off += 4
+		if off+ln > len(raw) {
+			return "", false
+		}
+		value := append([]byte(nil), raw[off:off+ln]...)
+		params = append(params, dnsmessage.SVCParam{Key: dnsmessage.SVCParamKey(key), Value: value})
+		off += ln
+	}
+	return formatSVCBValue(priority, target, params), true
+}
+
+func unpackDNSName(raw []byte, off int) (string, int, bool) {
+	var labels []string
+	for {
+		if off >= len(raw) {
+			return "", 0, false
+		}
+		ln := int(raw[off])
+		off++
+		if ln == 0 {
+			if len(labels) == 0 {
+				return ".", off, true
+			}
+			return strings.Join(labels, ".") + ".", off, true
+		}
+		if ln&0xc0 != 0 || off+ln > len(raw) {
+			return "", 0, false
+		}
+		labels = append(labels, string(raw[off:off+ln]))
+		off += ln
+	}
+}
+
+func resolverTarget(server *url.URL) (label, udpAddr string) {
+	switch {
+	case server == nil:
+		addr := systemDNSServer()
+		return "system (" + addr + ")", addr
+	case server.Scheme == "":
+		return "udp " + server.Host, server.Host
+	default:
+		return server.String(), ""
+	}
+}
+
+func systemDNSServer() string {
+	raw, err := os.ReadFile("/etc/resolv.conf")
+	if err == nil {
+		for _, line := range strings.Split(string(raw), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && fields[0] == "nameserver" {
+				return net.JoinHostPort(fields[1], "53")
+			}
+		}
+	}
+	return net.JoinHostPort("127.0.0.1", "53")
+}
+
+func absoluteName(host string) string {
+	if strings.HasSuffix(host, ".") {
+		return host
+	}
+	return host + "."
+}
+
+func typeLabel(typ dnsmessage.Type) string {
+	switch typ {
+	case dnsmessage.TypeA:
+		return "A"
+	case dnsmessage.TypeAAAA:
+		return "AAAA"
+	case dnsmessage.TypeCNAME:
+		return "CNAME"
+	case dnsmessage.TypeTXT:
+		return "TXT"
+	case dnsmessage.TypeMX:
+		return "MX"
+	case dnsmessage.TypeNS:
+		return "NS"
+	case dnsmessage.TypeSOA:
+		return "SOA"
+	case dnsmessage.TypeSRV:
+		return "SRV"
+	case dnsTypeCAA:
+		return "CAA"
+	case dnsmessage.TypeSVCB:
+		return "SVCB"
+	case dnsmessage.TypeHTTPS:
+		return "HTTPS"
+	default:
+		return fmt.Sprintf("TYPE%d", uint16(typ))
+	}
+}
+
+func rcodeName(status int) string {
+	switch status {
+	case 1:
+		return "FormatError"
+	case 2:
+		return "ServerFailure"
+	case 3:
+		return "NXDomain"
+	case 4:
+		return "NotImplemented"
+	case 5:
+		return "Refused"
+	default:
+		return ""
+	}
+}
+
+func renderIPLiteral(p *core.Printer, host string, ip net.IP, resolver string, duration time.Duration) {
+	p.WriteInfoPrefix()
+	p.Set(core.Bold)
+	p.Set(core.Cyan)
+	p.WriteString("DNS lookup")
+	p.Reset()
+	p.WriteString(": ")
+	p.Set(core.Bold)
+	p.WriteString(host)
+	p.Reset()
+	p.WriteString("\n")
+
+	p.WriteInfoPrefix()
+	p.WriteString("Resolver: ")
+	p.Set(core.Italic)
+	p.WriteString(resolver)
+	p.Reset()
+	p.WriteString("\n\n")
+
+	p.WriteInfoPrefix()
+	p.WriteString("  IP literal: ")
+	p.Set(core.Green)
+	p.WriteString(ip.String())
+	p.Reset()
+	p.WriteString(" (no DNS query needed)\n")
+
+	p.WriteInfoPrefix()
+	p.WriteString("  Duration: ")
+	p.Set(core.Dim)
+	p.WriteString(formatDuration(duration))
+	p.Reset()
+	p.WriteString("\n")
+}
+
+func render(p *core.Printer, res *result) {
+	p.WriteInfoPrefix()
+	p.Set(core.Bold)
+	p.Set(core.Cyan)
+	p.WriteString("DNS lookup")
+	p.Reset()
+	p.WriteString(": ")
+	p.Set(core.Bold)
+	p.WriteString(res.host)
+	p.Reset()
+	p.WriteString("\n")
+
+	p.WriteInfoPrefix()
+	p.WriteString("Resolver: ")
+	p.Set(core.Italic)
+	p.WriteString(res.resolver)
+	p.Reset()
+	p.WriteString("\n")
+	p.WriteInfoPrefix()
+	p.WriteString("\n")
+
+	for _, qt := range inspectTypes {
+		renderSection(p, qt.label, res.records[qt.label])
+	}
+	renderOtherSections(p, res.records)
+
+	p.WriteInfoPrefix()
+	p.WriteString("  Addresses: ")
+	p.Set(core.Bold)
+	p.WriteString(fmt.Sprintf("%d", len(res.records["A"])+len(res.records["AAAA"])))
+	p.Reset()
+	p.WriteString("\n")
+
+	p.WriteInfoPrefix()
+	p.WriteString("  Records: ")
+	p.Set(core.Bold)
+	p.WriteString(fmt.Sprintf("%d", recordCount(res)))
+	p.Reset()
+	p.WriteString("\n")
+
+	p.WriteInfoPrefix()
+	p.WriteString("  Duration: ")
+	p.Set(core.Dim)
+	p.WriteString(formatDuration(res.duration))
+	p.Reset()
+	p.WriteString("\n")
+}
+
+func renderOtherSections(p *core.Printer, records map[string][]record) {
+	known := make(map[string]bool, len(inspectTypes))
+	for _, qt := range inspectTypes {
+		known[qt.label] = true
+	}
+	var types []string
+	for typ := range records {
+		if known[typ] {
+			continue
+		}
+		types = append(types, typ)
+	}
+	slices.Sort(types)
+	for _, typ := range types {
+		renderSection(p, typ, records[typ])
+	}
+}
+
+func renderSection(p *core.Printer, name string, records []record) {
+	if len(records) == 0 {
+		return
+	}
+	records = slices.Clone(records)
+	slices.SortFunc(records, func(a, b record) int {
+		if cmp := strings.Compare(a.value, b.value); cmp != 0 {
+			return cmp
+		}
+		if a.ttl < b.ttl {
+			return -1
+		}
+		if a.ttl > b.ttl {
+			return 1
+		}
+		return 0
+	})
+
+	p.WriteInfoPrefix()
+	p.Set(core.Bold)
+	p.WriteString("  " + name)
+	p.Reset()
+	p.WriteString("\n")
+
+	for i, rec := range records {
+		p.WriteInfoPrefix()
+		if i == len(records)-1 {
+			p.WriteString("  \u2514\u2500 ")
+		} else {
+			p.WriteString("  \u251c\u2500 ")
+		}
+		p.Set(core.Green)
+		p.WriteString(rec.value)
+		p.Reset()
+		p.WriteString(" ")
+		p.Set(core.Dim)
+		p.WriteString("(TTL ")
+		p.WriteString(formatTTL(rec.ttl))
+		p.WriteString(")")
+		p.Reset()
+		p.WriteString("\n")
+	}
+
+	p.WriteInfoPrefix()
+	p.WriteString("\n")
+}
+
+func recordCount(res *result) int {
+	var count int
+	for _, records := range res.records {
+		count += len(records)
+	}
+	return count
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Millisecond {
+		return d.Round(time.Microsecond).String()
+	}
+	return d.Round(100 * time.Microsecond).String()
+}
+
+func formatTTL(ttl uint32) string {
+	if ttl == 1 {
+		return "1s"
+	}
+	d := time.Duration(ttl) * time.Second
+	if ttl < 60 {
+		return d.String()
+	}
+	text := strings.TrimSuffix(d.String(), "0s")
+	return strings.TrimSuffix(text, "0m")
+}
+
+func writeDNSError(p *core.Printer, err error) {
+	core.WriteErrorMsgNoFlush(p, err)
+	p.Flush()
+}

--- a/internal/dnsinspect/dnsinspect_test.go
+++ b/internal/dnsinspect/dnsinspect_test.go
@@ -1,0 +1,333 @@
+package dnsinspect
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ryanfowler/fetch/internal/core"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func TestInspectDOHShowsAAndAAAATTLs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("type") {
+		case "A":
+			io.WriteString(w, `{"Status":0,"Answer":[{"type":5,"data":"alias.example.com.","TTL":120},{"type":1,"data":"192.0.2.1","TTL":60}]}`)
+		case "AAAA":
+			io.WriteString(w, `{"Status":0,"Answer":[{"type":28,"data":"2001:db8::1","TTL":300}]}`)
+		case "TXT":
+			io.WriteString(w, `{"Status":0,"Answer":[{"type":16,"data":"v=spf1 -all","TTL":180}]}`)
+		default:
+			io.WriteString(w, `{"Status":0}`)
+		}
+	}))
+	defer server.Close()
+
+	p := core.TestPrinter(false)
+	status := Inspect(context.Background(), p, &Config{
+		DNSServer: mustURL(t, server.URL+"/dns-query"),
+		URL:       mustURL(t, "https://example.com"),
+	})
+	if status != 0 {
+		t.Fatalf("status = %d, want 0\n%s", status, p.Bytes())
+	}
+	out := string(p.Bytes())
+	for _, want := range []string{
+		"DNS lookup: example.com",
+		"Resolver: " + server.URL + "/dns-query",
+		"A\n",
+		"\u2514\u2500 192.0.2.1 (TTL 1m)",
+		"AAAA\n",
+		"\u2514\u2500 2001:db8::1 (TTL 5m)",
+		"CNAME\n",
+		"alias.example.com. (TTL 2m)",
+		"TXT\n",
+		"v=spf1 -all (TTL 3m)",
+		"Addresses: 2",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestInspectIPLiteralSkipsLookup(t *testing.T) {
+	p := core.TestPrinter(false)
+	status := Inspect(context.Background(), p, &Config{
+		URL: mustURL(t, "http://127.0.0.1"),
+	})
+	if status != 0 {
+		t.Fatalf("status = %d, want 0\n%s", status, p.Bytes())
+	}
+	out := string(p.Bytes())
+	if !strings.Contains(out, "IP literal: 127.0.0.1 (no DNS query needed)") {
+		t.Fatalf("output missing IP literal message:\n%s", out)
+	}
+}
+
+func TestLookupQueriesRecordTypesConcurrently(t *testing.T) {
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		mu.Unlock()
+
+		time.Sleep(25 * time.Millisecond)
+
+		mu.Lock()
+		active--
+		mu.Unlock()
+
+		switch r.URL.Query().Get("type") {
+		case "A":
+			io.WriteString(w, `{"Status":0,"Answer":[{"type":1,"data":"192.0.2.1","TTL":60}]}`)
+		default:
+			io.WriteString(w, `{"Status":0}`)
+		}
+	}))
+	defer server.Close()
+
+	_, err := lookup(context.Background(), &Config{
+		DNSServer: mustURL(t, server.URL+"/dns-query"),
+	}, "example.com", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	got := maxActive
+	mu.Unlock()
+	if got < 2 {
+		t.Fatalf("max concurrent requests = %d, want at least 2", got)
+	}
+}
+
+func TestLookupCollapsesDuplicateCNAMEsWithLowestTTL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("type") {
+		case "A":
+			io.WriteString(w, `{"Status":0,"Answer":[{"type":5,"data":"alias.example.com.","TTL":120},{"type":1,"data":"192.0.2.1","TTL":60}]}`)
+		case "AAAA":
+			io.WriteString(w, `{"Status":0,"Answer":[{"type":5,"data":"alias.example.com.","TTL":119}]}`)
+		default:
+			io.WriteString(w, `{"Status":0}`)
+		}
+	}))
+	defer server.Close()
+
+	res, err := lookup(context.Background(), &Config{
+		DNSServer: mustURL(t, server.URL+"/dns-query"),
+	}, "example.com", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cnames := res.records["CNAME"]
+	if len(cnames) != 1 {
+		t.Fatalf("CNAME records = %v, want 1 collapsed record", cnames)
+	}
+	if got, want := cnames[0].ttl, uint32(119); got != want {
+		t.Fatalf("CNAME TTL = %d, want lowest TTL %d", got, want)
+	}
+}
+
+func TestLookupUDPRecordsReturnsTTL(t *testing.T) {
+	addr, stop := startUDPServer(t)
+	defer stop()
+
+	records, err := lookupUDPRecords(context.Background(), addr, "example.com", queryType{
+		label:   "A",
+		dohType: "A",
+		dnsType: dnsmessage.TypeA,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %v, want 1 record", records)
+	}
+	if got, want := records[0].value, "192.0.2.10"; got != want {
+		t.Fatalf("value = %q, want %q", got, want)
+	}
+	if got, want := records[0].ttl, uint32(42); got != want {
+		t.Fatalf("TTL = %d, want %d", got, want)
+	}
+}
+
+func TestRenderShowsUnavailableTTLPerRecord(t *testing.T) {
+	p := core.TestPrinter(false)
+	render(p, &result{
+		host:     "example.com",
+		resolver: "system",
+		records: map[string][]record{
+			"A": {{typ: "A", value: "192.0.2.1", ttl: 60}},
+		},
+	})
+
+	out := string(p.Bytes())
+	if !strings.Contains(out, "\u2514\u2500 192.0.2.1 (TTL 1m)") {
+		t.Fatalf("output missing tree-formatted TTL:\n%s", out)
+	}
+}
+
+func TestRenderSortsRecordsWithinType(t *testing.T) {
+	p := core.TestPrinter(false)
+	render(p, &result{
+		host:     "example.com",
+		resolver: "system",
+		records: map[string][]record{
+			"A": {
+				{typ: "A", value: "192.0.2.20", ttl: 60},
+				{typ: "A", value: "192.0.2.10", ttl: 60},
+			},
+		},
+	})
+
+	out := string(p.Bytes())
+	first := strings.Index(out, "192.0.2.10")
+	second := strings.Index(out, "192.0.2.20")
+	if first == -1 || second == -1 || first > second {
+		t.Fatalf("records not sorted within type:\n%s", out)
+	}
+}
+
+func TestFormatTTLTrimsZeroUnits(t *testing.T) {
+	tests := map[int]string{
+		1:    "1s",
+		60:   "1m",
+		300:  "5m",
+		3600: "1h",
+		3660: "1h1m",
+	}
+	for ttl, want := range tests {
+		if got := formatTTL(uint32(ttl)); got != want {
+			t.Fatalf("formatTTL(%d) = %q, want %q", ttl, got, want)
+		}
+	}
+}
+
+func TestFormatCAA(t *testing.T) {
+	raw := append([]byte{0, 5}, []byte("issueletsencrypt.org")...)
+	if got, want := formatCAA(raw), `0 issue "letsencrypt.org"`; got != want {
+		t.Fatalf("formatCAA = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeDOHHTTPSGenericRDATA(t *testing.T) {
+	got := normalizeDOHValue(dnsmessage.TypeHTTPS, `\# 24 000100000100030268330003000201bb00040004c0000201`)
+	for _, want := range []string{
+		"1 .",
+		"ALPN=h3",
+		"Port=443",
+		"IPv4Hint=192.0.2.1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("decoded HTTPS value missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestNormalizeDOHCAAGenericRDATA(t *testing.T) {
+	got := normalizeDOHValue(dnsTypeCAA, `\# 22 000569737375656c657473656e63727970742e6f7267`)
+	if want := `0 issue "letsencrypt.org"`; got != want {
+		t.Fatalf("decoded CAA = %q, want %q", got, want)
+	}
+}
+
+func TestInspectDOHFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `{"Status":3}`)
+	}))
+	defer server.Close()
+
+	p := core.TestPrinter(false)
+	status := Inspect(context.Background(), p, &Config{
+		DNSServer: mustURL(t, server.URL),
+		URL:       mustURL(t, "https://missing.example"),
+	})
+	if status != 1 {
+		t.Fatalf("status = %d, want 1", status)
+	}
+	if out := string(p.Bytes()); !strings.Contains(out, "NXDomain") {
+		t.Fatalf("output missing NXDomain:\n%s", out)
+	}
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
+}
+
+func startUDPServer(t *testing.T) (string, func()) {
+	t.Helper()
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 512)
+		for {
+			n, addr, err := conn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			var req dnsmessage.Message
+			if err := req.Unpack(buf[:n]); err != nil {
+				continue
+			}
+			if len(req.Questions) == 0 {
+				continue
+			}
+			res := dnsmessage.Message{
+				Header: dnsmessage.Header{
+					ID:                 req.Header.ID,
+					Response:           true,
+					RecursionDesired:   req.Header.RecursionDesired,
+					RecursionAvailable: true,
+					RCode:              dnsmessage.RCodeSuccess,
+				},
+				Questions: req.Questions,
+			}
+			if req.Questions[0].Type == dnsmessage.TypeA {
+				res.Answers = []dnsmessage.Resource{{
+					Header: dnsmessage.ResourceHeader{
+						Name:  req.Questions[0].Name,
+						Type:  dnsmessage.TypeA,
+						Class: dnsmessage.ClassINET,
+						TTL:   42,
+					},
+					Body: &dnsmessage.AResource{A: [4]byte{192, 0, 2, 10}},
+				}}
+			}
+			raw, err := res.Pack()
+			if err == nil {
+				_, _ = conn.WriteTo(raw, addr)
+			}
+		}
+	}()
+
+	return conn.LocalAddr().String(), func() {
+		_ = conn.Close()
+		<-done
+	}
+}

--- a/internal/resolver/doh.go
+++ b/internal/resolver/doh.go
@@ -19,12 +19,16 @@ const (
 )
 
 func lookupDOH(ctx context.Context, serverURL *url.URL, host string) ([]net.IPAddr, error) {
-	a, aErr := lookupDOHType(ctx, serverURL, host, "A", dnsTypeA)
-	aaaa, aaaaErr := lookupDOHType(ctx, serverURL, host, "AAAA", dnsTypeAAAA)
+	a, aErr := LookupDOHType(ctx, serverURL, host, "A", dnsTypeA)
+	aaaa, aaaaErr := LookupDOHType(ctx, serverURL, host, "AAAA", dnsTypeAAAA)
 
 	addrs := make([]net.IPAddr, 0, len(a)+len(aaaa))
-	addrs = append(addrs, a...)
-	addrs = append(addrs, aaaa...)
+	for _, record := range a {
+		addrs = append(addrs, net.IPAddr{IP: record.IP})
+	}
+	for _, record := range aaaa {
+		addrs = append(addrs, net.IPAddr{IP: record.IP})
+	}
 	if len(addrs) > 0 {
 		return addrs, nil
 	}
@@ -37,10 +41,18 @@ func lookupDOH(ctx context.Context, serverURL *url.URL, host string) ([]net.IPAd
 	return nil, errors.New("no such host")
 }
 
-func lookupDOHType(ctx context.Context, serverURL *url.URL, host, dnsType string, answerType int) ([]net.IPAddr, error) {
+// DNSRecord is a resolved DNS answer with optional TTL metadata.
+type DNSRecord struct {
+	IP  net.IP
+	TTL int
+}
+
+// LookupDOHType resolves one DNS record family through a DNS-over-HTTPS JSON endpoint.
+func LookupDOHType(ctx context.Context, serverURL *url.URL, host, dnsType string, answerType int) ([]DNSRecord, error) {
 	type answer struct {
 		Type int    `json:"type"`
 		Data string `json:"data"`
+		TTL  int    `json:"TTL"`
 	}
 	type response struct {
 		Status int      `json:"Status"`
@@ -96,18 +108,18 @@ func lookupDOHType(ctx context.Context, serverURL *url.URL, host, dnsType string
 		return nil, fmt.Errorf("no such host: %s", name)
 	}
 
-	addrs := make([]net.IPAddr, 0, len(res.Answer))
+	records := make([]DNSRecord, 0, len(res.Answer))
 	for _, answer := range res.Answer {
 		if answer.Type != answerType {
 			continue
 		}
 		ip := net.ParseIP(answer.Data)
 		if ip != nil {
-			addrs = append(addrs, net.IPAddr{IP: ip})
+			records = append(records, DNSRecord{IP: ip, TTL: answer.TTL})
 		}
 	}
-	if len(addrs) == 0 {
+	if len(records) == 0 {
 		return nil, errors.New("no such host")
 	}
-	return addrs, nil
+	return records, nil
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -58,6 +58,27 @@ func TestLookupIPAddrDOHNXDomain(t *testing.T) {
 	}
 }
 
+func TestLookupDOHTypeReturnsTTL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1","TTL":123}]}`)
+	}))
+	defer server.Close()
+
+	records, err := LookupDOHType(context.Background(), mustURL(t, server.URL), "example.com", "A", dnsTypeA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %v, want 1 record", records)
+	}
+	if got, want := records[0].IP.String(), "127.0.0.1"; got != want {
+		t.Fatalf("IP = %q, want %q", got, want)
+	}
+	if got, want := records[0].TTL, 123; got != want {
+		t.Fatalf("TTL = %d, want %d", got, want)
+	}
+}
+
 func TestLookupIPAddrDoesNotTraceIPLiteral(t *testing.T) {
 	var started bool
 	ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ryanfowler/fetch/internal/complete"
 	"github.com/ryanfowler/fetch/internal/config"
 	"github.com/ryanfowler/fetch/internal/core"
+	"github.com/ryanfowler/fetch/internal/dnsinspect"
 	"github.com/ryanfowler/fetch/internal/fetch"
 	"github.com/ryanfowler/fetch/internal/format"
 	"github.com/ryanfowler/fetch/internal/multipart"
@@ -134,6 +135,11 @@ func main() {
 		p := handle.Stderr()
 		writeCLIErr(p, errors.New("cannot use a unix socket with HTTP/3.0"))
 		os.Exit(1)
+	}
+
+	// Handle --inspect-dns: resolve the URL hostname only, no HTTP request.
+	if app.InspectDNS {
+		os.Exit(inspectDNS(ctx, app, handle))
 	}
 
 	// Handle --inspect-tls: perform TLS handshake only, no HTTP request.
@@ -330,6 +336,122 @@ func writeCLIErr(p *core.Printer, err error) {
 
 	p.WriteString("'.\n")
 	p.Flush()
+}
+
+// inspectDNS performs DNS resolution only and renders the resolved records.
+func inspectDNS(ctx context.Context, app *cli.App, handle *core.Handle) int {
+	p := handle.Stderr()
+
+	var ignored []string
+	if app.Data != nil {
+		ignored = append(ignored, "--data/--json/--xml")
+	}
+	if len(app.Form) > 0 {
+		ignored = append(ignored, "--form")
+	}
+	if len(app.Multipart) > 0 {
+		ignored = append(ignored, "--multipart")
+	}
+	if app.GRPC {
+		ignored = append(ignored, "--grpc")
+	}
+	if app.GRPCDescribe != "" {
+		ignored = append(ignored, "--grpc-describe")
+	}
+	if app.GRPCList {
+		ignored = append(ignored, "--grpc-list")
+	}
+	if app.Output != "" {
+		ignored = append(ignored, "--output")
+	}
+	if app.RemoteName {
+		ignored = append(ignored, "--remote-name")
+	}
+	if app.RemoteHeaderName {
+		ignored = append(ignored, "--remote-header-name")
+	}
+	if getValue(app.Cfg.Copy) {
+		ignored = append(ignored, "--copy")
+	}
+	if app.Method != "" {
+		ignored = append(ignored, "--method")
+	}
+	if len(app.Cfg.Headers) > 0 {
+		ignored = append(ignored, "--header")
+	}
+	if len(app.Cfg.QueryParams) > 0 {
+		ignored = append(ignored, "--query")
+	}
+	if app.Edit {
+		ignored = append(ignored, "--edit")
+	}
+	if getValue(app.Cfg.Session) != "" {
+		ignored = append(ignored, "--session")
+	}
+	if getValue(app.Cfg.Retry) > 0 {
+		ignored = append(ignored, "--retry")
+	}
+	if len(app.Range) > 0 {
+		ignored = append(ignored, "--range")
+	}
+	if getValue(app.Cfg.Timing) {
+		ignored = append(ignored, "--timing")
+	}
+	if app.Cfg.Proxy != nil {
+		ignored = append(ignored, "--proxy")
+	}
+	if app.Discard {
+		ignored = append(ignored, "--discard")
+	}
+	if app.UnixSocket != "" {
+		ignored = append(ignored, "--unix")
+	}
+	if app.InspectTLS {
+		ignored = append(ignored, "--inspect-tls")
+	}
+	if app.Bearer != "" {
+		ignored = append(ignored, "--bearer")
+	}
+	if app.Basic != nil {
+		ignored = append(ignored, "--basic")
+	}
+	if app.Digest != nil {
+		ignored = append(ignored, "--digest")
+	}
+	if app.AWSSigv4 != nil {
+		ignored = append(ignored, "--aws-sigv4")
+	}
+	if len(app.Cfg.CACerts) > 0 {
+		ignored = append(ignored, "--ca-cert")
+	}
+	if app.Cfg.CertPath != "" {
+		ignored = append(ignored, "--cert")
+	}
+	if app.Cfg.KeyPath != "" {
+		ignored = append(ignored, "--key")
+	}
+	if app.Cfg.TLS != nil {
+		ignored = append(ignored, "--tls")
+	}
+	if getValue(app.Cfg.Insecure) {
+		ignored = append(ignored, "--insecure")
+	}
+	if app.Cfg.Format != core.FormatUnknown {
+		ignored = append(ignored, "--format")
+	}
+	if app.DryRun {
+		ignored = append(ignored, "--dry-run")
+	}
+	if len(ignored) > 0 {
+		msg := "--inspect-dns ignores: " + strings.Join(ignored, ", ") + "\n"
+		core.WriteWarningMsg(p, msg)
+	}
+
+	return dnsinspect.Inspect(ctx, p, &dnsinspect.Config{
+		DNSServer: app.Cfg.DNSServer,
+		Timeout:   getValue(app.Cfg.Timeout),
+		URL:       app.URL,
+	})
 }
 
 type errSelfUpdateDisabled string


### PR DESCRIPTION
## Summary
- Add `--inspect-dns` as a no-request diagnostic mode for hostname resolution
- Query DNS record types directly over UDP and DoH so TTLs are available in inspection output
- Render DNS results in a structured, tree-style format with support for common record types
- Update docs and README to describe the new inspection workflow

## Testing
- Added unit coverage for UDP/DoH lookup behavior, TTL handling, sorting, deduplication, and record formatting
- Verified the full Go test suite passes
- Verified staticcheck passes