### PR TITLE
Stop signal handling after first Ctrl-C

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 	signal.Notify(chSig, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
 	go func() {
 		sig := <-chSig
+		signal.Stop(chSig)
 		cancel(core.SignalError(sig.String()))
 	}()
 


### PR DESCRIPTION
## Summary
- Call `signal.Stop` after the first caught interrupt/termination signal in `main.go`
- Let repeated Ctrl-C fall back to default OS behavior instead of remaining intercepted by the runtime

## Testing
- Not run (not requested)