### PR TITLE
Fix DNS inspection fallback when no system nameserver is discovered

### DIFF
--- a/internal/dnsinspect/dnsinspect.go
+++ b/internal/dnsinspect/dnsinspect.go
@@ -52,9 +52,10 @@ type queryType struct {
 }
 
 type record struct {
-	typ   string
-	value string
-	ttl   uint32
+	typ    string
+	value  string
+	ttl    uint32
+	hasTTL bool
 }
 
 type result struct {
@@ -68,6 +69,17 @@ type queryResult struct {
 	records []record
 	err     error
 }
+
+type resolverTargetInfo struct {
+	label      string
+	udpAddr    string
+	useDefault bool
+}
+
+var (
+	readResolvConf      = func() ([]byte, error) { return os.ReadFile("/etc/resolv.conf") }
+	defaultLookupIPAddr = net.DefaultResolver.LookupIPAddr
+)
 
 // Inspect resolves the configured URL hostname and renders DNS information to
 // the printer. It returns a non-zero exit code on failure.
@@ -86,8 +98,8 @@ func Inspect(ctx context.Context, p *core.Printer, cfg *Config) int {
 
 	start := time.Now()
 	if ip := net.ParseIP(host); ip != nil {
-		resolver, _ := resolverTarget(cfg.DNSServer)
-		renderIPLiteral(p, host, ip, resolver, time.Since(start))
+		target := resolverTarget(cfg.DNSServer)
+		renderIPLiteral(p, host, ip, target.label, time.Since(start))
 		p.Flush()
 		return 0
 	}
@@ -103,11 +115,26 @@ func Inspect(ctx context.Context, p *core.Printer, cfg *Config) int {
 }
 
 func lookup(ctx context.Context, cfg *Config, host string, start time.Time) (*result, error) {
-	resolverLabel, udpAddr := resolverTarget(cfg.DNSServer)
+	target := resolverTarget(cfg.DNSServer)
 	out := &result{
 		host:     host,
-		resolver: resolverLabel,
+		resolver: target.label,
 		records:  make(map[string][]record),
+	}
+
+	if target.useDefault {
+		records, err := lookupDefaultResolverRecords(ctx, host)
+		out.duration = time.Since(start)
+		if err != nil {
+			return nil, fmt.Errorf("lookup %s: %w", host, err)
+		}
+		for _, rec := range records {
+			out.records[rec.typ] = append(out.records[rec.typ], rec)
+		}
+		if recordCount(out) == 0 {
+			return nil, fmt.Errorf("lookup %s: no DNS records found", host)
+		}
+		return out, nil
 	}
 
 	results := make([]queryResult, len(inspectTypes))
@@ -120,7 +147,7 @@ func lookup(ctx context.Context, cfg *Config, host string, start time.Time) (*re
 				results[i].records, results[i].err = lookupDOHRecords(ctx, cfg.DNSServer, host, qt)
 				return
 			}
-			results[i].records, results[i].err = lookupUDPRecords(ctx, udpAddr, host, qt)
+			results[i].records, results[i].err = lookupUDPRecords(ctx, target.udpAddr, host, qt)
 		}()
 	}
 	wg.Wait()
@@ -153,6 +180,25 @@ func lookup(ctx context.Context, cfg *Config, host string, start time.Time) (*re
 		return nil, fmt.Errorf("lookup %s: %w", host, firstErr)
 	}
 	return nil, fmt.Errorf("lookup %s: no DNS records found", host)
+}
+
+func lookupDefaultResolverRecords(ctx context.Context, host string) ([]record, error) {
+	addrs, err := defaultLookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]record, 0, len(addrs))
+	for _, addr := range addrs {
+		ip := addr.IP
+		switch {
+		case ip.To4() != nil:
+			records = append(records, record{typ: "A", value: ip.String()})
+		case ip.To16() != nil:
+			records = append(records, record{typ: "AAAA", value: ip.String()})
+		}
+	}
+	return records, nil
 }
 
 func lookupDOHRecords(ctx context.Context, serverURL *url.URL, host string, qt queryType) ([]record, error) {
@@ -211,9 +257,10 @@ func lookupDOHRecords(ctx context.Context, serverURL *url.URL, host string, qt q
 		typ := dnsmessage.Type(answer.Type)
 		label := typeLabel(typ)
 		records = append(records, record{
-			typ:   label,
-			value: normalizeDOHValue(typ, answer.Data),
-			ttl:   answer.TTL,
+			typ:    label,
+			value:  normalizeDOHValue(typ, answer.Data),
+			ttl:    answer.TTL,
+			hasTTL: true,
 		})
 	}
 	return records, nil
@@ -292,9 +339,10 @@ func resourceRecord(res dnsmessage.Resource) (record, bool) {
 		return record{}, false
 	}
 	return record{
-		typ:   typeLabel(res.Header.Type),
-		value: value,
-		ttl:   res.Header.TTL,
+		typ:    typeLabel(res.Header.Type),
+		value:  value,
+		ttl:    res.Header.TTL,
+		hasTTL: true,
 	}, true
 }
 
@@ -487,20 +535,23 @@ func unpackDNSName(raw []byte, off int) (string, int, bool) {
 	}
 }
 
-func resolverTarget(server *url.URL) (label, udpAddr string) {
+func resolverTarget(server *url.URL) resolverTargetInfo {
 	switch {
 	case server == nil:
-		addr := systemDNSServer()
-		return "system (" + addr + ")", addr
+		addr, ok := systemDNSServer()
+		if !ok {
+			return resolverTargetInfo{label: "system resolver", useDefault: true}
+		}
+		return resolverTargetInfo{label: "system (" + addr + ")", udpAddr: addr}
 	case server.Scheme == "":
-		return "udp " + server.Host, server.Host
+		return resolverTargetInfo{label: "udp " + server.Host, udpAddr: server.Host}
 	default:
-		return server.String(), ""
+		return resolverTargetInfo{label: server.String()}
 	}
 }
 
-func systemDNSServer() string {
-	raw, err := os.ReadFile("/etc/resolv.conf")
+func systemDNSServer() (string, bool) {
+	raw, err := readResolvConf()
 	if err == nil {
 		for _, line := range strings.Split(string(raw), "\n") {
 			line = strings.TrimSpace(line)
@@ -509,11 +560,11 @@ func systemDNSServer() string {
 			}
 			fields := strings.Fields(line)
 			if len(fields) >= 2 && fields[0] == "nameserver" {
-				return net.JoinHostPort(fields[1], "53")
+				return net.JoinHostPort(fields[1], "53"), true
 			}
 		}
 	}
-	return net.JoinHostPort("127.0.0.1", "53")
+	return "", false
 }
 
 func absoluteName(host string) string {
@@ -703,12 +754,14 @@ func renderSection(p *core.Printer, name string, records []record) {
 		p.Set(core.Green)
 		p.WriteString(rec.value)
 		p.Reset()
-		p.WriteString(" ")
-		p.Set(core.Dim)
-		p.WriteString("(TTL ")
-		p.WriteString(formatTTL(rec.ttl))
-		p.WriteString(")")
-		p.Reset()
+		if rec.hasTTL {
+			p.WriteString(" ")
+			p.Set(core.Dim)
+			p.WriteString("(TTL ")
+			p.WriteString(formatTTL(rec.ttl))
+			p.WriteString(")")
+			p.Reset()
+		}
 		p.WriteString("\n")
 	}
 

--- a/internal/dnsinspect/dnsinspect_test.go
+++ b/internal/dnsinspect/dnsinspect_test.go
@@ -2,6 +2,7 @@ package dnsinspect
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -167,13 +168,73 @@ func TestLookupUDPRecordsReturnsTTL(t *testing.T) {
 	}
 }
 
+func TestLookupUsesDefaultResolverWhenNoSystemDNSServerDiscovered(t *testing.T) {
+	origReadResolvConf := readResolvConf
+	origDefaultLookupIPAddr := defaultLookupIPAddr
+	t.Cleanup(func() {
+		readResolvConf = origReadResolvConf
+		defaultLookupIPAddr = origDefaultLookupIPAddr
+	})
+
+	readResolvConf = func() ([]byte, error) {
+		return nil, errors.New("missing resolv.conf")
+	}
+	var lookedUpHost string
+	defaultLookupIPAddr = func(ctx context.Context, host string) ([]net.IPAddr, error) {
+		lookedUpHost = host
+		return []net.IPAddr{
+			{IP: net.ParseIP("192.0.2.44")},
+			{IP: net.ParseIP("2001:db8::44")},
+		}, nil
+	}
+
+	res, err := lookup(context.Background(), &Config{}, "example.com", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lookedUpHost != "example.com" {
+		t.Fatalf("default resolver looked up host %q, want example.com", lookedUpHost)
+	}
+	if strings.Contains(res.resolver, "127.0.0.1") {
+		t.Fatalf("resolver label = %q, must not silently fall back to loopback", res.resolver)
+	}
+	if got, want := res.records["A"][0].value, "192.0.2.44"; got != want {
+		t.Fatalf("A record = %q, want %q", got, want)
+	}
+	if got, want := res.records["AAAA"][0].value, "2001:db8::44"; got != want {
+		t.Fatalf("AAAA record = %q, want %q", got, want)
+	}
+	if res.records["A"][0].hasTTL || res.records["AAAA"][0].hasTTL {
+		t.Fatalf("default resolver records unexpectedly reported TTLs: %#v", res.records)
+	}
+}
+
+func TestResolverTargetDoesNotDefaultToLoopback(t *testing.T) {
+	origReadResolvConf := readResolvConf
+	t.Cleanup(func() {
+		readResolvConf = origReadResolvConf
+	})
+
+	readResolvConf = func() ([]byte, error) {
+		return []byte("# no nameservers\n"), nil
+	}
+
+	target := resolverTarget(nil)
+	if !target.useDefault {
+		t.Fatalf("useDefault = false, want true")
+	}
+	if strings.Contains(target.label, "127.0.0.1") || strings.Contains(target.udpAddr, "127.0.0.1") {
+		t.Fatalf("resolver target silently used loopback: %#v", target)
+	}
+}
+
 func TestRenderShowsUnavailableTTLPerRecord(t *testing.T) {
 	p := core.TestPrinter(false)
 	render(p, &result{
 		host:     "example.com",
 		resolver: "system",
 		records: map[string][]record{
-			"A": {{typ: "A", value: "192.0.2.1", ttl: 60}},
+			"A": {{typ: "A", value: "192.0.2.1", ttl: 60, hasTTL: true}},
 		},
 	})
 
@@ -190,8 +251,8 @@ func TestRenderSortsRecordsWithinType(t *testing.T) {
 		resolver: "system",
 		records: map[string][]record{
 			"A": {
-				{typ: "A", value: "192.0.2.20", ttl: 60},
-				{typ: "A", value: "192.0.2.10", ttl: 60},
+				{typ: "A", value: "192.0.2.20", ttl: 60, hasTTL: true},
+				{typ: "A", value: "192.0.2.10", ttl: 60, hasTTL: true},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- Stop falling back to `127.0.0.1:53` when `/etc/resolv.conf` is missing or has no nameserver entry.
- Use `net.DefaultResolver` for `--inspect-dns` when no system DNS server can be determined, so Windows and similar environments do not silently query localhost.
- Preserve TTL rendering only for responses that actually supply TTLs.
- Add regression coverage for the no-system-DNS-discovered path and the resolver-target selection logic.

## Testing
- Added unit coverage for the missing-resolver fallback path and loopback-avoidance behavior.
- `go test -v ./internal/dnsinspect`