### PR TITLE
Validate header names during config parsing

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -95,6 +95,28 @@ func TestEndOfOptions(t *testing.T) {
 	})
 }
 
+func TestHeaderFlag(t *testing.T) {
+	t.Run("allows empty value", func(t *testing.T) {
+		app, err := Parse([]string{"-H", "X-Test:", "https://example.com"})
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if len(app.Cfg.Headers) != 1 || app.Cfg.Headers[0].Key != "X-Test" || app.Cfg.Headers[0].Val != "" {
+			t.Fatalf("Headers = %+v, want X-Test with empty value", app.Cfg.Headers)
+		}
+	})
+
+	t.Run("rejects empty name", func(t *testing.T) {
+		_, err := Parse([]string{"-H", ": value", "https://example.com"})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "--header") {
+			t.Fatalf("error = %q, want --header", err.Error())
+		}
+	})
+}
+
 func TestWebSocketSchemeExclusives(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/http/httpguts"
+
 	"github.com/ryanfowler/fetch/internal/core"
 	"github.com/ryanfowler/fetch/internal/session"
 )
@@ -376,10 +378,12 @@ func (c *Config) ParseFormat(value string) error {
 }
 
 func (c *Config) ParseHeader(value string) error {
-	key, val, _ := core.CutTrimmed(value, ":")
+	key, val, ok := core.CutTrimmed(value, ":")
+	if !ok || key == "" || !httpguts.ValidHeaderFieldName(key) {
+		return core.NewValueError("header", value, "must be in the format NAME:VALUE with a valid non-empty header name", c.isFile)
+	}
 	c.Headers = append(c.Headers, core.KeyVal[string]{Key: key, Val: val})
 	return nil
-
 }
 
 func (c *Config) ParseHTTP(value string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,58 @@
 package config
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/ryanfowler/fetch/internal/core"
 )
+
+func TestParseHeader(t *testing.T) {
+	t.Run("valid header", func(t *testing.T) {
+		c := &Config{}
+		if err := c.ParseHeader("X-Test: value"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := []core.KeyVal[string]{{Key: "X-Test", Val: "value"}}
+		if !reflect.DeepEqual(c.Headers, want) {
+			t.Fatalf("headers = %+v, want %+v", c.Headers, want)
+		}
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		c := &Config{}
+		if err := c.ParseHeader("X-Test:"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := []core.KeyVal[string]{{Key: "X-Test", Val: ""}}
+		if !reflect.DeepEqual(c.Headers, want) {
+			t.Fatalf("headers = %+v, want %+v", c.Headers, want)
+		}
+	})
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "missing colon", value: "X-Test"},
+		{name: "empty name", value: ": value"},
+		{name: "malformed name", value: "Bad Header: value"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := &Config{}
+			if err := c.ParseHeader(test.value); err == nil {
+				t.Fatalf("expected error for %q", test.value)
+			}
+			if len(c.Headers) != 0 {
+				t.Fatalf("headers = %+v, want none", c.Headers)
+			}
+		})
+	}
+}
 
 func TestParseRetry(t *testing.T) {
 	t.Run("negative value", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Tighten `-H`/header parsing so it rejects missing colons, empty names, and malformed header field names before request execution
- Keep `Header:` valid so empty header values still parse
- Add unit coverage for config parsing and CLI flag parsing

## Testing
- `go test ./...`