### PR TITLE
Refactor ignored inspection warnings

### DIFF
--- a/main.go
+++ b/main.go
@@ -365,10 +365,14 @@ func writeCLIErr(p *core.Printer, err error) {
 	p.Flush()
 }
 
-// inspectDNS performs DNS resolution only and renders the resolved records.
-func inspectDNS(ctx context.Context, app *cli.App, handle *core.Handle) int {
-	p := handle.Stderr()
+type inspectionMode string
 
+const (
+	inspectionDNS inspectionMode = "--inspect-dns"
+	inspectionTLS inspectionMode = "--inspect-tls"
+)
+
+func ignoredInspectionFlags(app *cli.App, mode inspectionMode) []string {
 	var ignored []string
 	if app.Data != nil {
 		ignored = append(ignored, "--data/--json/--xml")
@@ -433,49 +437,64 @@ func inspectDNS(ctx context.Context, app *cli.App, handle *core.Handle) int {
 	if app.UnixSocket != "" {
 		ignored = append(ignored, "--unix")
 	}
-	if app.InspectTLS {
-		ignored = append(ignored, "--inspect-tls")
+
+	if mode == inspectionDNS {
+		if app.InspectTLS {
+			ignored = append(ignored, "--inspect-tls")
+		}
+		if app.Bearer != "" {
+			ignored = append(ignored, "--bearer")
+		}
+		if app.Basic != nil {
+			ignored = append(ignored, "--basic")
+		}
+		if app.Digest != nil {
+			ignored = append(ignored, "--digest")
+		}
+		if app.AWSSigv4 != nil {
+			ignored = append(ignored, "--aws-sigv4")
+		}
+		if len(app.Cfg.CACerts) > 0 {
+			ignored = append(ignored, "--ca-cert")
+		}
+		if app.Cfg.CertPath != "" {
+			ignored = append(ignored, "--cert")
+		}
+		if app.Cfg.KeyPath != "" {
+			ignored = append(ignored, "--key")
+		}
+		if app.Cfg.TLSMin != nil {
+			ignored = append(ignored, "--tls")
+		}
+		if app.Cfg.TLSMax != nil {
+			ignored = append(ignored, "--max-tls")
+		}
+		if getValue(app.Cfg.Insecure) {
+			ignored = append(ignored, "--insecure")
+		}
+		if app.Cfg.Format != core.FormatUnknown {
+			ignored = append(ignored, "--format")
+		}
+		if app.DryRun {
+			ignored = append(ignored, "--dry-run")
+		}
 	}
-	if app.Bearer != "" {
-		ignored = append(ignored, "--bearer")
+
+	return ignored
+}
+
+func warnIgnoredInspectionFlags(p *core.Printer, mode inspectionMode, ignored []string) {
+	if len(ignored) == 0 {
+		return
 	}
-	if app.Basic != nil {
-		ignored = append(ignored, "--basic")
-	}
-	if app.Digest != nil {
-		ignored = append(ignored, "--digest")
-	}
-	if app.AWSSigv4 != nil {
-		ignored = append(ignored, "--aws-sigv4")
-	}
-	if len(app.Cfg.CACerts) > 0 {
-		ignored = append(ignored, "--ca-cert")
-	}
-	if app.Cfg.CertPath != "" {
-		ignored = append(ignored, "--cert")
-	}
-	if app.Cfg.KeyPath != "" {
-		ignored = append(ignored, "--key")
-	}
-	if app.Cfg.TLSMin != nil {
-		ignored = append(ignored, "--tls")
-	}
-	if app.Cfg.TLSMax != nil {
-		ignored = append(ignored, "--max-tls")
-	}
-	if getValue(app.Cfg.Insecure) {
-		ignored = append(ignored, "--insecure")
-	}
-	if app.Cfg.Format != core.FormatUnknown {
-		ignored = append(ignored, "--format")
-	}
-	if app.DryRun {
-		ignored = append(ignored, "--dry-run")
-	}
-	if len(ignored) > 0 {
-		msg := "--inspect-dns ignores: " + strings.Join(ignored, ", ") + "\n"
-		core.WriteWarningMsg(p, msg)
-	}
+	core.WriteWarningMsg(p, string(mode)+" ignores: "+strings.Join(ignored, ", "))
+}
+
+// inspectDNS performs DNS resolution only and renders the resolved records.
+func inspectDNS(ctx context.Context, app *cli.App, handle *core.Handle) int {
+	p := handle.Stderr()
+
+	warnIgnoredInspectionFlags(p, inspectionDNS, ignoredInspectionFlags(app, inspectionDNS))
 
 	return dnsinspect.Inspect(ctx, p, &dnsinspect.Config{
 		DNSServer: app.Cfg.DNSServer,
@@ -525,72 +544,7 @@ func inspectTLS(ctx context.Context, app *cli.App, handle *core.Handle) int {
 		return 1
 	}
 
-	// Warn on incompatible flags.
-	var ignored []string
-	if app.Data != nil {
-		ignored = append(ignored, "--data/--json/--xml")
-	}
-	if len(app.Form) > 0 {
-		ignored = append(ignored, "--form")
-	}
-	if len(app.Multipart) > 0 {
-		ignored = append(ignored, "--multipart")
-	}
-	if app.GRPC {
-		ignored = append(ignored, "--grpc")
-	}
-	if app.GRPCDescribe != "" {
-		ignored = append(ignored, "--grpc-describe")
-	}
-	if app.GRPCList {
-		ignored = append(ignored, "--grpc-list")
-	}
-	if app.Output != "" {
-		ignored = append(ignored, "--output")
-	}
-	if app.RemoteName {
-		ignored = append(ignored, "--remote-name")
-	}
-	if getValue(app.Cfg.Copy) {
-		ignored = append(ignored, "--copy")
-	}
-	if app.Method != "" {
-		ignored = append(ignored, "--method")
-	}
-	if len(app.Cfg.Headers) > 0 {
-		ignored = append(ignored, "--header")
-	}
-	if len(app.Cfg.QueryParams) > 0 {
-		ignored = append(ignored, "--query")
-	}
-	if app.Edit {
-		ignored = append(ignored, "--edit")
-	}
-	if getValue(app.Cfg.Session) != "" {
-		ignored = append(ignored, "--session")
-	}
-	if getValue(app.Cfg.Retry) > 0 {
-		ignored = append(ignored, "--retry")
-	}
-	if len(app.Range) > 0 {
-		ignored = append(ignored, "--range")
-	}
-	if getValue(app.Cfg.Timing) {
-		ignored = append(ignored, "--timing")
-	}
-	if app.Cfg.Proxy != nil {
-		ignored = append(ignored, "--proxy")
-	}
-	if app.Discard {
-		ignored = append(ignored, "--discard")
-	}
-	if app.UnixSocket != "" {
-		ignored = append(ignored, "--unix")
-	}
-	if len(ignored) > 0 {
-		msg := "--inspect-tls ignores: " + strings.Join(ignored, ", ") + "\n"
-		core.WriteWarningMsg(p, msg)
-	}
+	warnIgnoredInspectionFlags(p, inspectionTLS, ignoredInspectionFlags(app, inspectionTLS))
 
 	// Parse client certificate for mTLS.
 	clientCert, err := app.Cfg.ClientCert()

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ryanfowler/fetch/internal/aws"
+	"github.com/ryanfowler/fetch/internal/cli"
+	"github.com/ryanfowler/fetch/internal/config"
+	"github.com/ryanfowler/fetch/internal/core"
+)
+
+func TestIgnoredInspectionFlags(t *testing.T) {
+	app := inspectionFlagTestApp(t)
+
+	common := []string{
+		"--data/--json/--xml",
+		"--form",
+		"--multipart",
+		"--grpc",
+		"--grpc-describe",
+		"--grpc-list",
+		"--output",
+		"--remote-name",
+		"--remote-header-name",
+		"--copy",
+		"--method",
+		"--header",
+		"--query",
+		"--edit",
+		"--session",
+		"--retry",
+		"--range",
+		"--timing",
+		"--proxy",
+		"--discard",
+		"--unix",
+	}
+
+	if got := ignoredInspectionFlags(app, inspectionTLS); !slices.Equal(got, common) {
+		t.Fatalf("ignoredInspectionFlags(inspectionTLS) = %v, want %v", got, common)
+	}
+
+	wantDNS := append(slices.Clone(common),
+		"--inspect-tls",
+		"--bearer",
+		"--basic",
+		"--digest",
+		"--aws-sigv4",
+		"--ca-cert",
+		"--cert",
+		"--key",
+		"--tls",
+		"--max-tls",
+		"--insecure",
+		"--format",
+		"--dry-run",
+	)
+	if got := ignoredInspectionFlags(app, inspectionDNS); !slices.Equal(got, wantDNS) {
+		t.Fatalf("ignoredInspectionFlags(inspectionDNS) = %v, want %v", got, wantDNS)
+	}
+}
+
+func TestWarnIgnoredInspectionFlagsDoesNotAddBlankLine(t *testing.T) {
+	p := core.TestPrinter(false)
+
+	warnIgnoredInspectionFlags(p, inspectionDNS, []string{"--timing"})
+
+	got := string(p.Bytes())
+	want := "warning: --inspect-dns ignores: --timing\n"
+	if got != want {
+		t.Fatalf("warning output = %q, want %q", got, want)
+	}
+}
+
+func inspectionFlagTestApp(t *testing.T) *cli.App {
+	t.Helper()
+
+	copyOutput := true
+	insecure := true
+	retry := 1
+	session := "session-name"
+	timing := true
+	tlsMax := uint16(tls.VersionTLS13)
+	tlsMin := uint16(tls.VersionTLS12)
+	proxyURL, err := url.Parse("http://proxy.test")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+
+	return &cli.App{
+		AWSSigv4:         &aws.Config{},
+		Basic:            &core.KeyVal[string]{Key: "user", Val: "pass"},
+		Bearer:           "token",
+		Data:             strings.NewReader("body"),
+		Digest:           &core.KeyVal[string]{Key: "user", Val: "pass"},
+		Discard:          true,
+		DryRun:           true,
+		Edit:             true,
+		Form:             []core.KeyVal[string]{{Key: "field", Val: "value"}},
+		GRPC:             true,
+		GRPCDescribe:     "service.Method",
+		GRPCList:         true,
+		InspectTLS:       true,
+		Method:           "POST",
+		Multipart:        []core.KeyVal[string]{{Key: "file", Val: "path"}},
+		Output:           "out.txt",
+		Range:            []string{"0-10"},
+		RemoteHeaderName: true,
+		RemoteName:       true,
+		UnixSocket:       "/tmp/fetch.sock",
+		Cfg: config.Config{
+			CACerts:     []*x509.Certificate{{}},
+			CertPath:    "client.pem",
+			Copy:        &copyOutput,
+			Format:      core.FormatOn,
+			Headers:     []core.KeyVal[string]{{Key: "X-Test", Val: "1"}},
+			Insecure:    &insecure,
+			KeyPath:     "client-key.pem",
+			Proxy:       proxyURL,
+			QueryParams: []core.KeyVal[string]{{Key: "q", Val: "1"}},
+			Retry:       &retry,
+			Session:     &session,
+			Timing:      &timing,
+			TLSMax:      &tlsMax,
+			TLSMin:      &tlsMin,
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- Factored the duplicated ignored-flag collection for `--inspect-dns` and `--inspect-tls` into a shared helper.
- Removed embedded trailing newlines from the warning message so `WriteWarningMsg` no longer emits an extra blank line.
- Added unit coverage for the shared ignore list and warning formatting.

## Testing
- `go test ./...`
- `staticcheck ./...`