### PR TITLE
Align ALPN output with TLS line in inspect-tls

### DIFF
--- a/internal/tlsinspect/tlsinspect.go
+++ b/internal/tlsinspect/tlsinspect.go
@@ -134,7 +134,7 @@ func render(p *core.Printer, cs *tls.ConnectionState) {
 	// ALPN negotiated protocol.
 	if cs.NegotiatedProtocol != "" {
 		p.WriteInfoPrefix()
-		p.WriteString("  ALPN: ")
+		p.WriteString("ALPN: ")
 		p.Set(core.Italic)
 		p.WriteString(cs.NegotiatedProtocol)
 		p.Reset()

--- a/internal/tlsinspect/tlsinspect.go
+++ b/internal/tlsinspect/tlsinspect.go
@@ -258,7 +258,7 @@ func renderSANs(p *core.Printer, leaf *x509.Certificate) {
 	p.WriteInfoPrefix()
 	p.WriteString("\n")
 	p.WriteInfoPrefix()
-	p.WriteString("  SANs: ")
+	p.WriteString("SANs: ")
 	p.Set(core.Italic)
 	p.WriteString(strings.Join(sans, ", "))
 	p.Reset()

--- a/internal/tlsinspect/tlsinspect_test.go
+++ b/internal/tlsinspect/tlsinspect_test.go
@@ -258,8 +258,11 @@ func TestRenderSANs(t *testing.T) {
 		renderSANs(p, leaf)
 		out := string(p.Bytes())
 
-		if !strings.Contains(out, "SANs:") {
-			t.Errorf("expected 'SANs:' in output, got:\n%s", out)
+		if !strings.Contains(out, "* SANs:") {
+			t.Errorf("expected '* SANs:' in output, got:\n%s", out)
+		}
+		if strings.Contains(out, "*   SANs:") {
+			t.Errorf("expected SANs line to align with Certificate chain line, got:\n%s", out)
 		}
 		if !strings.Contains(out, "example.com") {
 			t.Errorf("expected 'example.com' in output, got:\n%s", out)

--- a/internal/tlsinspect/tlsinspect_test.go
+++ b/internal/tlsinspect/tlsinspect_test.go
@@ -323,8 +323,11 @@ func TestRender(t *testing.T) {
 		if !strings.Contains(out, "TLS 1.3") {
 			t.Errorf("expected 'TLS 1.3' in output, got:\n%s", out)
 		}
-		if !strings.Contains(out, "ALPN: h2") {
-			t.Errorf("expected 'ALPN: h2' in output, got:\n%s", out)
+		if !strings.Contains(out, "* ALPN: h2") {
+			t.Errorf("expected '* ALPN: h2' in output, got:\n%s", out)
+		}
+		if strings.Contains(out, "*   ALPN: h2") {
+			t.Errorf("expected ALPN line to align with TLS line, got:\n%s", out)
 		}
 		if !strings.Contains(out, "Certificate chain") {
 			t.Errorf("expected 'Certificate chain' in output, got:\n%s", out)


### PR DESCRIPTION
## Summary
- Remove the extra leading spaces before the `ALPN` label in `--inspect-tls` output so it lines up with the TLS version line.
- Tighten the TLS inspect test to assert the corrected prefix formatting.

## Testing
- `go test -v ./internal/tlsinspect`