### PR TITLE
Fix `--` handling for normal CLI parsing

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -84,13 +84,14 @@ func (a *App) CLI() *CLI {
 			{Name: "URL", Description: "The URL to make a request to"},
 		},
 		ArgFn: func(s string) error {
-			// Append extra args, if necessary.
 			if extraArgs {
 				a.ExtraArgs = append(a.ExtraArgs, s)
 				return nil
 			}
 			if s == "--" {
-				extraArgs = true
+				if a.Complete != "" {
+					extraArgs = true
+				}
 				return nil
 			}
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -60,6 +61,38 @@ func TestFlagsAlphabeticalOrder(t *testing.T) {
 			t.Errorf("flags out of alphabetical order: %q should come before %q", curr, prev)
 		}
 	}
+}
+
+func TestEndOfOptions(t *testing.T) {
+	t.Run("normal parse treats remaining args as positional", func(t *testing.T) {
+		app, err := Parse([]string{"--", "https://example.com"})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if app.URL == nil || app.URL.String() != "https://example.com" {
+			t.Fatalf("URL = %v, want https://example.com", app.URL)
+		}
+		if len(app.ExtraArgs) != 0 {
+			t.Fatalf("ExtraArgs = %v, want none", app.ExtraArgs)
+		}
+	})
+
+	t.Run("completion parse keeps remaining args as extra args", func(t *testing.T) {
+		app, err := Parse([]string{"--complete=bash", "--", "fetch", "--"})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if app.Complete != "bash" {
+			t.Fatalf("Complete = %q, want bash", app.Complete)
+		}
+		want := []string{"fetch", "--"}
+		if !slices.Equal(app.ExtraArgs, want) {
+			t.Fatalf("ExtraArgs = %v, want %v", app.ExtraArgs, want)
+		}
+		if app.URL != nil {
+			t.Fatalf("URL = %v, want nil", app.URL)
+		}
+	})
 }
 
 func TestWebSocketSchemeExclusives(t *testing.T) {


### PR DESCRIPTION
## Summary
- Treat `--` as a normal end-of-options marker unless completion mode is active
- Preserve the completion flow so `fetch --complete=bash -- ...` still forwards the remaining tokens into `ExtraArgs`
- Add regression tests for both normal request parsing and completion parsing

## Testing
- Added unit coverage for `fetch -- https://example.com`
- Added unit coverage for `fetch --complete=bash -- ...`
- `go test ./...`