### PR TITLE
Add min and max TLS flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ prettier -w .
 - `--grpc` now automatically tries gRPC reflection when no local schema is supplied.
 - Plaintext loopback gRPC servers are supported via `h2c` for both calls and discovery.
 - `--inspect-dns` resolves the URL hostname without making an HTTP request, showing common DNS record types, resolver backend, duration, and per-record TTLs from direct UDP or DoH responses.
+- `--tls` remains a compatibility alias for setting the minimum TLS version; prefer `--min-tls` in new docs/examples, and use `--max-tls` to cap negotiation or combine min/max for an exact TLS version.
 5. HTTP client executes request
 6. Response formatted based on Content-Type and output to stdout (optionally via pager)
 

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -184,13 +184,20 @@ By default, `fetch` negotiates the best available version:
 
 ## TLS Configuration
 
-### Minimum TLS Version
+### TLS Version Bounds
 
-`--tls VERSION` sets the minimum acceptable TLS version:
+`--min-tls VERSION` sets the minimum acceptable TLS version. `--tls VERSION` is kept as an alias for `--min-tls`:
 
 ```sh
-fetch --tls 1.2 example.com  # Require TLS 1.2+
-fetch --tls 1.3 example.com  # Require TLS 1.3
+fetch --min-tls 1.2 example.com  # Require TLS 1.2+
+fetch --tls 1.3 example.com      # Require TLS 1.3+
+```
+
+`--max-tls VERSION` sets the maximum acceptable TLS version:
+
+```sh
+fetch --min-tls 1.2 --max-tls 1.3 example.com  # Allow TLS 1.2 through 1.3
+fetch --min-tls 1.2 --max-tls 1.2 example.com  # Require exactly TLS 1.2
 ```
 
 | Value | Protocol                      |
@@ -256,7 +263,7 @@ fetch --inspect-tls --insecure expired.badssl.com
 
 ```ini
 # Require TLS 1.2 minimum
-tls = 1.2
+min-tls = 1.2
 
 # Internal server with private CA
 [internal.company.com]
@@ -397,7 +404,7 @@ Complex requests often combine multiple advanced options:
 fetch \
   --dns-server https://1.1.1.1/dns-query \
   --proxy socks5://localhost:9050 \
-  --tls 1.3 \
+  --min-tls 1.3 \
   --timeout 60 \
   --http 2 \
   -v \
@@ -409,7 +416,7 @@ fetch \
 ```ini
 # Global settings
 timeout = 30
-tls = 1.2
+min-tls = 1.2
 dns-server = 8.8.8.8
 
 # Internal services
@@ -425,7 +432,7 @@ timeout = 5
 
 # High-security API
 [secure-api.example.com]
-tls = 1.3
+min-tls = 1.3
 timeout = 60
 ```
 
@@ -529,7 +536,7 @@ fetch --dns-server 8.8.8.8 -v example.com
 fetch --http 1 -v example.com
 
 # Test TLS configuration
-fetch --tls 1.3 -vvv example.com
+fetch --min-tls 1.3 -vvv example.com
 ```
 
 ## See Also

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -383,10 +383,26 @@ fetch --unix /var/run/docker.sock http://unix/containers/json
 
 ### `--tls VERSION`
 
-Minimum TLS version. Values: `1.0`, `1.1`, `1.2`, `1.3`.
+Minimum TLS version. This is an alias for `--min-tls`. Values: `1.0`, `1.1`, `1.2`, `1.3`.
 
 ```sh
 fetch --tls 1.3 example.com
+```
+
+### `--min-tls VERSION`
+
+Minimum TLS version. Values: `1.0`, `1.1`, `1.2`, `1.3`.
+
+```sh
+fetch --min-tls 1.2 example.com
+```
+
+### `--max-tls VERSION`
+
+Maximum TLS version. Values: `1.0`, `1.1`, `1.2`, `1.3`. Combine with `--min-tls` to allow a bounded range or require an exact TLS version.
+
+```sh
+fetch --min-tls 1.2 --max-tls 1.2 example.com
 ```
 
 ### `--inspect-tls`
@@ -607,7 +623,7 @@ fetch --from-curl 'https://example.com'
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Request      | `-X`, `-H`, `-d`, `--data-raw`, `--data-binary`, `--data-urlencode`, `--json`, `-F`, `-T`, `-I`, `-G`                                         |
 | Auth         | `-u`, `--digest`, `--aws-sigv4`, `--oauth2-bearer`                                                                                            |
-| TLS          | `-k`, `--cacert`, `-E`/`--cert`, `--key`, `--tlsv1.x`                                                                                         |
+| TLS          | `-k`, `--cacert`, `-E`/`--cert`, `--key`, `--tlsv1.x`, `--tls-max`                                                                             |
 | Output       | `-o`, `-O`, `-J`                                                                                                                              |
 | Network      | `-L`, `--max-redirs`, `-m`/`--max-time`, `--connect-timeout`, `-x`, `--unix-socket`, `--doh-url`, `--retry`, `--retry-delay`, `-r`            |
 | HTTP version | `-0`, `--http1.1`, `--http2`, `--http3`                                                                                                       |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -352,14 +352,40 @@ http = 2
 **Values**: `1.0`, `1.1`, `1.2`, `1.3`
 **Default**: `1.2`
 
-Specify the minimum TLS version to use.
+Specify the minimum TLS version to use. This is an alias for `min-tls`.
 
 ```ini
 # Require TLS 1.2 or higher
 tls = 1.2
 
-# Require TLS 1.3
+# Require TLS 1.3 or higher
 tls = 1.3
+```
+
+#### `min-tls`
+
+**Type**: String
+**Values**: `1.0`, `1.1`, `1.2`, `1.3`
+**Default**: `1.2`
+
+Specify the minimum TLS version to use.
+
+```ini
+min-tls = 1.2
+```
+
+#### `max-tls`
+
+**Type**: String
+**Values**: `1.0`, `1.1`, `1.2`, `1.3`
+**Default**: No maximum
+
+Specify the maximum TLS version to use. Set `min-tls` and `max-tls` to the same value to require an exact TLS version.
+
+```ini
+# Require exactly TLS 1.2
+min-tls = 1.2
+max-tls = 1.2
 ```
 
 #### `insecure`
@@ -628,7 +654,7 @@ insecure = true
 
 # External APIs (strict security)
 [external-api.vendor.com]
-tls = 1.2
+min-tls = 1.2
 timeout = 60
 header = X-Company-ID: company-identifier
 ```

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -128,7 +128,7 @@ func (a *App) CLI() *CLI {
 			"form", "multipart", "basic", "bearer", "digest", "aws-sigv4",
 			"output", "remote-name", "remote-header-name",
 			"range", "unix", "timeout", "connect-timeout",
-			"redirects", "proxy", "insecure", "tls", "http",
+			"redirects", "proxy", "insecure", "max-tls", "min-tls", "tls", "http",
 			"cert", "key", "ca-cert", "dns-server",
 			"retry", "retry-delay", "grpc", "grpc-describe", "grpc-list", "query",
 		},
@@ -293,9 +293,17 @@ func (a *App) CLI() *CLI {
 				Fn:          a.parseKeyFlag,
 			},
 
+			cfgFlag("max-tls", "", "VERSION", "Maximum TLS version",
+				func() bool { return a.Cfg.TLSMax != nil }, a.Cfg.ParseMaxTLS).
+				WithValues(tlsValues()),
+
 			stringFlag(&a.Method, "method", "m", "METHOD", "HTTP method to use").
 				WithAliases("X").
 				WithDefault("GET"),
+
+			cfgFlag("min-tls", "", "VERSION", "Minimum TLS version",
+				func() bool { return a.Cfg.TLSMin != nil }, a.Cfg.ParseMinTLS).
+				WithValues(tlsValues()),
 
 			// Custom: multipart with file validation
 			{
@@ -375,13 +383,9 @@ func (a *App) CLI() *CLI {
 			ptrBoolFlag(&a.Cfg.Timing, "timing", "T", "Display a timing waterfall chart"),
 
 			cfgFlag("tls", "", "VERSION", "Minimum TLS version",
-				func() bool { return a.Cfg.TLS != nil }, a.Cfg.ParseTLS).
-				WithValues([]core.KeyVal[string]{
-					{Key: "1.0", Val: "TLS v1.0"},
-					{Key: "1.1", Val: "TLS v1.1"},
-					{Key: "1.2", Val: "TLS v1.2"},
-					{Key: "1.3", Val: "TLS v1.3"},
-				}),
+				func() bool { return a.Cfg.TLSMin != nil }, a.Cfg.ParseTLS).
+				WithValues(tlsValues()).
+				WithHidden(true),
 
 			stringFlag(&a.UnixSocket, "unix", "", "PATH", "Make the request over a unix socket").
 				WithOS(unixOS),
@@ -410,6 +414,15 @@ func (a *App) CLI() *CLI {
 				Fn:          a.parseXMLFlag,
 			},
 		},
+	}
+}
+
+func tlsValues() []core.KeyVal[string] {
+	return []core.KeyVal[string]{
+		{Key: "1.0", Val: "TLS v1.0"},
+		{Key: "1.1", Val: "TLS v1.1"},
+		{Key: "1.2", Val: "TLS v1.2"},
+		{Key: "1.3", Val: "TLS v1.3"},
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -684,6 +684,11 @@ func (a *App) applyFromCurl(r *curl.Result) error {
 			return err
 		}
 	}
+	if r.TLSMaxVersion != "" {
+		if err := a.Cfg.ParseMaxTLS(r.TLSMaxVersion); err != nil {
+			return err
+		}
+	}
 	if r.CACert != "" {
 		if err := a.Cfg.ParseCACerts(r.CACert); err != nil {
 			return err

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"crypto/tls"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,6 +11,41 @@ import (
 
 	"github.com/ryanfowler/fetch/internal/core"
 )
+
+func TestTLSFlags(t *testing.T) {
+	t.Run("tls remains minimum version alias", func(t *testing.T) {
+		app, err := Parse([]string{"--tls", "1.2", "https://example.com"})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if app.Cfg.TLSMin == nil || *app.Cfg.TLSMin != tls.VersionTLS12 {
+			t.Fatalf("TLSMin = %v, want TLS 1.2", app.Cfg.TLSMin)
+		}
+	})
+
+	t.Run("min and max tls", func(t *testing.T) {
+		app, err := Parse([]string{"--min-tls", "1.2", "--max-tls", "1.3", "https://example.com"})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if app.Cfg.TLSMin == nil || *app.Cfg.TLSMin != tls.VersionTLS12 {
+			t.Fatalf("TLSMin = %v, want TLS 1.2", app.Cfg.TLSMin)
+		}
+		if app.Cfg.TLSMax == nil || *app.Cfg.TLSMax != tls.VersionTLS13 {
+			t.Fatalf("TLSMax = %v, want TLS 1.3", app.Cfg.TLSMax)
+		}
+	})
+
+	t.Run("rejects invalid tls range", func(t *testing.T) {
+		_, err := Parse([]string{"--min-tls", "1.3", "--max-tls", "1.2", "https://example.com"})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "max-tls") {
+			t.Fatalf("error = %q, want max-tls", err.Error())
+		}
+	})
+}
 
 func TestFlagsAlphabeticalOrder(t *testing.T) {
 	app, err := Parse(nil)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -62,7 +62,8 @@ type ClientConfig struct {
 	Insecure       bool
 	Proxy          *url.URL
 	Redirects      *int
-	TLS            uint16
+	TLSMax         uint16
+	TLSMin         uint16
 	UnixSocket     string
 }
 
@@ -75,7 +76,8 @@ func NewClient(cfg ClientConfig) *Client {
 		CACerts:    cfg.CACerts,
 		ClientCert: cfg.ClientCert,
 		Insecure:   cfg.Insecure,
-		TLS:        cfg.TLS,
+		TLSMax:     cfg.TLSMax,
+		TLSMin:     cfg.TLSMin,
 	}
 	tlsConfig := tlsDialCfg.BuildTLSConfig()
 	res := resolver.New(resolver.Config{Server: cfg.DNSServer})

--- a/internal/client/tls.go
+++ b/internal/client/tls.go
@@ -11,18 +11,20 @@ type TLSDialConfig struct {
 	CACerts    []*x509.Certificate
 	ClientCert *tls.Certificate
 	Insecure   bool
-	TLS        uint16
+	TLSMax     uint16
+	TLSMin     uint16
 }
 
 // BuildTLSConfig returns a *tls.Config from the common configuration fields.
 func (c *TLSDialConfig) BuildTLSConfig() *tls.Config {
 	tlsConfig := &tls.Config{}
 
-	tlsVersion := c.TLS
-	if tlsVersion == 0 {
-		tlsVersion = tls.VersionTLS12
+	tlsMin := c.TLSMin
+	if tlsMin == 0 {
+		tlsMin = tls.VersionTLS12
 	}
-	tlsConfig.MinVersion = tlsVersion
+	tlsConfig.MinVersion = tlsMin
+	tlsConfig.MaxVersion = c.TLSMax
 
 	if c.Insecure {
 		tlsConfig.InsecureSkipVerify = true

--- a/internal/client/tls_test.go
+++ b/internal/client/tls_test.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestBuildTLSConfigVersionBounds(t *testing.T) {
+	t.Run("defaults to TLS 1.2 minimum", func(t *testing.T) {
+		cfg := (&TLSDialConfig{}).BuildTLSConfig()
+		if cfg.MinVersion != tls.VersionTLS12 {
+			t.Fatalf("MinVersion = %x, want %x", cfg.MinVersion, tls.VersionTLS12)
+		}
+		if cfg.MaxVersion != 0 {
+			t.Fatalf("MaxVersion = %x, want 0", cfg.MaxVersion)
+		}
+	})
+
+	t.Run("sets explicit min and max", func(t *testing.T) {
+		cfg := (&TLSDialConfig{
+			TLSMin: tls.VersionTLS12,
+			TLSMax: tls.VersionTLS13,
+		}).BuildTLSConfig()
+		if cfg.MinVersion != tls.VersionTLS12 {
+			t.Fatalf("MinVersion = %x, want %x", cfg.MinVersion, tls.VersionTLS12)
+		}
+		if cfg.MaxVersion != tls.VersionTLS13 {
+			t.Fatalf("MaxVersion = %x, want %x", cfg.MaxVersion, tls.VersionTLS13)
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,7 +48,8 @@ type Config struct {
 	Silent         *bool
 	Timeout        *time.Duration
 	Timing         *bool
-	TLS            *uint16
+	TLSMax         *uint16
+	TLSMin         *uint16
 	Verbosity      *int
 }
 
@@ -131,12 +132,24 @@ func (c *Config) Merge(c2 *Config) {
 	if c.Timing == nil {
 		c.Timing = c2.Timing
 	}
-	if c.TLS == nil {
-		c.TLS = c2.TLS
+	if c.TLSMax == nil {
+		c.TLSMax = c2.TLSMax
+	}
+	if c.TLSMin == nil {
+		c.TLSMin = c2.TLSMin
 	}
 	if c.Verbosity == nil {
 		c.Verbosity = c2.Verbosity
 	}
+}
+
+// Validate checks cross-option constraints that can only be evaluated after
+// CLI, global, and host-specific configuration have been merged.
+func (c *Config) Validate() error {
+	if c.TLSMin != nil && c.TLSMax != nil && *c.TLSMin > *c.TLSMax {
+		return fmt.Errorf("min-tls must be less than or equal to max-tls")
+	}
+	return nil
 }
 
 // Set sets the provided key and value pair, returning any error encountered.
@@ -193,6 +206,10 @@ func (c *Config) Set(key, val string) error {
 		err = c.ParseTimeout(val)
 	case "timing":
 		err = c.ParseTiming(val)
+	case "max-tls":
+		err = c.ParseMaxTLS(val)
+	case "min-tls":
+		err = c.ParseMinTLS(val)
 	case "tls":
 		err = c.ParseTLS(val)
 	case "verbosity":
@@ -541,24 +558,52 @@ func (c *Config) ParseTiming(value string) error {
 	return nil
 }
 
-func (c *Config) ParseTLS(value string) error {
-	var version uint16
+func parseTLSVersion(flag, value string, isFile bool) (uint16, error) {
 	switch value {
 	case "1.0":
-		version = tls.VersionTLS10
+		return tls.VersionTLS10, nil
 	case "1.1":
-		version = tls.VersionTLS11
+		return tls.VersionTLS11, nil
 	case "1.2":
-		version = tls.VersionTLS12
+		return tls.VersionTLS12, nil
 	case "1.3":
-		version = tls.VersionTLS13
+		return tls.VersionTLS13, nil
 	default:
 		const usage = "must be one of [1.0, 1.1, 1.2, 1.3]"
-		return core.NewValueError("tls", value, usage, c.isFile)
+		return 0, core.NewValueError(flag, value, usage, isFile)
 	}
-	c.TLS = &version
-	return nil
+}
 
+func (c *Config) ParseTLS(value string) error {
+	return c.parseMinTLS("tls", value)
+}
+
+func (c *Config) ParseMinTLS(value string) error {
+	return c.parseMinTLS("min-tls", value)
+}
+
+func (c *Config) parseMinTLS(flag, value string) error {
+	version, err := parseTLSVersion(flag, value, c.isFile)
+	if err != nil {
+		return err
+	}
+	if c.TLSMax != nil && version > *c.TLSMax {
+		return core.NewValueError(flag, value, "must be less than or equal to max-tls", c.isFile)
+	}
+	c.TLSMin = &version
+	return nil
+}
+
+func (c *Config) ParseMaxTLS(value string) error {
+	version, err := parseTLSVersion("max-tls", value, c.isFile)
+	if err != nil {
+		return err
+	}
+	if c.TLSMin != nil && version < *c.TLSMin {
+		return core.NewValueError("max-tls", value, "must be greater than or equal to min-tls", c.isFile)
+	}
+	c.TLSMax = &version
+	return nil
 }
 
 func (c *Config) ParseVerbosity(value string) error {

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -56,12 +56,14 @@ func TestParseFile(t *testing.T) {
 			name: "successful parse",
 			config: `
 				timeout = 10
-				tls = 1.3`,
+				tls = 1.2
+				max-tls = 1.3`,
 			expFile: &File{
 				Global: &Config{
 					isFile:  true,
 					Timeout: new(10 * time.Second),
-					TLS:     new(uint16(tls.VersionTLS13)),
+					TLSMax:  new(uint16(tls.VersionTLS13)),
+					TLSMin:  new(uint16(tls.VersionTLS12)),
 				},
 				Path: "test/config",
 			},

--- a/internal/curl/curl.go
+++ b/internal/curl/curl.go
@@ -47,6 +47,7 @@ type Result struct {
 	Proxy            string
 	DoHURL           string
 	HTTPVersion      string
+	TLSMaxVersion    string
 	TLSVersion       string
 	CACert           string
 	Cert             string

--- a/internal/curl/curl_test.go
+++ b/internal/curl/curl_test.go
@@ -476,6 +476,13 @@ func TestParseTLS(t *testing.T) {
 				assertEqual(t, "TLSVersion", r.TLSVersion, "1.0")
 			},
 		},
+		{
+			name:  "tls max",
+			input: "curl --tls-max 1.2 https://example.com",
+			check: func(t *testing.T, r *Result) {
+				assertEqual(t, "TLSMaxVersion", r.TLSMaxVersion, "1.2")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/curl/long_flags.go
+++ b/internal/curl/long_flags.go
@@ -180,6 +180,13 @@ func parseLongFlag(r *Result, name, value string, hasValue bool, rest []string) 
 	case "tlsv1.3":
 		r.TLSVersion = "1.3"
 		return 0, nil
+	case "tls-max":
+		v, n, err := consumeArg()
+		if err != nil {
+			return 0, fmt.Errorf("--tls-max requires an argument")
+		}
+		r.TLSMaxVersion = v
+		return n, nil
 
 	// Output.
 	case "output":

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -86,7 +86,8 @@ type Request struct {
 	Session          string
 	Timeout          time.Duration
 	Timing           bool
-	TLS              uint16
+	TLSMax           uint16
+	TLSMin           uint16
 	UnixSocket       string
 	URL              *url.URL
 	Verbosity        core.Verbosity

--- a/internal/fetch/grpc_reflection.go
+++ b/internal/fetch/grpc_reflection.go
@@ -550,7 +550,8 @@ func newClient(r *Request) *client.Client {
 		Insecure:       r.Insecure,
 		Proxy:          r.Proxy,
 		Redirects:      r.Redirects,
-		TLS:            r.TLS,
+		TLSMax:         r.TLSMax,
+		TLSMin:         r.TLSMin,
 		UnixSocket:     r.UnixSocket,
 	})
 }

--- a/internal/tlsinspect/tlsinspect.go
+++ b/internal/tlsinspect/tlsinspect.go
@@ -27,7 +27,8 @@ type Config struct {
 	ClientCert *tls.Certificate
 	DNSServer  *url.URL
 	Insecure   bool
-	TLS        uint16
+	TLSMax     uint16
+	TLSMin     uint16
 	Timeout    time.Duration
 	URL        *url.URL
 }
@@ -39,7 +40,8 @@ func Inspect(ctx context.Context, p *core.Printer, cfg *Config) int {
 		CACerts:    cfg.CACerts,
 		ClientCert: cfg.ClientCert,
 		Insecure:   cfg.Insecure,
-		TLS:        cfg.TLS,
+		TLSMax:     cfg.TLSMax,
+		TLSMin:     cfg.TLSMin,
 	}
 	tlsConfig := tlsDialCfg.BuildTLSConfig()
 	res := resolver.New(resolver.Config{Server: cfg.DNSServer})

--- a/main.go
+++ b/main.go
@@ -62,6 +62,11 @@ func main() {
 		core.WriteErrorMsg(p, err)
 		os.Exit(1)
 	}
+	if err := app.Cfg.Validate(); err != nil {
+		p := handle.Stderr()
+		core.WriteErrorMsg(p, err)
+		os.Exit(1)
+	}
 
 	// Start async update, if necessary.
 	if !app.Update && !core.NoSelfUpdate && app.Cfg.AutoUpdate != nil && *app.Cfg.AutoUpdate >= 0 {
@@ -210,7 +215,8 @@ func main() {
 		Session:          getValue(app.Cfg.Session),
 		Timeout:          getValue(app.Cfg.Timeout),
 		Timing:           getValue(app.Cfg.Timing),
-		TLS:              getValue(app.Cfg.TLS),
+		TLSMax:           getValue(app.Cfg.TLSMax),
+		TLSMin:           getValue(app.Cfg.TLSMin),
 		UnixSocket:       app.UnixSocket,
 		URL:              app.URL,
 		Verbosity:        verbosity,
@@ -430,8 +436,11 @@ func inspectDNS(ctx context.Context, app *cli.App, handle *core.Handle) int {
 	if app.Cfg.KeyPath != "" {
 		ignored = append(ignored, "--key")
 	}
-	if app.Cfg.TLS != nil {
+	if app.Cfg.TLSMin != nil {
 		ignored = append(ignored, "--tls")
+	}
+	if app.Cfg.TLSMax != nil {
+		ignored = append(ignored, "--max-tls")
 	}
 	if getValue(app.Cfg.Insecure) {
 		ignored = append(ignored, "--insecure")
@@ -574,7 +583,8 @@ func inspectTLS(ctx context.Context, app *cli.App, handle *core.Handle) int {
 		ClientCert: clientCert,
 		DNSServer:  app.Cfg.DNSServer,
 		Insecure:   getValue(app.Cfg.Insecure),
-		TLS:        getValue(app.Cfg.TLS),
+		TLSMax:     getValue(app.Cfg.TLSMax),
+		TLSMin:     getValue(app.Cfg.TLSMin),
 		Timeout:    getValue(app.Cfg.Timeout),
 		URL:        app.URL,
 	})


### PR DESCRIPTION
## Summary
- Keep `--tls` as a minimum-TLS compatibility alias and add explicit `--min-tls` and `--max-tls` flags.
- Wire TLS min/max bounds through normal requests, gRPC discovery, TLS inspection, and `--from-curl` parsing.
- Update config handling, docs, and tests to reflect version bounds and exact-TLS usage via matching min/max values.

## Testing
- Added unit coverage for CLI parsing, config file parsing, curl flag parsing, and TLS config construction.
- Ran `go test ./...` and `staticcheck ./...` successfully.