### PR TITLE
Use the challenged request for digest retries after redirects

### DIFF
--- a/internal/fetch/retry.go
+++ b/internal/fetch/retry.go
@@ -152,21 +152,26 @@ func doOnce(r *Request, c *client.Client, req *http.Request, replayer *replayabl
 		return resp, nil
 	}
 
-	auth, err := digest.Response(req, chal, r.Digest.Key, r.Digest.Val)
+	challengedReq := resp.Request
+	if challengedReq == nil {
+		challengedReq = req
+	}
+
+	auth, err := digest.Response(challengedReq, chal, r.Digest.Key, r.Digest.Val)
 	if err != nil {
 		return resp, nil
 	}
 
-	// Replay the request body.
+	// Replay the request body only if the challenged request still has one.
 	var body io.ReadCloser
-	if req.Body != nil && req.Body != http.NoBody {
+	if challengedReq.Body != nil && challengedReq.Body != http.NoBody {
 		if replayer != nil {
 			body, err = replayer.reset()
 			if err != nil {
 				return resp, nil
 			}
-		} else if req.GetBody != nil {
-			body, err = req.GetBody()
+		} else if challengedReq.GetBody != nil {
+			body, err = challengedReq.GetBody()
 			if err != nil {
 				return resp, nil
 			}
@@ -179,7 +184,7 @@ func doOnce(r *Request, c *client.Client, req *http.Request, replayer *replayabl
 	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 
-	req2 := req.Clone(req.Context())
+	req2 := challengedReq.Clone(challengedReq.Context())
 	req2.Body = body
 	req2.Header.Set("Authorization", auth)
 

--- a/internal/fetch/retry_test.go
+++ b/internal/fetch/retry_test.go
@@ -8,12 +8,14 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ryanfowler/fetch/internal/client"
 	"github.com/ryanfowler/fetch/internal/core"
 )
 
@@ -286,6 +288,104 @@ func TestSleepWithContext(t *testing.T) {
 			t.Error("expected error from cancelled context")
 		}
 	})
+}
+
+func TestDoOnceDigestAfterRedirectUsesChallengedRequest(t *testing.T) {
+	var startHits, protectedHits int
+	var protectedMethod, protectedBody, digestURI string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			startHits++
+			http.Redirect(w, r, server.URL+"/protected?token=1", http.StatusSeeOther)
+		case "/protected":
+			protectedHits++
+			auth := r.Header.Get("Authorization")
+			if auth == "" {
+				w.Header().Set("WWW-Authenticate", `Digest realm="test", nonce="abc123", qop="auth", algorithm="MD5"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			protectedMethod = r.Method
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read protected body: %v", err)
+			}
+			protectedBody = string(body)
+			digestURI = digestAuthParam(auth, "uri")
+			if digestURI != "/protected?token=1" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/start", strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("payload")), nil
+	}
+	replayer, err := newReplayableBody(req)
+	if err != nil {
+		t.Fatalf("new replayable body: %v", err)
+	}
+	body, err := replayer.reset()
+	if err != nil {
+		t.Fatalf("reset body: %v", err)
+	}
+	req.Body = body
+
+	resp, err := doOnce(
+		&Request{Digest: &core.KeyVal[string]{Key: "user", Val: "pass"}},
+		client.NewClient(client.ClientConfig{}),
+		req,
+		replayer,
+	)
+	if err != nil {
+		t.Fatalf("doOnce: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if startHits != 1 {
+		t.Fatalf("start hits = %d, want 1", startHits)
+	}
+	if protectedHits != 2 {
+		t.Fatalf("protected hits = %d, want 2", protectedHits)
+	}
+	if protectedMethod != http.MethodGet {
+		t.Fatalf("protected retry method = %s, want GET", protectedMethod)
+	}
+	if protectedBody != "" {
+		t.Fatalf("protected retry body = %q, want empty", protectedBody)
+	}
+	if digestURI != "/protected?token=1" {
+		t.Fatalf("digest uri = %q, want /protected?token=1", digestURI)
+	}
+}
+
+func digestAuthParam(auth, key string) string {
+	auth, ok := strings.CutPrefix(auth, "Digest ")
+	if !ok {
+		return ""
+	}
+	for part := range strings.SplitSeq(auth, ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok || k != key {
+			continue
+		}
+		return strings.Trim(v, `"`)
+	}
+	return ""
 }
 
 func TestReplayableBody(t *testing.T) {


### PR DESCRIPTION
## Summary
- Base digest challenge-response generation on the final challenged request instead of the original pre-redirect request
- Clone the challenged request for the authenticated retry so redirects preserve the correct URI and method
- Only replay the body when the challenged request actually carries one
- Add a regression test for a redirect followed by a digest challenge

## Testing
- `go test ./internal/fetch`
- `go test ./...`
- `staticcheck ./...`