### PR TITLE
Fix SigV4 canonical path handling for escaped URLs

### DIFF
--- a/internal/aws/escape.go
+++ b/internal/aws/escape.go
@@ -2,35 +2,23 @@ package aws
 
 import (
 	"bytes"
-	"unicode/utf8"
 )
-
-// escapeURIPath writes the path-escaped version of uri to w.
-func escapeURIPath(w *bytes.Buffer, uri string) {
-	var n int
-	for i, c := range uri {
-		if validURIBytes[uri[i]] {
-			continue
-		}
-
-		w.WriteString(uri[n:i])
-		n = i + utf8.RuneLen(c)
-
-		var buf [utf8.UTFMax]byte
-		length := utf8.EncodeRune(buf[:], c)
-
-		for i := range length {
-			w.WriteByte('%')
-			encodeHexUpper(w, buf[i])
-		}
-	}
-	w.WriteString(uri[n:])
-}
 
 func encodeHexUpper(w *bytes.Buffer, b byte) {
 	const hexUpper = "0123456789ABCDEF"
 	w.WriteByte(hexUpper[b>>4])
 	w.WriteByte(hexUpper[b&0x0F])
+}
+
+func isHex(b byte) bool {
+	return ('0' <= b && b <= '9') || ('a' <= b && b <= 'f') || ('A' <= b && b <= 'F')
+}
+
+func toUpperHex(b byte) byte {
+	if 'a' <= b && b <= 'f' {
+		return b - ('a' - 'A')
+	}
+	return b
 }
 
 // mapping of valid uri path bytes.

--- a/internal/aws/sigv4.go
+++ b/internal/aws/sigv4.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"strings"
@@ -225,11 +226,7 @@ func buildCanonicalRequest(req *http.Request, headers []core.KeyVal[string], pay
 	buf.WriteString(req.Method)
 	buf.WriteByte('\n')
 
-	path := req.URL.Path
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
-	}
-	escapeURIPath(&buf, path)
+	writeCanonicalURIPath(&buf, req.URL)
 	buf.WriteByte('\n')
 
 	buf.WriteString(strings.ReplaceAll(req.URL.Query().Encode(), "+", "%20"))
@@ -254,6 +251,32 @@ func buildCanonicalRequest(req *http.Request, headers []core.KeyVal[string], pay
 	buf.WriteString(payload)
 
 	return buf.Bytes()
+}
+
+func writeCanonicalURIPath(buf *bytes.Buffer, u *url.URL) {
+	path := u.EscapedPath()
+	if path == "" {
+		path = "/"
+	} else if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	for i := 0; i < len(path); i++ {
+		b := path[i]
+		if b == '%' && i+2 < len(path) && isHex(path[i+1]) && isHex(path[i+2]) {
+			buf.WriteByte('%')
+			buf.WriteByte(toUpperHex(path[i+1]))
+			buf.WriteByte(toUpperHex(path[i+2]))
+			i += 2
+			continue
+		}
+		if validURIBytes[b] {
+			buf.WriteByte(b)
+			continue
+		}
+		buf.WriteByte('%')
+		encodeHexUpper(buf, b)
+	}
 }
 
 func buildStringToSign(datetime string, region, service string, req []byte) []byte {

--- a/internal/aws/sigv4_test.go
+++ b/internal/aws/sigv4_test.go
@@ -134,6 +134,42 @@ func TestGetSignedHeadersCanonicalizesHeaderValues(t *testing.T) {
 	}
 }
 
+func TestBuildCanonicalRequestUsesEscapedPath(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "escaped slash",
+			url:  "https://example.com/a%2Fb",
+			want: "/a%2Fb",
+		},
+		{
+			name: "escaped space",
+			url:  "https://example.com/space%20here",
+			want: "/space%20here",
+		},
+		{
+			name: "non-ascii segment",
+			url:  "https://example.com/café/日本",
+			want: "/caf%C3%A9/%E6%97%A5%E6%9C%AC",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", test.url, nil)
+
+			canonicalRequest := string(buildCanonicalRequest(req, nil, emptySha256))
+			lines := strings.SplitN(canonicalRequest, "\n", 3)
+			if lines[1] != test.want {
+				t.Fatalf("unexpected canonical path: got %q, want %q", lines[1], test.want)
+			}
+		})
+	}
+}
+
 func TestGetSignedHeadersUsesRequestHost(t *testing.T) {
 	req, _ := http.NewRequest("GET", "https://127.0.0.1", nil)
 	req.Host = "vhost.example"


### PR DESCRIPTION
## Summary
- Build the AWS SigV4 canonical URI from `URL.EscapedPath()` instead of the decoded `URL.Path`
- Preserve escaped octets like `%2F` and normalize percent-encoding case for canonical signing
- Remove the obsolete decoded-path escaping helper and add coverage for escaped slash, escaped space, and non-ASCII segments

## Testing
- `go test -v ./internal/aws`
- `staticcheck ./...`
- `go test -v ./...`