### PR TITLE
Fix exact 1 MiB response formatting boundary

### DIFF
--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -415,12 +415,12 @@ func formatResponse(ctx context.Context, r *Request, resp *http.Response) (io.Re
 		return resp.Body, nil
 	}
 
-	buf, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	buf, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes+1))
 	if err != nil {
 		return nil, err
 	}
-	if len(buf) >= maxBodyBytes {
-		// We've reached the limit of bytes read into memory, skip formatting.
+	if len(buf) > maxBodyBytes {
+		// We've read past the in-memory formatting limit, skip formatting.
 		return io.MultiReader(bytes.NewReader(buf), resp.Body), nil
 	}
 

--- a/internal/fetch/format_response_test.go
+++ b/internal/fetch/format_response_test.go
@@ -1,0 +1,66 @@
+package fetch
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ryanfowler/fetch/internal/core"
+)
+
+func TestFormatResponseFormatsExactMaxBodyBytes(t *testing.T) {
+	body := []byte(`{"a":"` + strings.Repeat("x", maxBodyBytes-len(`{"a":""}`)) + `"}`)
+	if len(body) != maxBodyBytes {
+		t.Fatalf("test body is %d bytes, want %d", len(body), maxBodyBytes)
+	}
+
+	got := readFormattedResponse(t, body)
+	if bytes.Equal(got, body) {
+		t.Fatal("response exactly at maxBodyBytes was returned unformatted")
+	}
+	if !bytes.HasPrefix(got, []byte("{\n  \"a\": \"")) {
+		t.Fatalf("response was not formatted as JSON, got prefix %q", got[:min(len(got), 16)])
+	}
+}
+
+func TestFormatResponseSkipsFormattingOverMaxBodyBytes(t *testing.T) {
+	body := []byte(`{"a":"` + strings.Repeat("x", maxBodyBytes-len(`{"a":""}`)) + `"}`)
+	body = append(body, ' ')
+	if len(body) != maxBodyBytes+1 {
+		t.Fatalf("test body is %d bytes, want %d", len(body), maxBodyBytes+1)
+	}
+
+	got := readFormattedResponse(t, body)
+	if !bytes.Equal(got, body) {
+		t.Fatal("response over maxBodyBytes should be returned unformatted")
+	}
+}
+
+func readFormattedResponse(t *testing.T, body []byte) []byte {
+	t.Helper()
+
+	resp := &http.Response{
+		Body:   io.NopCloser(bytes.NewReader(body)),
+		Header: http.Header{"Content-Type": {"application/json"}},
+		Request: &http.Request{
+			Method: "GET",
+		},
+	}
+	r := &Request{
+		Format:        core.FormatOn,
+		PrinterHandle: core.NewHandle(core.ColorOff),
+	}
+
+	reader, err := formatResponse(context.Background(), r, resp)
+	if err != nil {
+		t.Fatalf("formatResponse returned error: %v", err)
+	}
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading formatted response: %v", err)
+	}
+	return got
+}


### PR DESCRIPTION
## Summary
- Read one byte past the in-memory formatting limit so exact 1 MiB responses still go through formatting.
- Skip formatting only when the response body exceeds `maxBodyBytes`.
- Add regression tests for both the exact-limit and over-limit cases.

## Testing
- Added unit coverage for exact 1 MiB JSON formatting and 1 MiB+1 passthrough behavior.
- `go test ./internal/fetch`
- `go test ./...`