### PR TITLE
Make multipart bodies replayable for 307 and 308 redirects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ prettier -w .
 6. Response formatted based on Content-Type and output to stdout (optionally via pager)
 
 Retryable requests replay bodies by calling `req.GetBody` when available, reopening file-backed bodies directly when possible, and only spooling the original body to a temp file as a final fallback for one-shot streams. This avoids holding large uploads in memory and keeps retries working for closable bodies like `*os.File`.
+Multipart `-F` request bodies are produced by a replayable factory with a stable boundary; request construction sets `req.GetBody` so 307/308 redirects can resend them without relying on retry/digest spooling.
 
 ### Content Type Detection
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -630,6 +630,77 @@ func TestMain(t *testing.T) {
 		assertExitCode(t, 0, res)
 	})
 
+	t.Run("multipart 307 redirect", func(t *testing.T) {
+		t.Parallel()
+		var startHits, finalHits atomic.Int64
+		var server *httptest.Server
+		server = startServer(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/start":
+				startHits.Add(1)
+				http.Redirect(w, r, server.URL+"/final", http.StatusTemporaryRedirect)
+			case "/final":
+				finalHits.Add(1)
+				if r.Method != http.MethodPost {
+					w.WriteHeader(400)
+					io.WriteString(w, "invalid method: "+r.Method)
+					return
+				}
+				mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+				if err != nil {
+					w.WriteHeader(400)
+					io.WriteString(w, "cannot parse media type: "+err.Error())
+					return
+				}
+				if mediaType != "multipart/form-data" {
+					w.WriteHeader(400)
+					io.WriteString(w, "invalid media type: "+mediaType)
+					return
+				}
+
+				form, err := multipart.NewReader(r.Body, params["boundary"]).ReadForm(1 << 24)
+				if err != nil {
+					w.WriteHeader(400)
+					io.WriteString(w, "cannot read form: "+err.Error())
+					return
+				}
+				values := form.Value["key1"]
+				if len(form.Value) != 1 || len(values) != 1 || values[0] != "val1" {
+					w.WriteHeader(400)
+					io.WriteString(w, fmt.Sprintf("invalid form values: %+v", form.Value))
+					return
+				}
+				files := form.File["file1"]
+				if len(form.File) != 1 || len(files) != 1 {
+					w.WriteHeader(400)
+					io.WriteString(w, fmt.Sprintf("invalid form files: %+v", form.File))
+					return
+				}
+				header := files[0]
+				if header.Filename != filepath.Base(header.Filename) {
+					w.WriteHeader(400)
+					io.WriteString(w, "multipart filename includes path: "+header.Filename)
+					return
+				}
+				w.WriteHeader(200)
+			default:
+				w.WriteHeader(404)
+			}
+		})
+		defer server.Close()
+
+		tempFile := createTempFile(t, "redirected file")
+		defer os.Remove(tempFile)
+		res := runFetch(t, fetchPath, server.URL+"/start", "-m", "POST", "-F", "key1=val1", "-F", "file1=@"+tempFile)
+		assertExitCode(t, 0, res)
+		if got := startHits.Load(); got != 1 {
+			t.Fatalf("start hits = %d, want 1", got)
+		}
+		if got := finalHits.Load(); got != 1 {
+			t.Fatalf("final hits = %d, want 1", got)
+		}
+	})
+
 	t.Run("output", func(t *testing.T) {
 		t.Parallel()
 		const data = "this is the data"

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -437,7 +437,11 @@ func (c *Client) NewRequest(ctx context.Context, cfg RequestConfig) (*http.Reque
 		}
 		body = strings.NewReader(q.Encode())
 	case cfg.Multipart != nil:
-		body = cfg.Multipart
+		var err error
+		body, err = cfg.Multipart.Open()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If no scheme was provided, default to HTTPS except for loopback
@@ -458,6 +462,9 @@ func (c *Client) NewRequest(ctx context.Context, cfg RequestConfig) (*http.Reque
 	// Create the initial HTTP request.
 	req, err := http.NewRequestWithContext(ctx, cfg.Method, cfg.URL.String(), body)
 	if err != nil {
+		if closer, ok := body.(io.Closer); ok {
+			_ = closer.Close()
+		}
 		return nil, err
 	}
 
@@ -499,8 +506,10 @@ func (c *Client) NewRequest(ctx context.Context, cfg RequestConfig) (*http.Reque
 	// Set the content-length header if the body is a file.
 	setFileContentLength(req)
 
-	// Set GetBody for file bodies so the request can be replayed.
-	if f, ok := body.(*os.File); ok && f != os.Stdin {
+	// Set GetBody for replayable request bodies.
+	if cfg.Multipart != nil {
+		req.GetBody = cfg.Multipart.Open
+	} else if f, ok := body.(*os.File); ok && f != os.Stdin {
 		path := f.Name()
 		req.GetBody = func() (io.ReadCloser, error) {
 			return os.Open(path)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ryanfowler/fetch/internal/core"
+	imultipart "github.com/ryanfowler/fetch/internal/multipart"
+
 	"github.com/klauspost/compress/gzip"
 	"github.com/klauspost/compress/zstd"
 )
@@ -61,6 +64,50 @@ func TestIsLoopback(t *testing.T) {
 				t.Errorf("IsLoopback(%q) = %v, want %v", tt.host, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewRequestSetsGetBodyForMultipart(t *testing.T) {
+	rawURL, err := url.Parse("https://example.com/upload")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mp := imultipart.NewMultipart([]core.KeyVal[string]{
+		{Key: "field", Val: "value"},
+	})
+
+	req, err := NewClient(ClientConfig{}).NewRequest(context.Background(), RequestConfig{
+		Method:    http.MethodPost,
+		Multipart: mp,
+		URL:       rawURL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer req.Body.Close()
+
+	if req.GetBody == nil {
+		t.Fatal("GetBody is nil")
+	}
+	if ct := req.Header.Get("Content-Type"); ct != mp.ContentType() {
+		t.Fatalf("Content-Type = %q, want %q", ct, mp.ContentType())
+	}
+
+	initial, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replay.Close()
+	replayed, err := io.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(initial, replayed) {
+		t.Fatal("replayed multipart body differs from initial body")
 	}
 }
 

--- a/internal/fetch/retry_test.go
+++ b/internal/fetch/retry_test.go
@@ -402,11 +402,16 @@ func TestRetryableRequestSetsGetBodyForMultipartRedirect(t *testing.T) {
 	mp := imultipart.NewMultipart([]core.KeyVal[string]{
 		{Key: "field", Val: "value"},
 	})
-	req, err := http.NewRequest(http.MethodPost, server.URL+"/start", mp)
+	body, err := mp.Open()
+	if err != nil {
+		t.Fatalf("open multipart: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/start", body)
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
 	req.Header.Set("Content-Type", mp.ContentType())
+	req.GetBody = mp.Open
 
 	code, err := retryableRequest(
 		context.Background(),

--- a/internal/multipart/multipart.go
+++ b/internal/multipart/multipart.go
@@ -11,9 +11,10 @@ import (
 	"github.com/ryanfowler/fetch/internal/core"
 )
 
-// Multipart implements io.Reader for multipart data.
+// Multipart builds replayable multipart request bodies.
 type Multipart struct {
-	io.Reader
+	fields      []core.KeyVal[string]
+	boundary    string
 	contentType string
 }
 
@@ -23,38 +24,58 @@ func NewMultipart(kvs []core.KeyVal[string]) *Multipart {
 		return nil
 	}
 
+	mpw := multipart.NewWriter(io.Discard)
+	fields := append([]core.KeyVal[string](nil), kvs...)
+	boundary := mpw.Boundary()
+
+	return &Multipart{
+		fields:      fields,
+		boundary:    boundary,
+		contentType: mpw.FormDataContentType(),
+	}
+}
+
+// Open returns a fresh multipart request body stream.
+func (m *Multipart) Open() (io.ReadCloser, error) {
 	// Create a pipe and asynchronously write to it in a goroutine.
 	reader, writer := io.Pipe()
 	mpw := multipart.NewWriter(writer)
+	if err := mpw.SetBoundary(m.boundary); err != nil {
+		_ = reader.CloseWithError(err)
+		_ = writer.CloseWithError(err)
+		return nil, err
+	}
+
 	go func() {
+		var err error
 		defer func() {
-			mpw.Close()
-			writer.Close()
+			if err != nil {
+				_ = writer.CloseWithError(err)
+				return
+			}
+			if err = mpw.Close(); err != nil {
+				_ = writer.CloseWithError(err)
+				return
+			}
+			_ = writer.Close()
 		}()
 
-		for _, kv := range kvs {
+		for _, kv := range m.fields {
 			if !strings.HasPrefix(kv.Val, "@") {
-				err := mpw.WriteField(kv.Key, kv.Val)
-				if err != nil {
-					writer.CloseWithError(err)
+				if err = mpw.WriteField(kv.Key, kv.Val); err != nil {
 					return
 				}
 				continue
 			}
 
 			// Form part is a file.
-			err := writeFilePart(mpw, kv.Key, kv.Val[1:])
-			if err != nil {
-				writer.CloseWithError(err)
+			if err = writeFilePart(mpw, kv.Key, kv.Val[1:]); err != nil {
 				return
 			}
 		}
 	}()
 
-	return &Multipart{
-		Reader:      reader,
-		contentType: mpw.FormDataContentType(),
-	}
+	return reader, nil
 }
 
 // ContentType returns the Content-Type header value to use for this request.

--- a/internal/multipart/multipart_test.go
+++ b/internal/multipart/multipart_test.go
@@ -2,6 +2,7 @@ package multipart
 
 import (
 	"bytes"
+	"io"
 	"mime"
 	"mime/multipart"
 	"os"
@@ -139,15 +140,21 @@ func TestMultipart(t *testing.T) {
 
 			mp := NewMultipart(input)
 
-			var buf bytes.Buffer
-			_, err := buf.ReadFrom(mp)
+			body, err := mp.Open()
 			if err != nil {
-				t.Fatalf("unable to read from multipart: %s", err.Error())
+				t.Fatalf("unable to open multipart: %s", err.Error())
 			}
+			defer body.Close()
 
 			_, params, err := mime.ParseMediaType(mp.ContentType())
 			if err != nil {
 				t.Fatalf("unable to parse media type: %s", err.Error())
+			}
+
+			var buf bytes.Buffer
+			_, err = buf.ReadFrom(body)
+			if err != nil {
+				t.Fatalf("unable to read from multipart: %s", err.Error())
 			}
 
 			form, err := multipart.NewReader(&buf, params["boundary"]).ReadForm(1 << 24)
@@ -158,4 +165,36 @@ func TestMultipart(t *testing.T) {
 			test.fnPost(t, form)
 		})
 	}
+}
+
+func TestMultipartOpenReplaysWithStableBoundary(t *testing.T) {
+	mp := NewMultipart([]core.KeyVal[string]{
+		{Key: "field", Val: "value"},
+	})
+
+	first := readMultipartBody(t, mp)
+	second := readMultipartBody(t, mp)
+
+	if !bytes.Equal(first, second) {
+		t.Fatal("multipart Open produced different bodies")
+	}
+	if !bytes.Contains(first, []byte(`name="field"`)) || !bytes.Contains(first, []byte("value")) {
+		t.Fatalf("multipart body missing field: %q", first)
+	}
+}
+
+func readMultipartBody(t *testing.T, mp *Multipart) []byte {
+	t.Helper()
+
+	body, err := mp.Open()
+	if err != nil {
+		t.Fatalf("unable to open multipart: %s", err.Error())
+	}
+	defer body.Close()
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("unable to read multipart: %s", err.Error())
+	}
+	return raw
 }


### PR DESCRIPTION
## Summary
- Reworked `internal/multipart` into a replayable factory that stores fields and a stable boundary instead of streaming from a one-shot pipe.
- Updated request construction to open multipart bodies per request and set `req.GetBody` so Go can resend `-F` uploads on 307/308 redirects without relying on retry or digest spooling.
- Added coverage for replayability at the unit level and a CLI integration test that exercises `-F` through a 307 redirect.

## Testing
- `go test ./...`
- `staticcheck ./...`