### PR TITLE
Handle Host overrides via req.Host

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -431,6 +431,21 @@ func TestMain(t *testing.T) {
 
 	})
 
+	t.Run("host header", func(t *testing.T) {
+		t.Parallel()
+		chHost := make(chan string, 1)
+		server := startServer(func(w http.ResponseWriter, r *http.Request) {
+			chHost <- r.Host
+		})
+		defer server.Close()
+
+		res := runFetch(t, fetchPath, "-H", "Host: vhost.example", server.URL)
+		assertExitCode(t, 0, res)
+		if host := <-chHost; host != "vhost.example" {
+			t.Fatalf("unexpected host: got %q, want %q", host, "vhost.example")
+		}
+	})
+
 	t.Run("dns over https", func(t *testing.T) {
 		t.Parallel()
 		server := startServer(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/aws/sigv4.go
+++ b/internal/aws/sigv4.go
@@ -135,13 +135,19 @@ func getSignedHeaders(req *http.Request) []core.KeyVal[string] {
 	out := make([]core.KeyVal[string], 0, len(req.Header)+1)
 
 	// Host header is required to be signed.
-	if _, ok := req.Header["Host"]; !ok {
-		out = append(out, core.KeyVal[string]{Key: "host", Val: req.URL.Host})
+	host := req.URL.Host
+	if req.Host != "" {
+		host = req.Host
+	}
+	if host != "" {
+		out = append(out, core.KeyVal[string]{Key: "host", Val: host})
 	}
 
 	for key, vals := range req.Header {
-		switch key {
-		case "Accept-Encoding", "Authorization", "Content-Length", "User-Agent":
+		switch {
+		case strings.EqualFold(key, "Host"):
+			continue
+		case key == "Accept-Encoding", key == "Authorization", key == "Content-Length", key == "User-Agent":
 			// Avoid signing these headers.
 			continue
 		}

--- a/internal/aws/sigv4_test.go
+++ b/internal/aws/sigv4_test.go
@@ -133,3 +133,20 @@ func TestGetSignedHeadersCanonicalizesHeaderValues(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSignedHeadersUsesRequestHost(t *testing.T) {
+	req, _ := http.NewRequest("GET", "https://127.0.0.1", nil)
+	req.Host = "vhost.example"
+
+	headers := getSignedHeaders(req)
+
+	for _, header := range headers {
+		if header.Key == "host" {
+			if header.Val != "vhost.example" {
+				t.Fatalf("unexpected host: got %q, want %q", header.Val, "vhost.example")
+			}
+			return
+		}
+	}
+	t.Fatal("signed host header not found")
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -481,6 +481,10 @@ func (c *Client) NewRequest(ctx context.Context, cfg RequestConfig) (*http.Reque
 
 	// Set any provided headers.
 	for _, kv := range cfg.Headers {
+		if strings.EqualFold(kv.Key, "Host") {
+			req.Host = kv.Val
+			continue
+		}
 		req.Header.Set(kv.Key, kv.Val)
 	}
 

--- a/internal/fetch/print.go
+++ b/internal/fetch/print.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -59,13 +60,19 @@ func printRequestMetadata(p *core.Printer, req *http.Request, httpVersion core.H
 
 	p.WriteString("\n")
 
-	headers := getHeaders(req.Header)
+	headers := slices.DeleteFunc(getHeaders(req.Header), func(kv core.KeyVal[string]) bool {
+		return strings.EqualFold(kv.Key, "Host")
+	})
 	if req.Body != nil && req.ContentLength > 0 {
 		val := strconv.FormatInt(req.ContentLength, 10)
 		headers = addHeader(headers, core.KeyVal[string]{Key: "content-length", Val: val})
 	}
-	if req.Header.Get("Host") == "" {
-		headers = addHeader(headers, core.KeyVal[string]{Key: "host", Val: req.URL.Host})
+	host := req.URL.Host
+	if req.Host != "" {
+		host = req.Host
+	}
+	if host != "" {
+		headers = addHeader(headers, core.KeyVal[string]{Key: "host", Val: host})
 	}
 
 	for _, h := range headers {

--- a/internal/fetch/print_test.go
+++ b/internal/fetch/print_test.go
@@ -65,6 +65,27 @@ func TestPrintRequestMetadataPrefixes(t *testing.T) {
 	})
 }
 
+func TestPrintRequestMetadataUsesRequestHost(t *testing.T) {
+	req := &http.Request{
+		Method: "GET",
+		URL:    mustParseURL("https://127.0.0.1/path"),
+		Host:   "vhost.example",
+		Header: http.Header{"Accept": {"*/*"}},
+		Proto:  "HTTP/1.1",
+	}
+
+	p := newTestPrinter()
+	printRequestMetadata(p, req, core.HTTPDefault, core.VVerbose)
+	out := string(p.Bytes())
+
+	if !strings.Contains(out, "host: vhost.example") {
+		t.Fatalf("expected overridden host in request metadata, got:\n%s", out)
+	}
+	if strings.Contains(out, "host: 127.0.0.1") {
+		t.Fatalf("expected URL host to be omitted when Request.Host is set, got:\n%s", out)
+	}
+}
+
 func TestPrintResponseMetadataPrefixes(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: 200,


### PR DESCRIPTION
## Summary
- Special-case `-H Host: ...` so the value is assigned to `req.Host` instead of `req.Header`
- Update request metadata printing and AWS SigV4 signing to use `req.Host` when present, falling back to `req.URL.Host`
- Add coverage for dry-run output, SigV4 host selection, and an integration test that verifies the server sees the overridden `r.Host`

## Testing
- `go test ./...`
- Added unit tests for request metadata and SigV4 host handling
- Added an integration test that checks `r.Host` on the server side