### PR TITLE
Handle explicit directory entries during update archive unpacking

### DIFF
--- a/internal/update/update_unix.go
+++ b/internal/update/update_unix.go
@@ -58,13 +58,13 @@ func handleHeader(root *os.Root, tr *tar.Reader, header *tar.Header) error {
 	}
 
 	if header.Typeflag == tar.TypeDir {
-		return root.Mkdir(name, os.FileMode(header.Mode))
+		return root.MkdirAll(name, os.FileMode(header.Mode))
 	}
 	if header.Typeflag != tar.TypeReg {
 		return nil
 	}
 
-	f, err := root.OpenFile(name, os.O_CREATE|os.O_WRONLY, os.FileMode(header.Mode))
+	f, err := root.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
 	if err != nil {
 		return err
 	}

--- a/internal/update/update_unix_test.go
+++ b/internal/update/update_unix_test.go
@@ -82,6 +82,83 @@ func TestCanReplaceFile_ReadOnlyFileWritableDirectory(t *testing.T) {
 	}
 }
 
+func TestUnpackArtifact_ExplicitDirectoryEntry(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "bin/",
+		Typeflag: tar.TypeDir,
+		Mode:     0755,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	content := []byte("content")
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "bin/fetch",
+		Mode: 0755,
+		Size: int64(len(content)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := unpackArtifact(dir, bytes.NewReader(buf.Bytes())); err != nil {
+		t.Fatalf("unpackArtifact: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "bin", "fetch")); err != nil {
+		t.Fatalf("expected file to exist: %v", err)
+	}
+}
+
+func TestUnpackArtifact_TruncatesExistingRegularFile(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	for _, content := range [][]byte{[]byte("longer content"), []byte("short")} {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: "fetch",
+			Mode: 0755,
+			Size: int64(len(content)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := unpackArtifact(dir, bytes.NewReader(buf.Bytes())); err != nil {
+		t.Fatalf("unpackArtifact: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "fetch"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "short" {
+		t.Fatalf("extracted content = %q, want %q", got, "short")
+	}
+}
+
 func createTarGz(t *testing.T, filename string, content []byte) []byte {
 	t.Helper()
 	var buf bytes.Buffer

--- a/internal/update/update_windows.go
+++ b/internal/update/update_windows.go
@@ -64,7 +64,7 @@ func handleZipFile(root *os.Root, f *zip.File) error {
 	}
 
 	if f.FileInfo().IsDir() {
-		return root.Mkdir(name, f.Mode())
+		return root.MkdirAll(name, f.Mode().Perm())
 	}
 
 	rc, err := f.Open()
@@ -73,7 +73,7 @@ func handleZipFile(root *os.Root, f *zip.File) error {
 	}
 	defer rc.Close()
 
-	out, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+	out, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/internal/update/update_windows_test.go
+++ b/internal/update/update_windows_test.go
@@ -64,6 +64,33 @@ func TestUnpackArtifact_PathTraversal(t *testing.T) {
 	}
 }
 
+func TestUnpackArtifact_ExplicitDirectoryEntry(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	if _, err := zw.Create("bin/"); err != nil {
+		t.Fatal(err)
+	}
+	fw, err := zw.Create("bin/fetch.exe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write([]byte("content")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := unpackArtifact(dir, bytes.NewReader(buf.Bytes())); err != nil {
+		t.Fatalf("unpackArtifact: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "bin", "fetch.exe")); err != nil {
+		t.Fatalf("expected file to exist: %v", err)
+	}
+}
+
 func createZip(t *testing.T, filename string, content []byte) []byte {
 	t.Helper()
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- Use `MkdirAll` for explicit directory entries in the Unix and Windows unpackers so archives with predeclared directories extract cleanly.
- Add `os.O_TRUNC` when writing Unix regular files to avoid leaving stale bytes behind on overwrite.
- Cover both cases with regression tests for explicit directory entries, plus a Unix truncation test.

## Testing
- `go test -v ./internal/update`
- `go test ./...`