### PR TITLE
Reduce formatter allocation overhead

### DIFF
--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use serde_json::Value;
 
 use crate::core::{Printer, Sequence};
@@ -32,8 +34,8 @@ pub fn format_ndjson(bytes: &[u8], color: bool) -> Result<Vec<u8>, serde_json::E
 fn write_value(out: &mut Printer, value: &Value, indent: usize) {
     match value {
         Value::Null => out.push_str("null"),
-        Value::Bool(value) => out.push_str(&value.to_string()),
-        Value::Number(value) => out.push_str(&value.to_string()),
+        Value::Bool(value) => write_bool(out, *value),
+        Value::Number(value) => write!(out, "{value}").expect("write to printer cannot fail"),
         Value::String(value) => write_json_string(out, value, &[Sequence::Green]),
         Value::Array(values) => write_array(out, values, indent),
         Value::Object(values) => write_object(out, values, indent),
@@ -43,8 +45,8 @@ fn write_value(out: &mut Printer, value: &Value, indent: usize) {
 fn write_line_value(out: &mut Printer, value: &Value) {
     match value {
         Value::Null => out.push_str("null"),
-        Value::Bool(value) => out.push_str(&value.to_string()),
-        Value::Number(value) => out.push_str(&value.to_string()),
+        Value::Bool(value) => write_bool(out, *value),
+        Value::Number(value) => write!(out, "{value}").expect("write to printer cannot fail"),
         Value::String(value) => write_json_string(out, value, &[Sequence::Green]),
         Value::Array(values) => write_line_array(out, values),
         Value::Object(values) => write_line_object(out, values),
@@ -122,10 +124,21 @@ fn write_object(out: &mut Printer, values: &serde_json::Map<String, Value>, inde
     out.push('}');
 }
 
+fn write_bool(out: &mut Printer, value: bool) {
+    out.push_str(if value { "true" } else { "false" });
+}
+
 fn write_json_string(out: &mut Printer, value: &str, color_codes: &[Sequence]) {
     out.push('"');
-    let escaped = escape_json_string(value);
-    out.write_styled(&escaped, color_codes);
+    if out.use_color() {
+        for code in color_codes {
+            out.set(*code);
+        }
+        write_escaped_json_string(out, value).expect("write to printer cannot fail");
+        out.reset();
+    } else {
+        write_escaped_json_string(out, value).expect("write to printer cannot fail");
+    }
     out.push('"');
 }
 
@@ -135,22 +148,28 @@ fn write_indent(out: &mut Printer, indent: usize) {
     }
 }
 
+#[cfg(test)]
 fn escape_json_string(value: &str) -> String {
     let mut out = String::new();
+    write_escaped_json_string(&mut out, value).expect("write to string cannot fail");
+    out
+}
+
+fn write_escaped_json_string(out: &mut impl std::fmt::Write, value: &str) -> std::fmt::Result {
     for c in value.chars() {
         match c {
-            '\u{08}' => out.push_str(r"\b"),
-            '\u{0c}' => out.push_str(r"\f"),
-            '\n' => out.push_str(r"\n"),
-            '\r' => out.push_str(r"\r"),
-            '\t' => out.push_str(r"\t"),
-            '"' => out.push_str(r#"\""#),
-            '\\' => out.push_str(r"\\"),
-            c if c < ' ' || c == '\u{7f}' => out.push_str(&format!(r"\u{:04x}", c as u32)),
-            c => out.push(c),
+            '\u{08}' => out.write_str(r"\b")?,
+            '\u{0c}' => out.write_str(r"\f")?,
+            '\n' => out.write_str(r"\n")?,
+            '\r' => out.write_str(r"\r")?,
+            '\t' => out.write_str(r"\t")?,
+            '"' => out.write_str(r#"\""#)?,
+            '\\' => out.write_str(r"\\")?,
+            c if c < ' ' || c == '\u{7f}' => write!(out, r"\u{:04x}", c as u32)?,
+            c => out.write_char(c)?,
         }
     }
-    out
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/format/msgpack.rs
+++ b/src/format/msgpack.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::fmt::Write as _;
 
 use base64::Engine;
 
@@ -54,7 +55,7 @@ impl<'a> MsgPackParser<'a> {
     fn write_value(&mut self, out: &mut String) -> Result<(), MsgPackError> {
         let marker = self.read_u8()?;
         match marker {
-            0x00..=0x7f => out.push_str(&marker.to_string()),
+            0x00..=0x7f => write!(out, "{marker}").expect("write to string cannot fail"),
             0x80..=0x8f => self.write_map(out, u32::from(marker & 0x0f))?,
             0x90..=0x9f => self.write_array(out, u32::from(marker & 0x0f))?,
             0xa0..=0xbf => self.write_string(out, usize::from(marker & 0x1f))?,
@@ -86,16 +87,26 @@ impl<'a> MsgPackParser<'a> {
                 let len = self.read_len_u32()?;
                 self.write_extension(out, len)?;
             }
-            0xca => out.push_str(&f64::from(f32::from_bits(self.read_u32()?)).to_string()),
-            0xcb => out.push_str(&f64::from_bits(self.read_u64()?).to_string()),
-            0xcc => out.push_str(&self.read_u8()?.to_string()),
-            0xcd => out.push_str(&self.read_u16()?.to_string()),
-            0xce => out.push_str(&self.read_u32()?.to_string()),
-            0xcf => out.push_str(&self.read_u64()?.to_string()),
-            0xd0 => out.push_str(&(self.read_u8()? as i8).to_string()),
-            0xd1 => out.push_str(&(self.read_u16()? as i16).to_string()),
-            0xd2 => out.push_str(&(self.read_u32()? as i32).to_string()),
-            0xd3 => out.push_str(&(self.read_u64()? as i64).to_string()),
+            0xca => write!(out, "{}", f64::from(f32::from_bits(self.read_u32()?)))
+                .expect("write to string cannot fail"),
+            0xcb => write!(out, "{}", f64::from_bits(self.read_u64()?))
+                .expect("write to string cannot fail"),
+            0xcc => write!(out, "{}", self.read_u8()?).expect("write to string cannot fail"),
+            0xcd => write!(out, "{}", self.read_u16()?).expect("write to string cannot fail"),
+            0xce => write!(out, "{}", self.read_u32()?).expect("write to string cannot fail"),
+            0xcf => write!(out, "{}", self.read_u64()?).expect("write to string cannot fail"),
+            0xd0 => {
+                write!(out, "{}", self.read_u8()? as i8).expect("write to string cannot fail");
+            }
+            0xd1 => {
+                write!(out, "{}", self.read_u16()? as i16).expect("write to string cannot fail");
+            }
+            0xd2 => {
+                write!(out, "{}", self.read_u32()? as i32).expect("write to string cannot fail");
+            }
+            0xd3 => {
+                write!(out, "{}", self.read_u64()? as i64).expect("write to string cannot fail");
+            }
             0xd4 => self.write_extension(out, 1)?,
             0xd5 => self.write_extension(out, 2)?,
             0xd6 => self.write_extension(out, 4)?,
@@ -129,7 +140,9 @@ impl<'a> MsgPackParser<'a> {
                 let len = self.read_u32()?;
                 self.write_map(out, len)?;
             }
-            0xe0..=0xff => out.push_str(&(marker as i8).to_string()),
+            0xe0..=0xff => {
+                write!(out, "{}", marker as i8).expect("write to string cannot fail");
+            }
         }
         Ok(())
     }
@@ -163,7 +176,7 @@ impl<'a> MsgPackParser<'a> {
     fn write_map_key(&mut self, out: &mut String) -> Result<(), MsgPackError> {
         let marker = self.read_u8()?;
         match marker {
-            0x00..=0x7f => write_json_string(out, marker.to_string().as_bytes()),
+            0x00..=0x7f => write_json_map_key_number(out, marker),
             0xa0..=0xbf => self.write_map_key_bytes(out, usize::from(marker & 0x1f))?,
             0xc4 => {
                 let len = usize::from(self.read_u8()?);
@@ -177,14 +190,14 @@ impl<'a> MsgPackParser<'a> {
                 let len = self.read_len_u32()?;
                 self.write_map_key_bytes(out, len)?;
             }
-            0xcc => write_json_string(out, self.read_u8()?.to_string().as_bytes()),
-            0xcd => write_json_string(out, self.read_u16()?.to_string().as_bytes()),
-            0xce => write_json_string(out, self.read_u32()?.to_string().as_bytes()),
-            0xcf => write_json_string(out, self.read_u64()?.to_string().as_bytes()),
-            0xd0 => write_json_string(out, (self.read_u8()? as i8).to_string().as_bytes()),
-            0xd1 => write_json_string(out, (self.read_u16()? as i16).to_string().as_bytes()),
-            0xd2 => write_json_string(out, (self.read_u32()? as i32).to_string().as_bytes()),
-            0xd3 => write_json_string(out, (self.read_u64()? as i64).to_string().as_bytes()),
+            0xcc => write_json_map_key_number(out, self.read_u8()?),
+            0xcd => write_json_map_key_number(out, self.read_u16()?),
+            0xce => write_json_map_key_number(out, self.read_u32()?),
+            0xcf => write_json_map_key_number(out, self.read_u64()?),
+            0xd0 => write_json_map_key_number(out, self.read_u8()? as i8),
+            0xd1 => write_json_map_key_number(out, self.read_u16()? as i16),
+            0xd2 => write_json_map_key_number(out, self.read_u32()? as i32),
+            0xd3 => write_json_map_key_number(out, self.read_u64()? as i64),
             0xd9 => {
                 let len = usize::from(self.read_u8()?);
                 self.write_map_key_bytes(out, len)?;
@@ -197,7 +210,7 @@ impl<'a> MsgPackParser<'a> {
                 let len = self.read_len_u32()?;
                 self.write_map_key_bytes(out, len)?;
             }
-            0xe0..=0xff => write_json_string(out, (marker as i8).to_string().as_bytes()),
+            0xe0..=0xff => write_json_map_key_number(out, marker as i8),
             _ => return Err(MsgPackError::new("unsupported MessagePack map key type")),
         }
         Ok(())
@@ -221,7 +234,7 @@ impl<'a> MsgPackParser<'a> {
     fn write_binary(&mut self, out: &mut String, len: usize) -> Result<(), MsgPackError> {
         let bytes = self.read_exact(len)?;
         out.push('"');
-        out.push_str(&base64::engine::general_purpose::STANDARD.encode(bytes));
+        base64::engine::general_purpose::STANDARD.encode_string(bytes, out);
         out.push('"');
         Ok(())
     }
@@ -230,9 +243,9 @@ impl<'a> MsgPackParser<'a> {
         let typ = self.read_u8()? as i8;
         let data = self.read_exact(len)?;
         out.push_str(r#"{"type":"#);
-        out.push_str(&typ.to_string());
+        write!(out, "{typ}").expect("write to string cannot fail");
         out.push_str(r#","data":""#);
-        out.push_str(&base64::engine::general_purpose::STANDARD.encode(data));
+        base64::engine::general_purpose::STANDARD.encode_string(data, out);
         out.push_str(r#""}"#);
         Ok(())
     }
@@ -306,10 +319,18 @@ fn write_json_string(out: &mut String, bytes: &[u8]) {
             '&' => out.push_str(r"\u0026"),
             '\u{2028}' => out.push_str(r"\u2028"),
             '\u{2029}' => out.push_str(r"\u2029"),
-            c if c < ' ' || c == '\u{7f}' => out.push_str(&format!(r"\u{:04x}", c as u32)),
+            c if c < ' ' || c == '\u{7f}' => {
+                write!(out, r"\u{:04x}", c as u32).expect("write to string cannot fail");
+            }
             c => out.push(c),
         }
     }
+    out.push('"');
+}
+
+fn write_json_map_key_number(out: &mut String, value: impl fmt::Display) {
+    out.push('"');
+    write!(out, "{value}").expect("write to string cannot fail");
     out.push('"');
 }
 

--- a/src/format/protobuf.rs
+++ b/src/format/protobuf.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::fmt::Write as _;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProtobufError(String);
@@ -29,7 +30,7 @@ fn format_message(mut buf: &[u8], out: &mut String, indent: usize) -> Result<(),
         }
 
         write_indent(out, indent);
-        out.push_str(&field_number.to_string());
+        write!(out, "{field_number}").expect("write to string cannot fail");
         out.push(':');
 
         match wire_type {
@@ -37,7 +38,7 @@ fn format_message(mut buf: &[u8], out: &mut String, indent: usize) -> Result<(),
                 let (value, n) = consume_varint(buf)?;
                 buf = &buf[n..];
                 out.push_str(" (varint) ");
-                out.push_str(&value.to_string());
+                write!(out, "{value}").expect("write to string cannot fail");
                 out.push('\n');
             }
             1 => {
@@ -49,7 +50,7 @@ fn format_message(mut buf: &[u8], out: &mut String, indent: usize) -> Result<(),
                 let value = u64::from_le_bytes(buf[..8].try_into().expect("slice length checked"));
                 buf = &buf[8..];
                 out.push_str(" (fixed64) ");
-                out.push_str(&format!("0x{value:016x}"));
+                write!(out, "0x{value:016x}").expect("write to string cannot fail");
                 out.push('\n');
             }
             2 => {
@@ -89,7 +90,7 @@ fn format_message(mut buf: &[u8], out: &mut String, indent: usize) -> Result<(),
                 let value = u32::from_le_bytes(buf[..4].try_into().expect("slice length checked"));
                 buf = &buf[4..];
                 out.push_str(" (fixed32) ");
-                out.push_str(&format!("0x{value:08x}"));
+                write!(out, "0x{value:08x}").expect("write to string cannot fail");
                 out.push('\n');
             }
             3 | 4 => return Err(ProtobufError("deprecated group wire type".to_string())),
@@ -175,7 +176,7 @@ fn write_protobuf_string(out: &mut String, value: &str) {
             '"' => out.push_str("\\\""),
             '\\' => out.push_str(r"\\"),
             ch if (ch as u32) < 0x20 || ch == '\u{7f}' => {
-                out.push_str(&format!("\\u{:04x}", ch as u32));
+                write!(out, "\\u{:04x}", ch as u32).expect("write to string cannot fail");
             }
             ch => out.push(ch),
         }
@@ -189,7 +190,7 @@ fn write_protobuf_bytes(out: &mut String, bytes: &[u8]) {
         if idx > 0 {
             out.push(' ');
         }
-        out.push_str(&format!("{byte:02x}"));
+        write!(out, "{byte:02x}").expect("write to string cannot fail");
     }
     out.push('>');
 }


### PR DESCRIPTION
## Summary
- Stream JSON string escaping directly into the printer and remove avoidable scalar `String` allocations.
- Replace tight-loop `to_string()`/`format!` calls in MessagePack and protobuf formatters with direct writes.
- Use base64 streaming writes in MessagePack instead of allocating intermediate encoded strings.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`