### PR TITLE
Set ALPN protocols for TLS inspection

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1837,6 +1837,7 @@ func TestMain(t *testing.T) {
 		}))
 		server.TLS = &tls.Config{
 			Certificates: []tls.Certificate{tlsCert},
+			NextProtos:   []string{"h2", "http/1.1"},
 		}
 		server.StartTLS()
 		t.Cleanup(func() { server.Close() })
@@ -1863,6 +1864,27 @@ func TestMain(t *testing.T) {
 			)
 			assertExitCode(t, 0, res)
 			assertBufContains(t, res.stderr, "TLS 1.3")
+		})
+
+		t.Run("shows default ALPN negotiation", func(t *testing.T) {
+			t.Parallel()
+			res := runFetch(t, fetchPath, server.URL,
+				"--inspect-tls",
+				"--ca-cert", caCertPath,
+			)
+			assertExitCode(t, 0, res)
+			assertBufContains(t, res.stderr, "ALPN: h2")
+		})
+
+		t.Run("honors HTTP/1 ALPN setting", func(t *testing.T) {
+			t.Parallel()
+			res := runFetch(t, fetchPath, server.URL,
+				"--inspect-tls",
+				"--http", "1",
+				"--ca-cert", caCertPath,
+			)
+			assertExitCode(t, 0, res)
+			assertBufContains(t, res.stderr, "ALPN: http/1.1")
 		})
 
 		t.Run("shows SANs", func(t *testing.T) {

--- a/internal/tlsinspect/tlsinspect.go
+++ b/internal/tlsinspect/tlsinspect.go
@@ -26,6 +26,7 @@ type Config struct {
 	CACerts    []*x509.Certificate
 	ClientCert *tls.Certificate
 	DNSServer  *url.URL
+	HTTP       core.HTTPVersion
 	Insecure   bool
 	TLSMax     uint16
 	TLSMin     uint16
@@ -44,6 +45,7 @@ func Inspect(ctx context.Context, p *core.Printer, cfg *Config) int {
 		TLSMin:     cfg.TLSMin,
 	}
 	tlsConfig := tlsDialCfg.BuildTLSConfig()
+	tlsConfig.NextProtos = alpnProtocols(cfg.HTTP)
 	res := resolver.New(resolver.Config{Server: cfg.DNSServer})
 
 	// Resolve host:port.
@@ -79,6 +81,13 @@ func Inspect(ctx context.Context, p *core.Printer, cfg *Config) int {
 	render(p, &cs)
 	p.Flush()
 	return 0
+}
+
+func alpnProtocols(httpVersion core.HTTPVersion) []string {
+	if httpVersion == core.HTTP1 {
+		return []string{"http/1.1"}
+	}
+	return []string{"h2", "http/1.1"}
 }
 
 // writeTLSError writes a TLS connection error, suggesting --insecure for cert errors.

--- a/internal/tlsinspect/tlsinspect_test.go
+++ b/internal/tlsinspect/tlsinspect_test.go
@@ -90,6 +90,32 @@ func TestCertDisplayName(t *testing.T) {
 	}
 }
 
+func TestALPNProtocols(t *testing.T) {
+	tests := []struct {
+		name        string
+		httpVersion core.HTTPVersion
+		want        []string
+	}{
+		{name: "default offers HTTP/2 and HTTP/1.1", httpVersion: core.HTTPDefault, want: []string{"h2", "http/1.1"}},
+		{name: "HTTP/2 offers HTTP/2 and HTTP/1.1", httpVersion: core.HTTP2, want: []string{"h2", "http/1.1"}},
+		{name: "HTTP/1 offers only HTTP/1.1", httpVersion: core.HTTP1, want: []string{"http/1.1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := alpnProtocols(tt.httpVersion)
+			if len(got) != len(tt.want) {
+				t.Fatalf("alpnProtocols() length = %d, want %d: %v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("alpnProtocols()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestCertExpiryInfo(t *testing.T) {
 	fixedNow := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
 	origNow := tlsInspectNow

--- a/main.go
+++ b/main.go
@@ -583,6 +583,7 @@ func inspectTLS(ctx context.Context, app *cli.App, handle *core.Handle) int {
 		CACerts:    app.Cfg.CACerts,
 		ClientCert: clientCert,
 		DNSServer:  app.Cfg.DNSServer,
+		HTTP:       app.Cfg.HTTP,
 		Insecure:   getValue(app.Cfg.Insecure),
 		TLSMax:     getValue(app.Cfg.TLSMax),
 		TLSMin:     getValue(app.Cfg.TLSMin),


### PR DESCRIPTION
## Summary
- Pass the selected HTTP version into `--inspect-tls` and set `tls.Config.NextProtos` before the handshake.
- Match normal fetch behavior by advertising `h2` + `http/1.1` for default/HTTP2, and `http/1.1` for HTTP/1.
- Add unit coverage for the ALPN mapping and integration coverage for negotiated output.

## Testing
- `go test -v ./internal/tlsinspect`
- `go test -v ./integration -run 'TestMain/inspect-tls'`
- Formatting and diff checks passed