### PR TITLE
Handle compressed gRPC frames in response formatting

### DIFF
--- a/internal/format/grpc.go
+++ b/internal/format/grpc.go
@@ -16,13 +16,17 @@ import (
 func FormatGRPCStream(r io.Reader, md protoreflect.MessageDescriptor, p *core.Printer) error {
 	var written bool
 	for {
-		data, _, err := grpc.ReadFrame(r)
+		data, compressed, err := grpc.ReadFrame(r)
 		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
 			p.Discard()
 			return err
+		}
+		if compressed {
+			p.Discard()
+			return errors.New("compressed gRPC messages are not supported")
 		}
 
 		if written {

--- a/internal/format/grpc_test.go
+++ b/internal/format/grpc_test.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/ryanfowler/fetch/internal/core"
@@ -52,6 +53,19 @@ func TestFormatGRPCStream(t *testing.T) {
 		p := core.NewHandle(core.ColorOff).Stderr()
 		err := FormatGRPCStream(bytes.NewReader(framed), nil, p)
 		if err != nil {
+			t.Fatalf("FormatGRPCStream() error = %v", err)
+		}
+	})
+
+	t.Run("compressed frame", func(t *testing.T) {
+		framed := grpc.Frame([]byte("compressed payload"), true)
+
+		p := core.NewHandle(core.ColorOff).Stderr()
+		err := FormatGRPCStream(bytes.NewReader(framed), nil, p)
+		if err == nil {
+			t.Fatal("expected error for compressed frame")
+		}
+		if !strings.Contains(err.Error(), "compressed gRPC messages are not supported") {
 			t.Fatalf("FormatGRPCStream() error = %v", err)
 		}
 	})


### PR DESCRIPTION
## Summary
- Capture the compressed flag when reading gRPC frames in `FormatGRPCStream`.
- Return a clear `compressed gRPC messages are not supported` error before attempting protobuf formatting.
- Add a regression test covering a compressed frame.

## Testing
- `go test -v ./internal/format`