### PR TITLE
Fix `--from-curl` redirect handling to match curl semantics

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -17,6 +17,8 @@ import (
 
 var unixOS = []string{"linux", "darwin", "freebsd", "openbsd", "netbsd", "aix", "dragonfly", "solaris"}
 
+const curlDefaultMaxRedirects = 50
+
 type CLI struct {
 	Description    string
 	ArgFn          func(s string) error
@@ -709,15 +711,14 @@ func (a *App) applyFromCurl(r *curl.Result) error {
 	}
 
 	// Network.
+	redirects := 0
 	if r.FollowRedirects {
-		redirects := 10
-		if r.MaxRedirects > 0 {
+		redirects = curlDefaultMaxRedirects
+		if r.MaxRedirectsSet {
 			redirects = r.MaxRedirects
 		}
-		a.Cfg.Redirects = &redirects
-	} else if r.MaxRedirects > 0 {
-		a.Cfg.Redirects = &r.MaxRedirects
 	}
+	a.Cfg.Redirects = &redirects
 	if r.Timeout > 0 {
 		if err := a.Cfg.ParseTimeout(strconv.FormatFloat(r.Timeout, 'f', -1, 64)); err != nil {
 			return err

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -220,6 +220,60 @@ func TestFromCurlGetData(t *testing.T) {
 	})
 }
 
+func TestFromCurlRedirects(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want int
+	}{
+		{
+			name: "disabled by default",
+			cmd:  "curl https://example.com",
+			want: 0,
+		},
+		{
+			name: "max redirs alone does not follow",
+			cmd:  "curl --max-redirs 5 https://example.com",
+			want: 0,
+		},
+		{
+			name: "location uses curl default limit",
+			cmd:  "curl -L https://example.com",
+			want: curlDefaultMaxRedirects,
+		},
+		{
+			name: "location with max redirs",
+			cmd:  "curl -L --max-redirs 5 https://example.com",
+			want: 5,
+		},
+		{
+			name: "location with explicit zero max redirs",
+			cmd:  "curl -L --max-redirs 0 https://example.com",
+			want: 0,
+		},
+		{
+			name: "location with unlimited max redirs",
+			cmd:  "curl -L --max-redirs -1 https://example.com",
+			want: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app, err := Parse([]string{"--from-curl", tt.cmd})
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if app.Cfg.Redirects == nil {
+				t.Fatal("Redirects = nil, want explicit from-curl redirect setting")
+			}
+			if *app.Cfg.Redirects != tt.want {
+				t.Fatalf("Redirects = %d, want %d", *app.Cfg.Redirects, tt.want)
+			}
+		})
+	}
+}
+
 func TestFromCurlDataFileClose(t *testing.T) {
 	// Verify that file descriptors are properly closed after reading.
 	dir := t.TempDir()

--- a/internal/curl/curl.go
+++ b/internal/curl/curl.go
@@ -42,6 +42,7 @@ type Result struct {
 	RemoteHeaderName bool
 	FollowRedirects  bool
 	MaxRedirects     int
+	MaxRedirectsSet  bool
 	Timeout          float64
 	ConnectTimeout   float64
 	Proxy            string

--- a/internal/curl/curl_test.go
+++ b/internal/curl/curl_test.go
@@ -563,6 +563,7 @@ func TestParseNetwork(t *testing.T) {
 			check: func(t *testing.T, r *Result) {
 				assertTrue(t, "FollowRedirects", r.FollowRedirects)
 				assertIntEqual(t, "MaxRedirects", r.MaxRedirects, 5)
+				assertTrue(t, "MaxRedirectsSet", r.MaxRedirectsSet)
 			},
 		},
 		{

--- a/internal/curl/long_flags.go
+++ b/internal/curl/long_flags.go
@@ -217,6 +217,7 @@ func parseLongFlag(r *Result, name, value string, hasValue bool, rest []string) 
 			return 0, fmt.Errorf("invalid --max-redirs value: %s", v)
 		}
 		r.MaxRedirects = num
+		r.MaxRedirectsSet = true
 		return n, nil
 	case "max-time":
 		v, n, err := consumeArg()


### PR DESCRIPTION
## Summary
- Make `--from-curl` disable redirects unless curl passed `-L/--location`.
- Use curl’s default redirect limit of `50` when `-L` is present and `--max-redirs` is omitted.
- Preserve explicit `--max-redirs` values, including `0` and `-1`, by tracking whether the flag was set.
- Add CLI and curl parser coverage for the redirect cases.

## Testing
- Added unit tests for `--from-curl` redirect translation in `internal/cli`.
- Added parser coverage for explicit `--max-redirs` values in `internal/curl`.
- Verified with `go test ./...`.