### PR TITLE
Fix metadata commands to bypass auto-update startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ prettier -w .
 - `--inspect-dns` resolves the URL hostname without making an HTTP request, showing common DNS record types, resolver backend, duration, and per-record TTLs from direct UDP or DoH responses.
 - `--tls` remains a compatibility alias for setting the minimum TLS version; prefer `--min-tls` in new docs/examples, and use `--max-tls` to cap negotiation or combine min/max for an exact TLS version.
 - WebSocket terminal sessions use the interactive prompt by default and can be controlled with `--ws-interactive auto|on|off`; output-file/clipboard/retry flags are rejected because the WebSocket path streams through the message loop instead of the normal response pipeline.
+- Metadata-only commands (`--help`, `--version`, `--buildinfo`) perform best-effort config parsing for presentation settings, but config errors and background auto-updates cannot block them.
 5. HTTP client executes request
 6. Response formatted based on Content-Type and output to stdout (optionally via pager)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -150,6 +150,45 @@ func TestMain(t *testing.T) {
 		assertBufContains(t, res.stdout, "\x1b[")
 	})
 
+	t.Run("metadata commands use best-effort config", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "config")
+		if err := os.WriteFile(path, []byte("format = nope\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		res := runFetch(t, fetchPath, "--config", path, "--help")
+		assertExitCode(t, 0, res)
+		assertBufEmpty(t, res.stderr)
+		assertBufContains(t, res.stdout, "Usage")
+
+		res = runFetch(t, fetchPath, "--config", path, "--version")
+		assertExitCode(t, 0, res)
+		assertBufEmpty(t, res.stderr)
+		assertBufContains(t, res.stdout, "fetch ")
+
+		res = runFetch(t, fetchPath, "--config", path, "--buildinfo")
+		assertExitCode(t, 0, res)
+		assertBufEmpty(t, res.stderr)
+		assertBufContains(t, res.stdout, `"fetch"`)
+
+		path = filepath.Join(t.TempDir(), "config")
+		if err := os.WriteFile(path, []byte("color = on\nformat = off\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		res = runFetch(t, fetchPath, "--config", path, "--help")
+		assertExitCode(t, 0, res)
+		assertBufEmpty(t, res.stderr)
+		assertBufContains(t, res.stdout, "\x1b[")
+
+		res = runFetch(t, fetchPath, "--config", path, "--buildinfo")
+		assertExitCode(t, 0, res)
+		assertBufEmpty(t, res.stderr)
+		assertBufContains(t, res.stdout, `"fetch"`)
+		assertBufNotContains(t, res.stdout, "\n")
+	})
+
 	t.Run("aws-sigv4 auth", func(t *testing.T) {
 		t.Parallel()
 		server := startServer(func(w http.ResponseWriter, r *http.Request) {
@@ -1568,7 +1607,9 @@ func TestMain(t *testing.T) {
 		urlStr.Store(&empty)
 		var newVersion atomic.Pointer[string]
 		newVersion.Store(&version)
+		var updateRequests atomic.Int64
 		server := startServer(func(w http.ResponseWriter, r *http.Request) {
+			updateRequests.Add(1)
 			if r.URL.Path != "/artifact" {
 				type Asset struct {
 					Name string `json:"name"`
@@ -1709,8 +1750,24 @@ func TestMain(t *testing.T) {
 			t.Fatal("binary was modified during dry-run update")
 		}
 
-		// Test the auto-update functionality.
+		// Metadata-only commands should not start background auto-updates.
+		metadataRequests := updateRequests.Load()
+		metadataModTime := getModTime(t, updateFetchPath)
 		res = runFetchOpts(t, updateFetchPath, fetchOpts{env: updateEnv}, "--version", "--auto-update", "0s")
+		assertExitCode(t, 0, res)
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			if updateRequests.Load() != metadataRequests {
+				t.Fatal("metadata command started an auto-update request")
+			}
+			time.Sleep(25 * time.Millisecond)
+		}
+		if !getModTime(t, updateFetchPath).Equal(metadataModTime) {
+			t.Fatal("metadata command modified the binary")
+		}
+
+		// Test the auto-update functionality.
+		res = runFetchOpts(t, updateFetchPath, fetchOpts{env: updateEnv}, server.URL, "--auto-update", "0s")
 		assertExitCode(t, 0, res)
 		var n int
 		for {

--- a/main.go
+++ b/main.go
@@ -55,6 +55,15 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Metadata-only commands should never be blocked by config errors or start
+	// background update work. Valid config is still merged so presentation
+	// settings like color and buildinfo formatting continue to apply.
+	if app.Help || app.Version || app.BuildInfo {
+		_, _ = parseConfigFile(app)
+		handleMetadataCommand(app, core.NewHandle(app.Cfg.Color))
+		os.Exit(0)
+	}
+
 	// Parse any config file with the CLI color setting for parse errors, then
 	// recreate the handle after config values are merged.
 	tmpHandle := core.NewHandle(app.Cfg.Color)
@@ -75,33 +84,6 @@ func main() {
 	// Start async update, if necessary.
 	if !app.Update && !core.NoSelfUpdate && app.Cfg.AutoUpdate != nil && *app.Cfg.AutoUpdate >= 0 {
 		checkForUpdate(ctx, handle.Stderr(), *app.Cfg.AutoUpdate)
-	}
-
-	// Print help to stdout.
-	if app.Help {
-		p := handle.Stdout()
-		app.PrintHelp(p)
-		p.Flush()
-		os.Exit(0)
-	}
-
-	// Print version to stdout.
-	if app.Version {
-		fmt.Fprintln(os.Stdout, "fetch", core.Version)
-		os.Exit(0)
-	}
-
-	// Print build info to stdout.
-	if app.BuildInfo {
-		p := handle.Stdout()
-		info := core.GetBuildInfo()
-		if app.Cfg.Format != core.FormatOff {
-			format.FormatJSON(info, p)
-		} else {
-			p.Write(info)
-		}
-		p.Flush()
-		os.Exit(0)
 	}
 
 	// Attempt to update the current executable.
@@ -233,6 +215,35 @@ func main() {
 	}
 	status := fetch.Fetch(ctx, &req)
 	os.Exit(status)
+}
+
+func handleMetadataCommand(app *cli.App, handle *core.Handle) {
+	// Print help to stdout.
+	if app.Help {
+		p := handle.Stdout()
+		app.PrintHelp(p)
+		p.Flush()
+		return
+	}
+
+	// Print version to stdout.
+	if app.Version {
+		fmt.Fprintln(os.Stdout, "fetch", core.Version)
+		return
+	}
+
+	// Print build info to stdout.
+	if app.BuildInfo {
+		p := handle.Stdout()
+		info := core.GetBuildInfo()
+		if app.Cfg.Format != core.FormatOff {
+			format.FormatJSON(info, p)
+		} else {
+			p.Write(info)
+		}
+		p.Flush()
+		return
+	}
 }
 
 func handleCompletion(name string, args []string) error {


### PR DESCRIPTION
## Summary
- Move `--help`, `--version`, and `--buildinfo` ahead of async update checks so metadata commands do not start background network or self-update work.
- Keep presentation config working for metadata commands with best-effort config parsing, while ignoring config errors that would otherwise block output.
- Add integration coverage for broken config files, colorized help, formatted build info, and the no-auto-update behavior on `--version`.

## Testing
- `go test -v ./integration -run 'TestMain/(metadata commands use best-effort config|update)$'`
- `go test -v ./...`
- `staticcheck ./...`