### PR TITLE
Decode percent-encoded gRPC status messages

### DIFF
--- a/internal/grpc/status.go
+++ b/internal/grpc/status.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 )
 
@@ -81,6 +82,11 @@ func ParseStatus(grpcStatus, grpcMessage string) *Status {
 	if grpcStatus != "" {
 		if n, err := strconv.Atoi(grpcStatus); err == nil {
 			code = Code(n)
+		}
+	}
+	if grpcMessage != "" {
+		if decoded, err := url.PathUnescape(grpcMessage); err == nil {
+			grpcMessage = decoded
 		}
 	}
 	return &Status{Code: code, Message: grpcMessage}

--- a/internal/grpc/status_test.go
+++ b/internal/grpc/status_test.go
@@ -120,6 +120,20 @@ func TestParseStatus(t *testing.T) {
 			wantCode:    Unauthenticated,
 			wantMessage: "invalid token",
 		},
+		{
+			name:        "percent-encoded message",
+			grpcStatus:  "13",
+			grpcMessage: "bad%20thing%3A%20no%20tokens",
+			wantCode:    Internal,
+			wantMessage: "bad thing: no tokens",
+		},
+		{
+			name:        "invalid percent-encoded message",
+			grpcStatus:  "13",
+			grpcMessage: "bad%zzmessage",
+			wantCode:    Internal,
+			wantMessage: "bad%zzmessage",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Decode `grpc-message` values with `url.PathUnescape` when parsing gRPC status trailers and headers.
- Preserve the raw message if decoding fails, so malformed status text still surfaces unchanged.
- Add unit coverage for decoded and invalid percent-encoded messages.

## Testing
- `go test ./internal/grpc ./internal/fetch`
- `go test ./...`