### PR TITLE
Run CI only for pull requests to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: ci
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
 


### PR DESCRIPTION
## Summary
- Removed the `push` trigger from the CI workflow.
- CI now runs only when a pull request targets `main`.

## Testing
- Not run (not requested)