### PR TITLE
Pass Host overrides into WebSocket dial options

### DIFF
--- a/internal/fetch/websocket.go
+++ b/internal/fetch/websocket.go
@@ -94,6 +94,7 @@ func handleWebSocket(ctx context.Context, r *Request, c *client.Client, req *htt
 	opts := &websocket.DialOptions{
 		HTTPClient:   c.HTTPClient(),
 		HTTPHeader:   req.Header,
+		Host:         req.Host,
 		Subprotocols: subprotocols,
 	}
 


### PR DESCRIPTION
## Summary
- Forward `req.Host` to `websocket.DialOptions` so `-H "Host: ..."` applies to WebSocket handshakes
- Keep WebSocket request handling consistent with the normal HTTP client path

## Testing
- `go test ./internal/fetch`
- `gofmt -w internal/fetch/websocket.go`