### PR TITLE
Move AWS SigV4 signing to the final request mutation point

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ryanfowler/fetch/internal/aws"
 	"github.com/ryanfowler/fetch/internal/core"
 	"github.com/ryanfowler/fetch/internal/multipart"
 	"github.com/ryanfowler/fetch/internal/resolver"
@@ -397,7 +396,6 @@ func (c *Client) SetJar(jar http.CookieJar) {
 
 // RequestConfig represents the configuration for creating an HTTP request.
 type RequestConfig struct {
-	AWSSigV4    *aws.Config
 	Basic       *core.KeyVal[string]
 	Bearer      string
 	ContentType string
@@ -508,11 +506,6 @@ func (c *Client) NewRequest(ctx context.Context, cfg RequestConfig) (*http.Reque
 
 	// Optionally set the authorization header.
 	switch {
-	case cfg.AWSSigV4 != nil:
-		err = aws.Sign(req, *cfg.AWSSigV4, time.Now().UTC())
-		if err != nil {
-			return nil, err
-		}
 	case cfg.Basic != nil:
 		req.SetBasicAuth(cfg.Basic.Key, cfg.Basic.Val)
 	case cfg.Bearer != "":

--- a/internal/fetch/aws_test.go
+++ b/internal/fetch/aws_test.go
@@ -1,0 +1,82 @@
+package fetch
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ryanfowler/fetch/internal/aws"
+)
+
+func TestSignAWSRequestUsesCurrentBody(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/", strings.NewReader(`{"name":"before"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	setReplayableBody(req, []byte("final body"))
+
+	if err := signAWSRequest(testAWSRequest(), req); err != nil {
+		t.Fatal(err)
+	}
+
+	got := req.Header.Get("X-Amz-Content-Sha256")
+	want := hexSHA256([]byte("final body"))
+	if got != want {
+		t.Fatalf("payload hash = %s, want %s", got, want)
+	}
+}
+
+func TestSignWebSocketHandshakeUsesEmptyPayloadAndPreservesBody(t *testing.T) {
+	u, err := url.Parse("wss://example.com/socket")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &http.Request{
+		Method:        http.MethodGet,
+		URL:           u,
+		Header:        make(http.Header),
+		Body:          io.NopCloser(strings.NewReader("initial message")),
+		ContentLength: int64(len("initial message")),
+	}
+
+	if err := signWebSocketHandshake(testAWSRequest(), req); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := req.Header.Get("X-Amz-Content-Sha256"); got != hexSHA256(nil) {
+		t.Fatalf("payload hash = %s, want empty payload hash", got)
+	}
+	if req.Body == nil || req.Body == http.NoBody {
+		t.Fatal("expected WebSocket initial message body to be preserved")
+	}
+	gotBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotBody) != "initial message" {
+		t.Fatalf("body = %q, want initial message", gotBody)
+	}
+	if req.ContentLength != int64(len("initial message")) {
+		t.Fatalf("content length = %d, want %d", req.ContentLength, len("initial message"))
+	}
+}
+
+func testAWSRequest() *Request {
+	return &Request{
+		AWSSigv4: &aws.Config{
+			AccessKey: "AKIDEXAMPLE",
+			SecretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+			Region:    "us-east-1",
+			Service:   "execute-api",
+		},
+	}
+}
+
+func hexSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -175,7 +175,6 @@ func fetch(ctx context.Context, r *Request) (int, error) {
 		headers = grpcHeaders(r.Headers)
 	}
 	req, err := c.NewRequest(ctx, client.RequestConfig{
-		AWSSigV4:    r.AWSSigv4,
 		Basic:       r.Basic,
 		Bearer:      r.Bearer,
 		ContentType: r.ContentType,
@@ -240,6 +239,10 @@ func fetch(ctx context.Context, r *Request) (int, error) {
 		}
 	}
 
+	if err := signAWSRequest(r, req); err != nil {
+		return 0, err
+	}
+
 	// 7. Print request metadata / dry-run.
 	if r.Verbosity >= core.VExtraVerbose || r.DryRun {
 		errPrinter := r.PrinterHandle.Stderr()
@@ -287,6 +290,13 @@ func fetch(ctx context.Context, r *Request) (int, error) {
 	}
 
 	return code, err
+}
+
+func signAWSRequest(r *Request, req *http.Request) error {
+	if r.AWSSigv4 == nil {
+		return nil
+	}
+	return aws.Sign(req, *r.AWSSigv4, time.Now().UTC())
 }
 
 func processResponse(ctx context.Context, r *Request, resp *http.Response, hadRedirects, hadRetries bool, metrics *connectionMetrics) (int, error) {

--- a/internal/fetch/grpc_reflection.go
+++ b/internal/fetch/grpc_reflection.go
@@ -378,7 +378,6 @@ func (rc *reflectionClient) invokeHTTP(ctx context.Context, path string, payload
 	}
 	headers := grpcHeaders(rc.request.Headers)
 	req, err := rc.client.NewRequest(ctx, client.RequestConfig{
-		AWSSigV4:    rc.request.AWSSigv4,
 		Basic:       rc.request.Basic,
 		Bearer:      rc.request.Bearer,
 		ContentType: fetchgrpc.ContentType,
@@ -397,6 +396,10 @@ func (rc *reflectionClient) invokeHTTP(ctx context.Context, path string, payload
 			req.Body.Close()
 		}
 	}()
+
+	if err := signAWSRequest(rc.request, req); err != nil {
+		return nil, err
+	}
 
 	resp, err := doOnce(rc.request, rc.client, req, nil)
 	if err != nil {

--- a/internal/fetch/retry.go
+++ b/internal/fetch/retry.go
@@ -89,6 +89,11 @@ func retryableRequest(ctx context.Context, r *Request, c *client.Client, req *ht
 			}))
 		}
 
+		if err := signAWSRequest(r, attemptReq); err != nil {
+			cancelAttempt()
+			return 0, err
+		}
+
 		resp, doErr := doOnce(r, c, attemptReq, replayer)
 
 		retryable, retryAfter := shouldRetry(resp, doErr)

--- a/internal/fetch/websocket.go
+++ b/internal/fetch/websocket.go
@@ -32,6 +32,25 @@ func handleWebSocket(ctx context.Context, r *Request, c *client.Client, req *htt
 		core.WriteWarningMsg(p, "--timing is not supported for WebSocket connections")
 	}
 
+	// Prepare the initial message from -d or -j flags. It is sent after the
+	// handshake and is not part of the signed WebSocket upgrade request.
+	var initialMsg []byte
+	if req.Body != nil {
+		if r.DryRun {
+			req.Body.Close()
+		} else {
+			var err error
+			initialMsg, err = io.ReadAll(req.Body)
+			req.Body.Close()
+			if err != nil {
+				return 1, err
+			}
+		}
+		req.Body = http.NoBody
+		req.GetBody = nil
+		req.ContentLength = 0
+	}
+
 	// Extract Sec-WebSocket-Protocol for DialOptions.Subprotocols.
 	var subprotocols []string
 	if proto := req.Header.Get("Sec-WebSocket-Protocol"); proto != "" {
@@ -42,6 +61,10 @@ func handleWebSocket(ctx context.Context, r *Request, c *client.Client, req *htt
 			}
 		}
 		req.Header.Del("Sec-WebSocket-Protocol")
+	}
+
+	if err := signWebSocketHandshake(r, req); err != nil {
+		return 1, err
 	}
 
 	// Print request metadata / dry-run.
@@ -88,16 +111,6 @@ func handleWebSocket(ctx context.Context, r *Request, c *client.Client, req *htt
 		p.Flush()
 	}
 
-	// Prepare the initial message from -d or -j flags.
-	var initialMsg []byte
-	if req.Body != nil {
-		initialMsg, err = io.ReadAll(req.Body)
-		req.Body.Close()
-		if err != nil {
-			return 1, err
-		}
-	}
-
 	// Detect interactive mode: default to TUI only when all three FDs are terminals.
 	interactive := core.IsStdinTerm && core.IsStdoutTerm && core.IsStderrTerm
 	switch r.WSInteractive {
@@ -137,4 +150,25 @@ func handleWebSocket(ctx context.Context, r *Request, c *client.Client, req *htt
 		return 1, err
 	}
 	return 0, nil
+}
+
+func signWebSocketHandshake(r *Request, req *http.Request) error {
+	if r.AWSSigv4 == nil {
+		return nil
+	}
+	if req.Body == nil || req.Body == http.NoBody {
+		return signAWSRequest(r, req)
+	}
+
+	body := req.Body
+	getBody := req.GetBody
+	contentLength := req.ContentLength
+	req.Body = http.NoBody
+	req.GetBody = nil
+	req.ContentLength = 0
+	err := signAWSRequest(r, req)
+	req.Body = body
+	req.GetBody = getBody
+	req.ContentLength = contentLength
+	return err
 }


### PR DESCRIPTION
## Summary
- Remove AWS signing from `client.NewRequest` so request construction stays separate from authentication.
- Sign after all request mutations in `fetch`, including `--edit`, gRPC JSON-to-protobuf framing, and WebSocket method normalization.
- Re-sign on each retry attempt so delayed retries use a fresh SigV4 timestamp and payload hash.
- Add regression coverage for body-sensitive signing and the WebSocket handshake path.

## Testing
- `go test ./...`
- `staticcheck ./...`
- `git diff --check`