### PR TITLE
Drain suppressed binary responses before copying to clipboard

### DIFF
--- a/internal/fetch/clipboard_test.go
+++ b/internal/fetch/clipboard_test.go
@@ -1,10 +1,37 @@
 package fetch
 
 import (
+	"bytes"
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/ryanfowler/fetch/internal/core"
 )
+
+func TestStreamToStdoutDrainsSuppressedBinaryForClipboard(t *testing.T) {
+	wasStdoutTerm := core.IsStdoutTerm
+	core.IsStdoutTerm = true
+	t.Cleanup(func() {
+		core.IsStdoutTerm = wasStdoutTerm
+	})
+
+	data := bytes.Repeat([]byte("a"), 4096)
+	data[10] = 0
+
+	lb := &limitedBuffer{max: int64(len(data))}
+	r := io.TeeReader(bytes.NewReader(data), lb)
+	if err := streamToStdout(r, newTestPrinter(), false, true, true); err != nil {
+		t.Fatalf("streamToStdout returned error: %v", err)
+	}
+
+	if got := lb.buf.Bytes(); !bytes.Equal(got, data) {
+		t.Fatalf("captured %d bytes, want %d", len(got), len(data))
+	}
+	if lb.overflow {
+		t.Fatal("buffer should not overflow when response fits")
+	}
+}
 
 func TestLimitedBuffer(t *testing.T) {
 	t.Run("under limit", func(t *testing.T) {

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -352,7 +352,7 @@ func processResponse(ctx context.Context, r *Request, resp *http.Response, hadRe
 
 	if body != nil {
 		p := r.PrinterHandle.Stderr()
-		err = streamToStdout(body, p, r.Output == "-", r.NoPager)
+		err = streamToStdout(body, p, r.Output == "-", r.NoPager, cc != nil)
 		if err != nil {
 			return 0, err
 		}
@@ -463,7 +463,7 @@ func formatResponse(ctx context.Context, r *Request, resp *http.Response) (io.Re
 	return bytes.NewReader(buf), nil
 }
 
-func streamToStdout(r io.Reader, p *core.Printer, forceOutput, noPager bool) error {
+func streamToStdout(r io.Reader, p *core.Printer, forceOutput, noPager, drainSuppressedBinary bool) error {
 	// Check output to see if it's likely safe to print to stdout.
 	if core.IsStdoutTerm && !forceOutput {
 		var ok bool
@@ -474,6 +474,10 @@ func streamToStdout(r io.Reader, p *core.Printer, forceOutput, noPager bool) err
 		}
 		if !ok {
 			printBinaryWarning(p)
+			if drainSuppressedBinary {
+				_, err = io.Copy(io.Discard, r)
+				return err
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
## Summary
- Drain binary responses to `io.Discard` when terminal output is suppressed and `--copy` is active, so the tee captures the full body instead of only the sniffed prefix.
- Keep the existing binary warning behavior for terminal output.
- Add a regression test that verifies clipboard capture sees the full response body when binary output is suppressed.

## Testing
- `go test -v ./internal/fetch`
- `go test -v ./...`