### PR TITLE
Improve WebSocket interactive terminal behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ prettier -w .
 - Plaintext loopback gRPC servers are supported via `h2c` for both calls and discovery.
 - `--inspect-dns` resolves the URL hostname without making an HTTP request, showing common DNS record types, resolver backend, duration, and per-record TTLs from direct UDP or DoH responses.
 - `--tls` remains a compatibility alias for setting the minimum TLS version; prefer `--min-tls` in new docs/examples, and use `--max-tls` to cap negotiation or combine min/max for an exact TLS version.
-- WebSocket terminal sessions use the interactive prompt; output-file/clipboard/retry flags are rejected because the WebSocket path streams through the message loop instead of the normal response pipeline.
+- WebSocket terminal sessions use the interactive prompt by default and can be controlled with `--ws-interactive auto|on|off`; output-file/clipboard/retry flags are rejected because the WebSocket path streams through the message loop instead of the normal response pipeline.
 5. HTTP client executes request
 6. Response formatted based on Content-Type and output to stdout (optionally via pager)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -519,6 +519,8 @@ fetch ws://echo.websocket.events
 fetch wss://echo.websocket.events -d "hello"
 ```
 
+Use `--ws-interactive auto|on|off` to control the terminal prompt.
+
 See [WebSocket documentation](websocket.md) for details.
 
 ## gRPC Options

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -33,6 +33,19 @@ printf "msg1\nmsg2\n" | fetch ws://echo.websocket.events
 
 When stdin/stdout/stderr are terminals, `fetch` opens an interactive prompt. Type a message and press Enter to send it. Use Ctrl+C or Ctrl+D to exit.
 
+Control this behavior with `--ws-interactive`:
+
+```sh
+# Automatically use the prompt when attached to a terminal
+fetch ws://api.example.com/stream --ws-interactive auto
+
+# Require the prompt, failing if stdio is not a terminal
+fetch ws://api.example.com/stream --ws-interactive on
+
+# Disable the prompt and stream server messages to stdout
+fetch ws://api.example.com/stream --ws-interactive off
+```
+
 ## Output
 
 - **Text messages**: Written to stdout. JSON messages are automatically formatted when connected to a terminal.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -53,6 +53,7 @@ type App struct {
 	UnixSocket       string
 	Update           bool
 	Version          bool
+	WSInteractive    core.WSInteractiveMode
 
 	dataSet bool
 	jsonSet bool
@@ -410,6 +411,18 @@ func (a *App) CLI() *CLI {
 
 			boolFlag(&a.Version, "version", "V", "Print version"),
 
+			Flag{
+				Long:        "ws-interactive",
+				Args:        "MODE",
+				Description: "WebSocket prompt mode",
+				IsSet:       func() bool { return a.WSInteractive != core.WSInteractiveAuto },
+				Fn:          a.parseWSInteractiveFlag,
+			}.WithValues([]core.KeyVal[string]{
+				{Key: "auto", Val: "Use interactive prompt when attached to a terminal"},
+				{Key: "on", Val: "Require interactive prompt"},
+				{Key: "off", Val: "Disable interactive prompt"},
+			}),
+
 			// Custom: XML body
 			{
 				Short:       "x",
@@ -605,6 +618,20 @@ func (a *App) parseXMLFlag(value string) error {
 	a.Data = r
 	a.ContentType = "application/xml"
 	a.xmlSet = true
+	return nil
+}
+
+func (a *App) parseWSInteractiveFlag(value string) error {
+	switch value {
+	case "auto":
+		a.WSInteractive = core.WSInteractiveAuto
+	case "on":
+		a.WSInteractive = core.WSInteractiveOn
+	case "off":
+		a.WSInteractive = core.WSInteractiveOff
+	default:
+		return core.NewValueError("ws-interactive", value, "must be one of [auto, on, off]", false)
+	}
 	return nil
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -284,6 +284,9 @@ func Parse(args []string) (*App, error) {
 	if err := validateSchemeExclusives(&app, cli, long); err != nil {
 		return &app, err
 	}
+	if app.URL != nil && !app.WS && app.WSInteractive != core.WSInteractiveAuto {
+		return &app, fmt.Errorf("'--ws-interactive' requires a ws:// or wss:// URL")
+	}
 	if err := validateGRPCModes(&app, long); err != nil {
 		return &app, err
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -87,6 +87,38 @@ func TestWebSocketSchemeExclusives(t *testing.T) {
 	}
 }
 
+func TestWebSocketInteractiveFlag(t *testing.T) {
+	t.Run("parses off", func(t *testing.T) {
+		app, err := Parse([]string{"ws://example.com", "--ws-interactive", "off"})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if app.WSInteractive != core.WSInteractiveOff {
+			t.Fatalf("WSInteractive = %v, want off", app.WSInteractive)
+		}
+	})
+
+	t.Run("rejects invalid value", func(t *testing.T) {
+		_, err := Parse([]string{"ws://example.com", "--ws-interactive", "maybe"})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "ws-interactive") {
+			t.Fatalf("error = %q, want ws-interactive", err.Error())
+		}
+	})
+
+	t.Run("requires websocket url", func(t *testing.T) {
+		_, err := Parse([]string{"https://example.com", "--ws-interactive", "off"})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "ws://") {
+			t.Fatalf("error = %q, want ws://", err.Error())
+		}
+	})
+}
+
 func TestFromCurlDataUrlencode(t *testing.T) {
 	t.Run("@file reads and encodes contents", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -22,6 +22,15 @@ const (
 	FormatOn
 )
 
+// WSInteractiveMode represents WebSocket terminal prompt behavior.
+type WSInteractiveMode int
+
+const (
+	WSInteractiveAuto WSInteractiveMode = iota
+	WSInteractiveOn
+	WSInteractiveOff
+)
+
 // HTTPVersion represents the options for the maximum allowed HTTP version.
 type HTTPVersion int
 

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -92,6 +92,7 @@ type Request struct {
 	URL              *url.URL
 	Verbosity        core.Verbosity
 	WS               bool
+	WSInteractive    core.WSInteractiveMode
 
 	// responseDescriptor is set internally after proto setup for response formatting.
 	responseDescriptor protoreflect.MessageDescriptor

--- a/internal/fetch/websocket.go
+++ b/internal/fetch/websocket.go
@@ -2,6 +2,7 @@ package fetch
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptrace"
@@ -97,8 +98,16 @@ func handleWebSocket(ctx context.Context, r *Request, c *client.Client, req *htt
 		}
 	}
 
-	// Detect interactive mode: all three FDs are terminals.
+	// Detect interactive mode: default to TUI only when all three FDs are terminals.
 	interactive := core.IsStdinTerm && core.IsStdoutTerm && core.IsStderrTerm
+	switch r.WSInteractive {
+	case core.WSInteractiveOn:
+		if !interactive {
+			return 1, errors.New("--ws-interactive on requires stdin, stdout, and stderr to be terminals")
+		}
+	case core.WSInteractiveOff:
+		interactive = false
+	}
 
 	// Determine stdin: use it for the write loop only if it's a pipe or
 	// file. When stdin is a terminal or /dev/null, pass nil so we run in

--- a/internal/ws/interactive.go
+++ b/internal/ws/interactive.go
@@ -3,13 +3,16 @@ package ws
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
+	"github.com/ryanfowler/fetch/internal/core"
 	"github.com/ryanfowler/fetch/internal/format"
 
 	"github.com/coder/websocket"
@@ -40,6 +43,9 @@ func runInteractive(ctx context.Context, cfg Config) error {
 	if rows < minRows {
 		// Terminal too small; fall back to read-only.
 		t.restore()
+		if err := sendInitialMessage(ctx, cfg); err != nil {
+			return err
+		}
 		return readLoop(ctx, cfg)
 	}
 
@@ -51,6 +57,7 @@ func runInteractive(ctx context.Context, cfg Config) error {
 		term:   t,
 		editor: &lineEditor{},
 		cancel: cancel,
+		status: "connected",
 	}
 
 	// Channel for raw stdin bytes.
@@ -108,12 +115,11 @@ func runInteractive(ctx context.Context, cfg Config) error {
 	go t.watchResize(ctx, resizeCh)
 
 	// Send initial message from -d / -j flag.
+	if err := sendInitialMessage(ctx, cfg); err != nil {
+		im.teardownScreen()
+		return err
+	}
 	if len(cfg.InitialMsg) > 0 {
-		err := cfg.Conn.Write(ctx, websocket.MessageText, cfg.InitialMsg)
-		if err != nil && !errors.Is(err, context.Canceled) {
-			im.teardownScreen()
-			return err
-		}
 		im.renderSentMessage(cfg.InitialMsg)
 	}
 
@@ -144,6 +150,10 @@ func runInteractive(ctx context.Context, cfg Config) error {
 			rows, cols := t.size()
 			if rows >= minRows {
 				im.setupScreen(rows, cols, 0)
+			} else {
+				im.teardownScreen()
+				cancel()
+				return nil
 			}
 
 		case <-ctx.Done():
@@ -202,11 +212,12 @@ type interactiveMode struct {
 	rows     int
 	cols     int
 	nextRow  int // next row to write a message in the scroll region (1-indexed)
+	status   string
 	messages []messageEntry
 }
 
 // setupScreen configures the scroll region and draws the separators and input line.
-// Layout: scroll region (1..N-3), separator (N-2), input (N-1), separator (N).
+// Layout: scroll region (1..N-3), status (N-2), input (N-1), separator (N).
 func (im *interactiveMode) setupScreen(rows, cols, initialCursorRow int) {
 	im.mu.Lock()
 	defer im.mu.Unlock()
@@ -273,7 +284,7 @@ func (im *interactiveMode) setupScreen(rows, cols, initialCursorRow int) {
 	// Set scroll region to top N-3 rows.
 	fmt.Fprintf(os.Stdout, "\x1b[1;%dr", scrollEnd)
 
-	im.drawSeparatorLocked(rows - 2)
+	im.drawStatusLocked()
 	im.drawSeparatorLocked(rows)
 
 	if !firstSetup {
@@ -291,10 +302,17 @@ func (im *interactiveMode) replayMessagesLocked() {
 		return
 	}
 
-	// Each message occupies ~2 rows (content + spacing).
 	scrollEnd := im.rows - 3
-	capacity := (scrollEnd + 1) / 2
-	start := max(len(im.messages)-capacity, 0)
+	start := len(im.messages)
+	used := 0
+	for i := len(im.messages) - 1; i >= 0; i-- {
+		rows := im.messageRowCount(im.messages[i])
+		if used+rows > scrollEnd && start != len(im.messages) {
+			break
+		}
+		used += rows
+		start = i
+	}
 
 	for _, msg := range im.messages[start:] {
 		if msg.data != nil {
@@ -332,6 +350,13 @@ func (im *interactiveMode) drawSeparatorLocked(row int) {
 		os.Stdout.WriteString("─")
 	}
 	fmt.Fprint(os.Stdout, "\x1b[0m")
+}
+
+func (im *interactiveMode) drawStatusLocked() {
+	row := im.rows - 2
+	status := strings.ReplaceAll(sanitizeMessageText(im.status), "\n", " ")
+	msg := fitDisplayWidth(status, im.cols)
+	fmt.Fprintf(os.Stdout, "\x1b[%d;1H\x1b[2K\x1b[90m%s\x1b[0m", row, msg)
 }
 
 func (im *interactiveMode) drawInputLineLocked() {
@@ -382,24 +407,23 @@ func (im *interactiveMode) drawInputLineLocked() {
 	fmt.Fprintf(os.Stdout, "\x1b[%d;%dH", inputRow, cursorCol+1)
 }
 
-// writeMessageLine positions the cursor for a new message line. If the scroll
-// region is not yet full, the message is placed at nextRow (with a blank line
-// after it for spacing). Once full, the region scrolls naturally.
-func (im *interactiveMode) writeMessageLine() {
+// writePhysicalLine positions the cursor for one rendered message row. Once
+// the scroll region is full, the region scrolls naturally.
+func (im *interactiveMode) writePhysicalLine() {
 	scrollEnd := im.rows - 3
 
 	if im.nextRow <= scrollEnd {
-		// Space remaining — place the message directly.
 		fmt.Fprintf(os.Stdout, "\x1b[%d;1H\x1b[2K", im.nextRow)
-		// Reserve a blank line for spacing (if room allows).
-		if im.nextRow+1 <= scrollEnd {
-			im.nextRow += 2
-		} else {
-			im.nextRow++
-		}
+		im.nextRow++
 	} else {
 		// Scroll region is full — scroll by writing at the bottom.
 		fmt.Fprintf(os.Stdout, "\x1b[%d;1H\n\x1b[2K", scrollEnd)
+	}
+}
+
+func (im *interactiveMode) writeMessageSpacer() {
+	if im.nextRow <= im.rows-3 {
+		im.writePhysicalLine()
 	}
 }
 
@@ -439,27 +463,128 @@ func (im *interactiveMode) renderBinaryIndicator(n int) {
 }
 
 func (im *interactiveMode) writeMessageLocked(arrow string, data []byte) {
-	im.writeMessageLine()
-	fmt.Fprintf(os.Stdout, "\x1b[2m%s \x1b[0m", arrow)
-	im.writeFormattedMessage(data)
+	prefix := arrow + " "
+	continuation := "  "
+	width := max(im.cols-runewidth.StringWidth(prefix), 1)
+	lines := wrapDisplayLines(im.formatMessage(data), width)
+	for i, line := range lines {
+		im.writePhysicalLine()
+		if i == 0 {
+			fmt.Fprintf(os.Stdout, "\x1b[2m%s\x1b[0m", prefix)
+		} else {
+			fmt.Fprint(os.Stdout, continuation)
+		}
+		fmt.Fprint(os.Stdout, line)
+	}
+	im.writeMessageSpacer()
 }
 
 func (im *interactiveMode) writeBinaryLocked(n int) {
-	im.writeMessageLine()
+	im.writePhysicalLine()
 	fmt.Fprintf(os.Stdout, "\x1b[2m← [binary %d bytes]\x1b[0m", n)
+	im.writeMessageSpacer()
 }
 
-func (im *interactiveMode) writeFormattedMessage(data []byte) {
+func (im *interactiveMode) formatMessage(data []byte) string {
 	if shouldFormat(im.cfg.Format) && json.Valid(data) {
-		p := im.cfg.Stdout
+		p := core.TestPrinter(false)
 		if format.FormatJSONLine(data, p) == nil {
-			p.Flush()
-			return
+			_ = p.Flush()
+			return sanitizeMessageText(strings.TrimSuffix(string(p.Bytes()), "\n"))
 		}
-		p.Discard()
 	}
-	os.Stdout.Write(data)
-	os.Stdout.WriteString("\n")
+	return sanitizeMessageText(string(data))
+}
+
+func (im *interactiveMode) messageRowCount(msg messageEntry) int {
+	if msg.data == nil {
+		return 2
+	}
+	prefixWidth := runewidth.StringWidth(msg.arrow + " ")
+	width := max(im.cols-prefixWidth, 1)
+	return len(wrapDisplayLines(im.formatMessage(msg.data), width)) + 1
+}
+
+func sanitizeMessageText(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+
+	var b strings.Builder
+	for _, r := range strings.ToValidUTF8(s, "\uFFFD") {
+		switch {
+		case r == '\n':
+			b.WriteRune(r)
+		case r == '\t':
+			b.WriteString("    ")
+		case r == 0x1b:
+			b.WriteString(`\x1b`)
+		case unicode.IsControl(r):
+			if r <= 0xff {
+				fmt.Fprintf(&b, `\x%02x`, r)
+			} else {
+				b.WriteString(strconv.QuoteRuneToASCII(r))
+			}
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func wrapDisplayLines(s string, width int) []string {
+	if width < 1 {
+		width = 1
+	}
+
+	parts := strings.Split(s, "\n")
+	lines := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			lines = append(lines, "")
+			continue
+		}
+
+		var line strings.Builder
+		lineWidth := 0
+		for _, r := range part {
+			rw := runewidth.RuneWidth(r)
+			if rw < 1 {
+				rw = 1
+			}
+			if lineWidth > 0 && lineWidth+rw > width {
+				lines = append(lines, line.String())
+				line.Reset()
+				lineWidth = 0
+			}
+			line.WriteRune(r)
+			lineWidth += rw
+		}
+		lines = append(lines, line.String())
+	}
+	if len(lines) == 0 {
+		return []string{""}
+	}
+	return lines
+}
+
+func fitDisplayWidth(s string, width int) string {
+	if width < 1 {
+		return ""
+	}
+	var b strings.Builder
+	used := 0
+	for _, r := range s {
+		rw := runewidth.RuneWidth(r)
+		if rw < 1 {
+			rw = 1
+		}
+		if used+rw > width {
+			break
+		}
+		b.WriteRune(r)
+		used += rw
+	}
+	return b.String()
 }
 
 // handleInput processes accumulated raw bytes, returning any unconsumed bytes.
@@ -627,10 +752,16 @@ func (im *interactiveMode) sendMessage(ctx context.Context) {
 	if err != nil {
 		// Restore the text so the user doesn't lose their input.
 		im.mu.Lock()
+		im.status = "send failed: " + err.Error()
 		im.editor.setText(text)
+		im.drawStatusLocked()
 		im.drawInputLineLocked()
 		im.mu.Unlock()
 		return
 	}
+	im.mu.Lock()
+	im.status = fmt.Sprintf("sent %d bytes", len(data))
+	im.drawStatusLocked()
+	im.mu.Unlock()
 	im.renderSentMessage(data)
 }

--- a/internal/ws/interactive_test.go
+++ b/internal/ws/interactive_test.go
@@ -1,0 +1,71 @@
+package ws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ryanfowler/fetch/internal/core"
+)
+
+func TestSanitizeMessageText(t *testing.T) {
+	got := sanitizeMessageText("ok\x1b[31m\r\nbad\x00\tend")
+	want := `ok\x1b[31m` + "\n" + `bad\x00    end`
+	if got != want {
+		t.Fatalf("sanitizeMessageText() = %q, want %q", got, want)
+	}
+}
+
+func TestWrapDisplayLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		width int
+		want  []string
+	}{
+		{
+			name:  "wraps ascii",
+			input: "abcdef",
+			width: 3,
+			want:  []string{"abc", "def"},
+		},
+		{
+			name:  "preserves explicit newlines",
+			input: "ab\ncd",
+			width: 8,
+			want:  []string{"ab", "cd"},
+		},
+		{
+			name:  "wide runes count as two cells",
+			input: "日本語",
+			width: 4,
+			want:  []string{"日本", "語"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapDisplayLines(tt.input, tt.width)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("wrapDisplayLines() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInteractiveMessageRowCount(t *testing.T) {
+	im := &interactiveMode{
+		cfg:  Config{Format: core.FormatOff},
+		rows: 12,
+		cols: 7,
+	}
+
+	msg := messageEntry{arrow: "←", data: []byte("abcdef")}
+	if got, want := im.messageRowCount(msg), 3; got != want {
+		t.Fatalf("messageRowCount() = %d, want %d", got, want)
+	}
+
+	msg = messageEntry{arrow: "←", data: []byte("ab\ncd")}
+	if got, want := im.messageRowCount(msg), 3; got != want {
+		t.Fatalf("messageRowCount() = %d, want %d", got, want)
+	}
+}

--- a/internal/ws/terminal.go
+++ b/internal/ws/terminal.go
@@ -38,6 +38,7 @@ func (t *terminal) enterRaw() error {
 func (t *terminal) restore() {
 	if t.saved != nil {
 		term.Restore(t.fd, t.saved)
+		t.saved = nil
 	}
 }
 

--- a/internal/ws/ws.go
+++ b/internal/ws/ws.go
@@ -36,11 +36,8 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	// Send initial message from -d / -j flag.
-	if len(cfg.InitialMsg) > 0 {
-		err := cfg.Conn.Write(ctx, websocket.MessageText, cfg.InitialMsg)
-		if err != nil && !errors.Is(err, context.Canceled) {
-			return err
-		}
+	if err := sendInitialMessage(ctx, cfg); err != nil {
+		return err
 	}
 
 	if cfg.Stdin != nil {
@@ -50,6 +47,17 @@ func Run(ctx context.Context, cfg Config) error {
 	// No stdin: just read messages from the server until it closes or
 	// the context is cancelled (Ctrl+C).
 	return readLoop(ctx, cfg)
+}
+
+func sendInitialMessage(ctx context.Context, cfg Config) error {
+	if len(cfg.InitialMsg) == 0 {
+		return nil
+	}
+	err := cfg.Conn.Write(ctx, websocket.MessageText, cfg.InitialMsg)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
 }
 
 // runBidirectional handles the case where we have both stdin and server

--- a/main.go
+++ b/main.go
@@ -221,6 +221,7 @@ func main() {
 		URL:              app.URL,
 		Verbosity:        verbosity,
 		WS:               app.WS,
+		WSInteractive:    app.WSInteractive,
 	}
 	if app.HasGRPCDiscovery() {
 		status := fetch.DiscoverGRPC(ctx, &req)


### PR DESCRIPTION
## Summary
- Add `--ws-interactive auto|on|off` so users can control the WebSocket prompt explicitly
- Fix terminal fallback cases, including preserving initial `-d` / `-j` sends and exiting cleanly when the terminal shrinks too small
- Make the TUI safer and more usable by wrapping long messages, sanitizing control bytes, and showing status feedback for sends and errors
- Update docs and add focused tests for the new flag and layout helpers

## Testing
- `go test ./internal/ws ./internal/fetch ./internal/cli`
- `go test ./integration -run 'TestMain/websocket|TestMain/timing_waterfall_websocket'`
- `go test ./...`
- `staticcheck ./...`