### PR TITLE
Fix EDITOR path parsing for unquoted paths with flags

### DIFF
--- a/internal/fetch/edit.go
+++ b/internal/fetch/edit.go
@@ -123,7 +123,31 @@ func parseEditorArgs(s string) []string {
 		return []string{s}
 	}
 
+	if args, ok := parseEditorExecutablePrefix(s); ok {
+		return args
+	}
+
 	return splitArgs(s)
+}
+
+func parseEditorExecutablePrefix(s string) ([]string, bool) {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] != ' ' && s[i] != '\t' {
+			continue
+		}
+		name := strings.TrimSpace(s[:i])
+		if name == "" {
+			continue
+		}
+		if _, err := exec.LookPath(name); err != nil {
+			continue
+		}
+
+		args := []string{name}
+		args = append(args, splitArgs(s[i+1:])...)
+		return args, true
+	}
+	return nil, false
 }
 
 // splitArgs splits a string into arguments, respecting single and double

--- a/internal/fetch/edit_test.go
+++ b/internal/fetch/edit_test.go
@@ -161,4 +161,33 @@ func TestFindEditor(t *testing.T) {
 			t.Errorf("findEditor() = %v, want %v", got, want)
 		}
 	})
+
+	t.Run("EDITOR with unquoted path containing spaces and flag", func(t *testing.T) {
+		t.Setenv("VISUAL", "")
+
+		dir := filepath.Join(t.TempDir(), "editor path")
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatalf("os.Mkdir() error = %v", err)
+		}
+
+		name := "edit-tool"
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		editor := filepath.Join(dir, name)
+		if err := os.WriteFile(editor, nil, 0o755); err != nil {
+			t.Fatalf("os.WriteFile() error = %v", err)
+		}
+
+		t.Setenv("EDITOR", editor+" --wait")
+
+		got, ok := findEditor()
+		if !ok {
+			t.Fatal("findEditor() returned false")
+		}
+		want := []string{editor, "--wait"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("findEditor() = %v, want %v", got, want)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Preserve unquoted executable paths that contain spaces when `$VISUAL`/`$EDITOR` includes trailing flags.
- Scan for the longest executable prefix from right to left before falling back to generic whitespace splitting.
- Add a regression test for `EDITOR="/tmp/editor path/edit-tool --wait"`.

## Testing
- `go test -v ./internal/fetch`
- `go test -v ./...`