### PR TITLE
Fix content detection and validation edge cases

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -622,7 +622,8 @@ func (c *Config) ParseVerbosity(value string) error {
 
 func parseDurationSeconds(flag, value, usage string, isFile bool) (*time.Duration, error) {
 	secs, err := strconv.ParseFloat(value, 64)
-	if err != nil || secs < 0 || math.IsNaN(secs) || math.IsInf(secs, 0) {
+	maxSeconds := float64(math.MaxInt64) / float64(time.Second)
+	if err != nil || secs < 0 || secs > maxSeconds || math.IsNaN(secs) || math.IsInf(secs, 0) {
 		return nil, core.NewValueError(flag, value, usage, isFile)
 	}
 	return new(time.Duration(float64(time.Second) * secs)), nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -325,11 +326,11 @@ func (c *Config) ParseColor(value string) error {
 }
 
 func (c *Config) ParseConnectTimeout(value string) error {
-	secs, err := strconv.ParseFloat(value, 64)
-	if err != nil || secs < 0 {
-		return core.NewValueError("connect-timeout", value, "must be a non-negative number", c.isFile)
+	timeout, err := parseDurationSeconds("connect-timeout", value, "must be a non-negative number", c.isFile)
+	if err != nil {
+		return err
 	}
-	c.ConnectTimeout = new(time.Duration(float64(time.Second) * secs))
+	c.ConnectTimeout = timeout
 	return nil
 }
 
@@ -518,11 +519,11 @@ func (c *Config) ParseRetry(value string) error {
 }
 
 func (c *Config) ParseRetryDelay(value string) error {
-	secs, err := strconv.ParseFloat(value, 64)
-	if err != nil || secs < 0 {
-		return core.NewValueError("retry-delay", value, "must be a non-negative number", c.isFile)
+	delay, err := parseDurationSeconds("retry-delay", value, "must be a non-negative number", c.isFile)
+	if err != nil {
+		return err
 	}
-	c.RetryDelay = new(time.Duration(float64(time.Second) * secs))
+	c.RetryDelay = delay
 	return nil
 }
 
@@ -545,11 +546,11 @@ func (c *Config) ParseSilent(value string) error {
 }
 
 func (c *Config) ParseTimeout(value string) error {
-	secs, err := strconv.ParseFloat(value, 64)
-	if err != nil || secs < 0 {
-		return core.NewValueError("timeout", value, "must be a non-negative number", c.isFile)
+	timeout, err := parseDurationSeconds("timeout", value, "must be a non-negative number", c.isFile)
+	if err != nil {
+		return err
 	}
-	c.Timeout = new(time.Duration(float64(time.Second) * secs))
+	c.Timeout = timeout
 	return nil
 }
 
@@ -617,6 +618,14 @@ func (c *Config) ParseVerbosity(value string) error {
 	}
 	c.Verbosity = &v
 	return nil
+}
+
+func parseDurationSeconds(flag, value, usage string, isFile bool) (*time.Duration, error) {
+	secs, err := strconv.ParseFloat(value, 64)
+	if err != nil || secs < 0 || math.IsNaN(secs) || math.IsInf(secs, 0) {
+		return nil, core.NewValueError(flag, value, usage, isFile)
+	}
+	return new(time.Duration(float64(time.Second) * secs)), nil
 }
 
 func (c *Config) ClientCert() (*tls.Certificate, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -149,6 +149,26 @@ func TestParseDurationSecondsRejectsNonFiniteValues(t *testing.T) {
 	}
 }
 
+func TestParseDurationSecondsRejectsOverflow(t *testing.T) {
+	tests := []struct {
+		name  string
+		parse func(*Config, string) error
+	}{
+		{name: "connect-timeout", parse: (*Config).ParseConnectTimeout},
+		{name: "retry-delay", parse: (*Config).ParseRetryDelay},
+		{name: "timeout", parse: (*Config).ParseTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{}
+			if err := tt.parse(c, "1e100"); err == nil {
+				t.Fatalf("expected overflow error for %s", tt.name)
+			}
+		})
+	}
+}
+
 func TestParseRetryDelay(t *testing.T) {
 	t.Run("negative value", func(t *testing.T) {
 		c := &Config{}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -126,6 +126,29 @@ func TestParseConnectTimeout(t *testing.T) {
 	})
 }
 
+func TestParseDurationSecondsRejectsNonFiniteValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		parse func(*Config, string) error
+	}{
+		{name: "connect-timeout", parse: (*Config).ParseConnectTimeout},
+		{name: "retry-delay", parse: (*Config).ParseRetryDelay},
+		{name: "timeout", parse: (*Config).ParseTimeout},
+	}
+	values := []string{"NaN", "+Inf", "-Inf", "Inf"}
+
+	for _, tt := range tests {
+		for _, value := range values {
+			t.Run(tt.name+"/"+value, func(t *testing.T) {
+				c := &Config{}
+				if err := tt.parse(c, value); err == nil {
+					t.Fatalf("expected error for %s=%s", tt.name, value)
+				}
+			})
+		}
+	}
+}
+
 func TestParseRetryDelay(t *testing.T) {
 	t.Run("negative value", func(t *testing.T) {
 		c := &Config{}

--- a/internal/fetch/print.go
+++ b/internal/fetch/print.go
@@ -223,10 +223,12 @@ func colorForStatus(code int) core.Sequence {
 func isPrintable(r io.Reader) (bool, io.Reader, error) {
 	buf := make([]byte, 1024)
 	n, err := io.ReadFull(r, buf)
+	previewComplete := false
 	switch {
 	case err == io.EOF || err == io.ErrUnexpectedEOF:
 		buf = buf[:n]
 		r = bytes.NewReader(buf)
+		previewComplete = true
 	case err != nil:
 		return false, nil, err
 	default:
@@ -239,13 +241,14 @@ func isPrintable(r io.Reader) (bool, io.Reader, error) {
 
 	var safe, total int
 	for len(buf) > 0 {
-		c, size := utf8.DecodeRune(buf)
-		buf = buf[size:]
-		if c == utf8.RuneError && len(buf) < 4 {
+		if !previewComplete && !utf8.FullRune(buf) {
 			break
 		}
+		c, size := utf8.DecodeRune(buf)
+		buf = buf[size:]
 		total++
-		if unicode.IsPrint(c) || unicode.IsSpace(c) || c == '\x1b' {
+		validRune := c != utf8.RuneError || size > 1
+		if validRune && (unicode.IsPrint(c) || unicode.IsSpace(c) || c == '\x1b') {
 			safe++
 		}
 	}

--- a/internal/fetch/print_test.go
+++ b/internal/fetch/print_test.go
@@ -1,6 +1,8 @@
 package fetch
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -185,6 +187,24 @@ func TestPrintResponseHeadersPrefix(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestIsPrintableRejectsInvalidUTF8(t *testing.T) {
+	input := []byte{0xff, 0xfe, 0xfd}
+	ok, r, err := isPrintable(bytes.NewReader(input))
+	if err != nil {
+		t.Fatalf("isPrintable returned error: %v", err)
+	}
+	if ok {
+		t.Fatal("isPrintable accepted invalid UTF-8 bytes")
+	}
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading returned reader: %v", err)
+	}
+	if !bytes.Equal(got, input) {
+		t.Fatalf("returned reader = %v, want %v", got, input)
+	}
 }
 
 func mustParseURL(raw string) *url.URL {

--- a/internal/format/contenttype.go
+++ b/internal/format/contenttype.go
@@ -45,11 +45,12 @@ func GetContentType(headers http.Header) (ContentType, string) {
 		case "image":
 			return TypeImage, charset
 		case "application":
+			if subtype == "grpc" || strings.HasPrefix(subtype, "grpc+") {
+				return TypeGRPC, charset
+			}
 			switch subtype {
 			case "csv":
 				return TypeCSV, charset
-			case "grpc", "grpc+proto":
-				return TypeGRPC, charset
 			case "json":
 				return TypeJSON, charset
 			case "msgpack", "x-msgpack", "vnd.msgpack":

--- a/internal/format/contenttype_test.go
+++ b/internal/format/contenttype_test.go
@@ -171,6 +171,18 @@ func TestGetContentType(t *testing.T) {
 			wantType:    TypeCSV,
 			wantCharset: "shift_jis",
 		},
+		{
+			name:        "grpc json",
+			contentType: "application/grpc+json",
+			wantType:    TypeGRPC,
+			wantCharset: "",
+		},
+		{
+			name:        "grpc with charset",
+			contentType: "application/grpc+proto; charset=utf-8",
+			wantType:    TypeGRPC,
+			wantCharset: "utf-8",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tlsinspect/tlsinspect_test.go
+++ b/internal/tlsinspect/tlsinspect_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"errors"
 	"math/big"
 	"net"
 	"net/url"
@@ -129,28 +128,27 @@ func TestInspectHTTP3UsesQUICAndH3ALPN(t *testing.T) {
 	caCert, caKey := generateTestCACert(t)
 	serverCert, serverKey := generateTestCert(t, caCert, caKey, "quic-server")
 
-	ln, err := quic.ListenAddr("127.0.0.1:0", &tls.Config{
+	handshakeSeen := make(chan struct{}, 1)
+	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{{
 			Certificate: [][]byte{serverCert.Raw},
 			PrivateKey:  serverKey,
 			Leaf:        serverCert,
 		}},
 		NextProtos: []string{http3.NextProtoH3},
-	}, nil)
+		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			select {
+			case handshakeSeen <- struct{}{}:
+			default:
+			}
+			return nil, nil
+		},
+	}
+	ln, err := quic.ListenAddr("127.0.0.1:0", tlsConfig, nil)
 	if err != nil {
 		t.Fatalf("quic.ListenAddr() error = %v", err)
 	}
 	t.Cleanup(func() { ln.Close() })
-
-	acceptErr := make(chan error, 1)
-	go func() {
-		conn, err := ln.Accept(context.Background())
-		if err != nil {
-			acceptErr <- err
-			return
-		}
-		acceptErr <- conn.CloseWithError(0, "")
-	}()
 
 	u, err := url.Parse("https://" + ln.Addr().String())
 	if err != nil {
@@ -168,12 +166,9 @@ func TestInspectHTTP3UsesQUICAndH3ALPN(t *testing.T) {
 	}
 
 	select {
-	case err := <-acceptErr:
-		if err != nil && !errors.Is(err, net.ErrClosed) {
-			t.Fatalf("server accept error = %v", err)
-		}
+	case <-handshakeSeen:
 	case <-time.After(5 * time.Second):
-		t.Fatal("server did not accept QUIC connection")
+		t.Fatal("server did not observe QUIC TLS handshake")
 	}
 
 	out := string(p.Bytes())


### PR DESCRIPTION
## Summary

This PR collects five correctness fixes found during a focused bug-hunt pass:

- classify all `application/grpc+...` content types as gRPC so framed responses do not fall through to generic JSON/protobuf handling
- reject invalid UTF-8 in terminal output safety checks instead of treating short invalid byte sequences as printable
- reject `NaN` and infinite second values for duration-style config/CLI options
- reject finite duration values that overflow `time.Duration`
- stabilize the HTTP/3 TLS inspection test by observing the QUIC TLS handshake directly instead of waiting for an application-level accept

## Impact

Users get safer terminal output behavior, stricter validation for timeout-style options, and correct formatting behavior for gRPC responses that use non-protobuf content subtype suffixes. The test suite also avoids a race-mode flake in the HTTP/3 TLS inspection coverage.

## Root Cause

The gRPC detector handled only `application/grpc` and `application/grpc+proto`, while generic suffix checks later treated `application/grpc+json` as plain JSON. The terminal safety scan did not count invalid UTF-8 bytes as unsafe in short inputs. Duration parsing accepted special floating-point values and did not bound finite values before converting to `time.Duration`. The HTTP/3 test relied on listener `Accept`, which is not the right synchronization point for a TLS-only QUIC inspection that closes immediately after handshake state is captured.

## Validation

- `go test ./...`
- `staticcheck ./...`
- `go vet ./...`
- `go test -shuffle=on ./...`
- `go test -race ./...`
- `go test -race ./internal/tlsinspect -run TestInspectHTTP3UsesQUICAndH3ALPN -count=5`