### PR TITLE
Allow inspection modes to ignore request-only flags

### DIFF
--- a/internal/aws/sigv4.go
+++ b/internal/aws/sigv4.go
@@ -31,9 +31,36 @@ type Config struct {
 	Service   string
 }
 
+// MissingEnvVarError is returned when credentials are required for signing but
+// the corresponding environment variable is not set.
+type MissingEnvVarError struct {
+	EnvVar string
+}
+
+func (err *MissingEnvVarError) Error() string {
+	return "missing environment variable '" + err.EnvVar + "' required for option '--aws-sigv4'"
+}
+
+func (err *MissingEnvVarError) PrintTo(p *core.Printer) {
+	p.WriteString("missing environment variable '")
+	p.Set(core.Yellow)
+	p.WriteString(err.EnvVar)
+	p.Reset()
+
+	p.WriteString("' required for option '")
+	p.Set(core.Bold)
+	p.WriteString("--aws-sigv4")
+	p.Reset()
+	p.WriteString("'")
+}
+
 // Sign signs the provided HTTP request with the information from Config,
 // returning any error encountered.
 func Sign(req *http.Request, cfg Config, now time.Time) error {
+	if err := fillEnvCredentials(&cfg); err != nil {
+		return err
+	}
+
 	datetime := now.Format(datetimeFormat)
 	req.Header.Set("X-Amz-Date", datetime)
 
@@ -73,6 +100,22 @@ func Sign(req *http.Request, cfg Config, now time.Time) error {
 	sb.WriteString(signature)
 
 	req.Header.Set("Authorization", sb.String())
+	return nil
+}
+
+func fillEnvCredentials(cfg *Config) error {
+	if cfg.AccessKey == "" {
+		cfg.AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		if cfg.AccessKey == "" {
+			return &MissingEnvVarError{EnvVar: "AWS_ACCESS_KEY_ID"}
+		}
+	}
+	if cfg.SecretKey == "" {
+		cfg.SecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		if cfg.SecretKey == "" {
+			return &MissingEnvVarError{EnvVar: "AWS_SECRET_ACCESS_KEY"}
+		}
+	}
 	return nil
 }
 

--- a/internal/aws/sigv4_test.go
+++ b/internal/aws/sigv4_test.go
@@ -108,6 +108,40 @@ func TestSign(t *testing.T) {
 	}
 }
 
+func TestSignLoadsMissingCredentialsFromEnv(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+	req, _ := http.NewRequest("GET", "https://examplebucket.s3.amazonaws.com/test.txt", nil)
+	cfg := Config{
+		Region:  "us-east-1",
+		Service: "s3",
+	}
+	err := Sign(req, cfg, time.Date(2013, 05, 24, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("Sign() error = %v", err)
+	}
+
+	auth := req.Header.Get("Authorization")
+	if !strings.Contains(auth, "Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request") {
+		t.Fatalf("Authorization = %q, want env access key credential", auth)
+	}
+}
+
+func TestSignReportsMissingEnvCredentials(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	req, _ := http.NewRequest("GET", "https://examplebucket.s3.amazonaws.com/test.txt", nil)
+	err := Sign(req, Config{Region: "us-east-1", Service: "s3"}, time.Date(2013, 05, 24, 0, 0, 0, 0, time.UTC))
+	if err == nil {
+		t.Fatal("Sign() error = nil, want missing env error")
+	}
+	if !strings.Contains(err.Error(), "AWS_ACCESS_KEY_ID") {
+		t.Fatalf("Sign() error = %q, want AWS_ACCESS_KEY_ID", err.Error())
+	}
+}
+
 func TestGetSignedHeadersCanonicalizesHeaderValues(t *testing.T) {
 	req, _ := http.NewRequest("GET", "https://example.com", nil)
 	req.Header["X-Foo"] = []string{"  a  ", "  b  "}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -146,7 +146,7 @@ func (a *App) CLI() *CLI {
 				func() bool { return a.Cfg.AutoUpdate != nil }, a.Cfg.ParseAutoUpdate).
 				WithHidden(true),
 
-			// Custom: AWS signature V4 with env var lookups
+			// Custom: AWS signature V4
 			{
 				Long:        "aws-sigv4",
 				Args:        "REGION/SERVICE",
@@ -636,22 +636,13 @@ func (a *App) parseWSInteractiveFlag(value string) error {
 	return nil
 }
 
-// buildAWSConfig creates an AWS configuration from region and service,
-// reading credentials from environment variables.
+// buildAWSConfig creates an AWS configuration from region and service.
+// Credentials are loaded when the request is signed so inspection modes can
+// ignore --aws-sigv4 without requiring AWS environment variables.
 func buildAWSConfig(region, service string) (*aws.Config, error) {
-	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-	if accessKey == "" {
-		return nil, missingEnvVarErr("AWS_ACCESS_KEY_ID", "aws-sigv4")
-	}
-	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-	if secretKey == "" {
-		return nil, missingEnvVarErr("AWS_SECRET_ACCESS_KEY", "aws-sigv4")
-	}
 	return &aws.Config{
-		Region:    region,
-		Service:   service,
-		AccessKey: accessKey,
-		SecretKey: secretKey,
+		Region:  region,
+		Service: service,
 	}, nil
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -632,3 +632,41 @@ func TestDigestFlag(t *testing.T) {
 		}
 	})
 }
+
+func TestAWSSigv4CredentialsAreNotLoadedDuringParse(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	app, err := Parse([]string{"--aws-sigv4", "us-east-1/s3", "https://example.com"})
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if app.AWSSigv4 == nil {
+		t.Fatal("AWSSigv4 = nil, want config")
+	}
+	if app.AWSSigv4.Region != "us-east-1" || app.AWSSigv4.Service != "s3" {
+		t.Fatalf("AWSSigv4 = %#v, want region us-east-1 and service s3", app.AWSSigv4)
+	}
+	if app.AWSSigv4.AccessKey != "" || app.AWSSigv4.SecretKey != "" {
+		t.Fatalf("AWSSigv4 credentials = %q/%q, want empty", app.AWSSigv4.AccessKey, app.AWSSigv4.SecretKey)
+	}
+}
+
+func TestFromCurlAWSSigv4CredentialsAreNotLoadedDuringParse(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	app, err := Parse([]string{"--from-curl", `curl --aws-sigv4 "aws:amz:us-east-1:s3" https://example.com`})
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if app.AWSSigv4 == nil {
+		t.Fatal("AWSSigv4 = nil, want config")
+	}
+	if app.AWSSigv4.Region != "us-east-1" || app.AWSSigv4.Service != "s3" {
+		t.Fatalf("AWSSigv4 = %#v, want region us-east-1 and service s3", app.AWSSigv4)
+	}
+	if app.AWSSigv4.AccessKey != "" || app.AWSSigv4.SecretKey != "" {
+		t.Fatalf("AWSSigv4 credentials = %q/%q, want empty", app.AWSSigv4.AccessKey, app.AWSSigv4.SecretKey)
+	}
+}

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -144,39 +144,6 @@ func (err fileIsDirError) PrintTo(p *core.Printer) {
 	p.WriteString("' is a directory")
 }
 
-// MissingEnvVarError is returned when a required environment variable is not
-// set for a given flag.
-type MissingEnvVarError struct {
-	EnvVar string
-	Flag   string
-}
-
-func missingEnvVarErr(envVar, flag string) *MissingEnvVarError {
-	return &MissingEnvVarError{
-		EnvVar: envVar,
-		Flag:   flag,
-	}
-}
-
-func (err *MissingEnvVarError) Error() string {
-	return fmt.Sprintf("missing environment variable '%s' required for option '--%s'", err.EnvVar, err.Flag)
-}
-
-func (err *MissingEnvVarError) PrintTo(p *core.Printer) {
-	p.WriteString("missing environment variable '")
-	p.Set(core.Yellow)
-	p.WriteString(err.EnvVar)
-	p.Reset()
-
-	p.WriteString("' required for option '")
-	p.Set(core.Bold)
-	p.WriteString("--")
-	p.WriteString(err.Flag)
-	p.Reset()
-
-	p.WriteString("'")
-}
-
 type requiredFlagError struct {
 	flag     string
 	required []string

--- a/main.go
+++ b/main.go
@@ -114,6 +114,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Handle --inspect-dns: resolve the URL hostname only, no HTTP request.
+	if app.InspectDNS {
+		os.Exit(inspectDNS(ctx, app, handle))
+	}
+
+	// Handle --inspect-tls: perform TLS handshake only, no HTTP request.
+	if app.InspectTLS {
+		os.Exit(inspectTLS(ctx, app, handle))
+	}
+
 	// Respond with an error if a proxy is specified with HTTP/2 or higher.
 	if app.Cfg.Proxy != nil && app.Cfg.HTTP >= core.HTTP2 {
 		p := handle.Stderr()
@@ -126,16 +136,6 @@ func main() {
 		p := handle.Stderr()
 		writeCLIErr(p, errors.New("cannot use a unix socket with HTTP/3.0"))
 		os.Exit(1)
-	}
-
-	// Handle --inspect-dns: resolve the URL hostname only, no HTTP request.
-	if app.InspectDNS {
-		os.Exit(inspectDNS(ctx, app, handle))
-	}
-
-	// Handle --inspect-tls: perform TLS handshake only, no HTTP request.
-	if app.InspectTLS {
-		os.Exit(inspectTLS(ctx, app, handle))
 	}
 
 	// Respond with an error if WebSocket is used with HTTP/3.


### PR DESCRIPTION
## Summary
- Move `--inspect-dns` and `--inspect-tls` dispatch ahead of request-only compatibility checks so inspection runs are not blocked by ignored flags like `--proxy` or `--unix`
- Defer AWS SigV4 credential lookup until a request is actually signed, so inspection modes can accept `--aws-sigv4` without requiring AWS env vars
- Add tests covering inspection-flag handling and deferred AWS credential loading

## Testing
- `go test ./...`
- `staticcheck ./...`
- Local CLI validation confirmed `--inspect-dns --http 2 --proxy ... --aws-sigv4 ...` now warns that those flags are ignored instead of failing early