### PR TITLE
Tighten WebSocket UX and dry-run behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ prettier -w .
 - Plaintext loopback gRPC servers are supported via `h2c` for both calls and discovery.
 - `--inspect-dns` resolves the URL hostname without making an HTTP request, showing common DNS record types, resolver backend, duration, and per-record TTLs from direct UDP or DoH responses.
 - `--tls` remains a compatibility alias for setting the minimum TLS version; prefer `--min-tls` in new docs/examples, and use `--max-tls` to cap negotiation or combine min/max for an exact TLS version.
+- WebSocket terminal sessions use the interactive prompt; output-file/clipboard/retry flags are rejected because the WebSocket path streams through the message loop instead of the normal response pipeline.
 5. HTTP client executes request
 6. Response formatted based on Content-Type and output to stdout (optionally via pager)
 

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -31,7 +31,7 @@ echo "hello" | fetch ws://echo.websocket.events
 printf "msg1\nmsg2\n" | fetch ws://echo.websocket.events
 ```
 
-When stdin is not piped (i.e. running from a terminal), `fetch` operates in read-only mode — it listens for server messages until the connection closes or Ctrl+C is pressed.
+When stdin/stdout/stderr are terminals, `fetch` opens an interactive prompt. Type a message and press Enter to send it. Use Ctrl+C or Ctrl+D to exit.
 
 ## Output
 
@@ -88,6 +88,6 @@ fetch --timeout 5 ws://api.example.com/ws
 ## Limitations
 
 - WebSocket requires HTTP/1.1 for the upgrade handshake. Using `--http 3` with WebSocket is not supported.
-- WebSocket (`ws://` / `wss://`) cannot be combined with `--grpc`, `--form`, `--multipart`, `--xml`, or `--edit`.
+- WebSocket (`ws://` / `wss://`) cannot be combined with `--grpc`, `--form`, `--multipart`, `--xml`, `--edit`, output-file/clipboard flags, or retry flags.
 - Binary message content is not displayed; only a size indicator is shown.
 - The pager is disabled for WebSocket output.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2738,6 +2738,15 @@ func TestMain(t *testing.T) {
 		assertBufContains(t, res.stderr, "/chat")
 	})
 
+	t.Run("websocket dry-run non-GET shows effective GET", func(t *testing.T) {
+		t.Parallel()
+		res := runFetch(t, fetchPath, "--dry-run", "-X", "POST", "ws://localhost:1234/chat")
+		assertExitCode(t, 0, res)
+		assertBufContains(t, res.stderr, "ignoring method POST")
+		assertBufContains(t, res.stderr, "GET /chat")
+		assertBufNotContains(t, res.stderr, "POST /chat")
+	})
+
 	t.Run("websocket ctrl-c exits", func(t *testing.T) {
 		t.Parallel()
 		if runtime.GOOS == "windows" {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -120,8 +120,14 @@ func (a *App) CLI() *CLI {
 			{Key: "remote-header-name", Val: []string{"remote-name"}},
 		},
 		SchemeExclusiveFlags: map[string][]string{
-			"ws":  {"discard", "grpc", "grpc-describe", "grpc-list", "form", "multipart", "xml", "edit"},
-			"wss": {"discard", "grpc", "grpc-describe", "grpc-list", "form", "multipart", "xml", "edit"},
+			"ws": {
+				"clobber", "copy", "discard", "edit", "form", "grpc", "grpc-describe", "grpc-list",
+				"multipart", "output", "remote-header-name", "remote-name", "retry", "retry-delay", "xml",
+			},
+			"wss": {
+				"clobber", "copy", "discard", "edit", "form", "grpc", "grpc-describe", "grpc-list",
+				"multipart", "output", "remote-header-name", "remote-name", "retry", "retry-delay", "xml",
+			},
 		},
 		FromCurlExclusiveFlags: []string{
 			"method", "header", "data", "json", "xml",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -62,6 +62,31 @@ func TestFlagsAlphabeticalOrder(t *testing.T) {
 	}
 }
 
+func TestWebSocketSchemeExclusives(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		flag string
+	}{
+		{name: "copy", args: []string{"ws://example.com", "--copy"}, flag: "copy"},
+		{name: "output", args: []string{"ws://example.com", "--output", "out.txt"}, flag: "output"},
+		{name: "remote name", args: []string{"ws://example.com", "--remote-name"}, flag: "remote-name"},
+		{name: "retry", args: []string{"ws://example.com", "--retry", "1"}, flag: "retry"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse(tt.args)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "--"+tt.flag) {
+				t.Fatalf("error = %q, want --%s", err.Error(), tt.flag)
+			}
+		})
+	}
+}
+
 func TestFromCurlDataUrlencode(t *testing.T) {
 	t.Run("@file reads and encodes contents", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/fetch/websocket.go
+++ b/internal/fetch/websocket.go
@@ -22,6 +22,7 @@ func handleWebSocket(ctx context.Context, r *Request, c *client.Client, req *htt
 	if req.Method != "GET" {
 		p := r.PrinterHandle.Stderr()
 		core.WriteWarningMsg(p, "WebSocket requires GET; ignoring method "+req.Method)
+		req.Method = "GET"
 	}
 
 	// Timing waterfall is not supported for persistent WebSocket connections.


### PR DESCRIPTION
## Summary
- Align WebSocket handling with the actual interactive flow in the docs.
- Reject WebSocket-incompatible flags up front instead of accepting them and doing nothing.
- Fix dry-run output so a non-GET WebSocket request shows the effective `GET` handshake.
- Add CLI and integration coverage for the updated behavior.

## Testing
- `go test ./internal/ws ./internal/fetch ./internal/cli`
- `go test ./integration -run 'TestMain/websocket|TestMain/timing_waterfall_websocket'`
- Verified the dry-run path now prints `GET` after warning on `-X POST`.