### PR TITLE
Wrap gRPC streaming request bodies for replay

### DIFF
--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -217,11 +217,11 @@ func fetch(ctx context.Context, r *Request) (int, error) {
 		if isClientStreaming && requestDesc != nil {
 			// Client/bidi streaming: stream multiple JSON objects as gRPC frames.
 			if req.Body != nil && req.Body != http.NoBody {
-				req.Body = streamGRPCRequest(req.Body, requestDesc)
-				req.ContentLength = -1 // Unknown length; use chunked encoding.
+				setStreamingGRPCBody(req, requestDesc)
 			} else {
 				// Empty client stream: no frames, just close immediately.
 				req.Body = http.NoBody
+				req.GetBody = nil
 			}
 		} else {
 			// Unary / server-streaming: existing single-message path.

--- a/internal/fetch/proto.go
+++ b/internal/fetch/proto.go
@@ -158,3 +158,20 @@ func streamGRPCRequest(data io.ReadCloser, desc protoreflect.MessageDescriptor) 
 	}()
 	return pr
 }
+
+func setStreamingGRPCBody(req *http.Request, desc protoreflect.MessageDescriptor) {
+	getBody := req.GetBody
+	req.Body = streamGRPCRequest(req.Body, desc)
+	req.ContentLength = -1
+	if getBody == nil {
+		req.GetBody = nil
+		return
+	}
+	req.GetBody = func() (io.ReadCloser, error) {
+		body, err := getBody()
+		if err != nil {
+			return nil, err
+		}
+		return streamGRPCRequest(body, desc), nil
+	}
+}

--- a/internal/fetch/proto_test.go
+++ b/internal/fetch/proto_test.go
@@ -3,6 +3,7 @@ package fetch
 import (
 	"bytes"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -119,6 +120,57 @@ func TestStreamGRPCRequestClosesBody(t *testing.T) {
 	_ = readAllFrames(t, rc)
 	if !body.closed {
 		t.Fatal("expected streamGRPCRequest to close body")
+	}
+}
+
+func TestSetStreamingGRPCBodyWrapsGetBody(t *testing.T) {
+	desc := testMessageDescriptor(t)
+	req := &http.Request{
+		Body: io.NopCloser(strings.NewReader(`{"name":"first"}`)),
+		GetBody: func() (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader(`{"name":"replay"}`)), nil
+		},
+		ContentLength: int64(len(`{"name":"first"}`)),
+	}
+
+	setStreamingGRPCBody(req, desc)
+	if req.ContentLength != -1 {
+		t.Fatalf("expected unknown content length, got %d", req.ContentLength)
+	}
+
+	frames := readAllFrames(t, req.Body)
+	if len(frames) != 1 {
+		t.Fatalf("expected current body to contain 1 framed message, got %d", len(frames))
+	}
+
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatalf("unexpected GetBody error: %v", err)
+	}
+	defer replay.Close()
+	frames = readAllFrames(t, replay)
+	if len(frames) != 1 {
+		t.Fatalf("expected replay body to contain 1 framed message, got %d", len(frames))
+	}
+}
+
+func TestSetStreamingGRPCBodyClearsMissingGetBody(t *testing.T) {
+	desc := testMessageDescriptor(t)
+	req := &http.Request{
+		Body:          io.NopCloser(strings.NewReader(`{"name":"first"}`)),
+		ContentLength: int64(len(`{"name":"first"}`)),
+	}
+
+	setStreamingGRPCBody(req, desc)
+	if req.GetBody != nil {
+		t.Fatal("expected GetBody to remain nil")
+	}
+	if req.ContentLength != -1 {
+		t.Fatalf("expected unknown content length, got %d", req.ContentLength)
+	}
+	frames := readAllFrames(t, req.Body)
+	if len(frames) != 1 {
+		t.Fatalf("expected current body to contain 1 framed message, got %d", len(frames))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Wrap client-streaming gRPC bodies so retries, digest auth, and redirect replays use the gRPC-framed body instead of the original JSON payload.
- Clear `GetBody` for empty client streams and preserve replay behavior by wrapping the original `GetBody` when it exists.
- Add regression tests covering both replayable and non-replayable streaming requests.

## Testing
- `go test -v ./internal/fetch`
- `go test ./...`