### PR TITLE
Dispatch final SSE event at EOF

### DIFF
--- a/internal/format/sse.go
+++ b/internal/format/sse.go
@@ -89,6 +89,27 @@ func streamEvents(r io.Reader) iter.Seq2[event, error] {
 		var eventType string
 		var sb strings.Builder
 		var lastEventID string
+		dispatch := func() bool {
+			ev := event{
+				LastID: lastEventID,
+				Type:   eventType,
+				Data:   sb.String(),
+			}
+			ev.Data = strings.TrimSuffix(ev.Data, "\n")
+
+			eventType = ""
+			sb.Reset()
+
+			if ev.Data == "" {
+				// Empty data, return.
+				return true
+			}
+
+			if ev.Type == "" {
+				ev.Type = "message"
+			}
+			return yield(ev, nil)
+		}
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			if !seenLine {
@@ -98,25 +119,7 @@ func streamEvents(r io.Reader) iter.Seq2[event, error] {
 
 			if len(line) == 0 {
 				// Empty line, dispatch the ev.
-				ev := event{
-					LastID: lastEventID,
-					Type:   eventType,
-					Data:   sb.String(),
-				}
-				ev.Data = strings.TrimSuffix(ev.Data, "\n")
-
-				eventType = ""
-				sb.Reset()
-
-				if ev.Data == "" {
-					// Empty data, return.
-					continue
-				}
-
-				if ev.Type == "" {
-					ev.Type = "message"
-				}
-				if !yield(ev, nil) {
+				if !dispatch() {
 					return
 				}
 				continue
@@ -141,6 +144,10 @@ func streamEvents(r io.Reader) iter.Seq2[event, error] {
 		}
 		if err := scanner.Err(); err != nil {
 			yield(event{}, err)
+			return
+		}
+		if sb.Len() > 0 {
+			dispatch()
 		}
 	}
 }

--- a/internal/format/sse_test.go
+++ b/internal/format/sse_test.go
@@ -1,0 +1,48 @@
+package format
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestStreamEventsEOFDispatchesFinalEventWithoutBlankLine(t *testing.T) {
+	got := collectStreamEvents(t, "data: final\n")
+	want := []event{
+		{
+			Type: "message",
+			Data: "final",
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("streamEvents() = %#v, want %#v", got, want)
+	}
+}
+
+func TestStreamEventsEOFDoesNotDuplicateFinalEventWithBlankLine(t *testing.T) {
+	got := collectStreamEvents(t, "data: final\n\n")
+	want := []event{
+		{
+			Type: "message",
+			Data: "final",
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("streamEvents() = %#v, want %#v", got, want)
+	}
+}
+
+func collectStreamEvents(t *testing.T, input string) []event {
+	t.Helper()
+
+	var events []event
+	for ev, err := range streamEvents(strings.NewReader(input)) {
+		if err != nil {
+			t.Fatalf("streamEvents() returned error: %v", err)
+		}
+		events = append(events, ev)
+	}
+	return events
+}


### PR DESCRIPTION
## Summary
- Reused the SSE dispatch path so buffered data is emitted both on blank-line separators and at EOF.
- Defaulted EOF-flushed events to `message` and preserved the existing trailing newline trim behavior.
- Added regression tests for EOF with and without a final blank line.

## Testing
- `go test -v ./internal/format`