### PR TITLE
Fix no-clobber output writes to avoid overwriting newly created files

### DIFF
--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -380,7 +380,7 @@ func formatResponse(ctx context.Context, r *Request, resp *http.Response) (io.Re
 	if output != "" && r.Output != "-" {
 		size := resp.ContentLength
 		p := r.PrinterHandle.Stderr()
-		return nil, writeOutputToFile(output, resp.Body, size, p, r.Verbosity)
+		return nil, writeOutputToFile(output, resp.Body, size, p, r.Verbosity, r.Clobber)
 	}
 
 	if r.Format == core.FormatOff || (!core.IsStdoutTerm && r.Format != core.FormatOn) {

--- a/internal/fetch/output.go
+++ b/internal/fetch/output.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ryanfowler/fetch/internal/fileutil"
 )
 
-func writeOutputToFile(filename string, body io.Reader, size int64, p *core.Printer, v core.Verbosity) error {
+func writeOutputToFile(filename string, body io.Reader, size int64, p *core.Printer, v core.Verbosity, clobber bool) error {
 	name, err := filepath.Abs(filename)
 	if err != nil {
 		return err
@@ -54,7 +54,12 @@ func writeOutputToFile(filename string, body io.Reader, size int64, p *core.Prin
 		return err
 	}
 
-	if err = fileutil.AtomicReplaceFile(f.Name(), filename); err != nil {
+	if clobber {
+		err = fileutil.AtomicReplaceFile(f.Name(), filename)
+	} else {
+		err = fileutil.AtomicWriteNewFile(f.Name(), filename)
+	}
+	if err != nil {
 		os.Remove(f.Name())
 		return err
 	}

--- a/internal/fetch/output_test.go
+++ b/internal/fetch/output_test.go
@@ -154,7 +154,7 @@ func TestGetOutputValue_DirectStdoutSkipsFileCheck(t *testing.T) {
 	}
 }
 
-func TestWriteOutputToFile_OverwritesExistingFile(t *testing.T) {
+func TestWriteOutputToFile_OverwritesExistingFileWithClobber(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "download.txt")
 
@@ -163,7 +163,7 @@ func TestWriteOutputToFile_OverwritesExistingFile(t *testing.T) {
 	}
 
 	printer := core.TestPrinter(false)
-	err := writeOutputToFile(path, bytes.NewReader([]byte("new")), int64(len("new")), printer, core.VSilent)
+	err := writeOutputToFile(path, bytes.NewReader([]byte("new")), int64(len("new")), printer, core.VSilent, true)
 	if err != nil {
 		t.Fatalf("writeOutputToFile returned error: %v", err)
 	}
@@ -174,5 +174,28 @@ func TestWriteOutputToFile_OverwritesExistingFile(t *testing.T) {
 	}
 	if string(data) != "new" {
 		t.Fatalf("output file = %q, want %q", data, "new")
+	}
+}
+
+func TestWriteOutputToFile_DoesNotOverwriteExistingFileWithoutClobber(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "download.txt")
+
+	if err := os.WriteFile(path, []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	printer := core.TestPrinter(false)
+	err := writeOutputToFile(path, bytes.NewReader([]byte("new")), int64(len("new")), printer, core.VSilent, false)
+	if err == nil {
+		t.Fatal("writeOutputToFile succeeded for an existing output file without clobber")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading output file: %v", err)
+	}
+	if string(data) != "old" {
+		t.Fatalf("output file = %q, want %q", data, "old")
 	}
 }

--- a/internal/fileutil/replace_test.go
+++ b/internal/fileutil/replace_test.go
@@ -33,3 +33,56 @@ func TestAtomicReplaceFile_ReplacesExistingFile(t *testing.T) {
 		t.Fatalf("temp file should be gone, stat err = %v", err)
 	}
 }
+
+func TestAtomicWriteNewFile_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.txt")
+	tempPath := filepath.Join(dir, "temp.txt")
+
+	if err := os.WriteFile(tempPath, []byte("new"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AtomicWriteNewFile(tempPath, targetPath); err != nil {
+		t.Fatalf("AtomicWriteNewFile returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("reading target file: %v", err)
+	}
+	if string(data) != "new" {
+		t.Fatalf("target file = %q, want %q", data, "new")
+	}
+	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+		t.Fatalf("temp file should be gone, stat err = %v", err)
+	}
+}
+
+func TestAtomicWriteNewFile_DoesNotReplaceExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.txt")
+	tempPath := filepath.Join(dir, "temp.txt")
+
+	if err := os.WriteFile(targetPath, []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tempPath, []byte("new"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AtomicWriteNewFile(tempPath, targetPath); err == nil {
+		t.Fatal("AtomicWriteNewFile succeeded for an existing target")
+	}
+
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("reading target file: %v", err)
+	}
+	if string(data) != "old" {
+		t.Fatalf("target file = %q, want %q", data, "old")
+	}
+	if _, err := os.Stat(tempPath); err != nil {
+		t.Fatalf("temp file should remain after failed install, stat err = %v", err)
+	}
+}

--- a/internal/fileutil/replace_unix.go
+++ b/internal/fileutil/replace_unix.go
@@ -9,3 +9,13 @@ import "os"
 func AtomicReplaceFile(tempPath, targetPath string) error {
 	return os.Rename(tempPath, targetPath)
 }
+
+// AtomicWriteNewFile atomically installs tempPath at targetPath only if targetPath
+// does not already exist. tempPath and targetPath must be on the same filesystem.
+func AtomicWriteNewFile(tempPath, targetPath string) error {
+	if err := os.Link(tempPath, targetPath); err != nil {
+		return err
+	}
+	_ = os.Remove(tempPath)
+	return nil
+}

--- a/internal/fileutil/replace_windows.go
+++ b/internal/fileutil/replace_windows.go
@@ -31,3 +31,22 @@ func AtomicReplaceFile(tempPath, targetPath string) error {
 
 	return nil
 }
+
+// AtomicWriteNewFile atomically installs tempPath at targetPath only if targetPath
+// does not already exist. tempPath and targetPath must be on the same filesystem.
+func AtomicWriteNewFile(tempPath, targetPath string) error {
+	src, err := windows.UTF16PtrFromString(tempPath)
+	if err != nil {
+		return &os.PathError{Op: "write", Path: tempPath, Err: err}
+	}
+	dst, err := windows.UTF16PtrFromString(targetPath)
+	if err != nil {
+		return &os.PathError{Op: "write", Path: targetPath, Err: err}
+	}
+
+	if err := windows.MoveFileEx(src, dst, moveFileWriteThrough); err != nil {
+		return &os.PathError{Op: "write", Path: targetPath, Err: err}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Pass `r.Clobber` through the fetch output path so file commits use the correct semantics.
- Keep atomic replacement for `--clobber`, and add atomic no-replace installation for normal writes.
- Add tests for both overwrite and no-overwrite behavior in `internal/fetch` and `internal/fileutil`.

## Testing
- `go test ./...`
- `staticcheck ./...`
- Cross-compiled `internal/fileutil` for Windows to verify the Windows-specific helper builds