### PR TITLE
Prefer filename* over filename in Content-Disposition parsing

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -416,7 +416,7 @@ fn parse_content_disposition_filename(value: &str) -> Option<String> {
         }
     }
 
-    filename.or(filename_star)
+    filename_star.or(filename)
 }
 
 fn split_parameters(value: &str) -> Vec<&str> {
@@ -671,6 +671,16 @@ mod tests {
         assert_eq!(
             parse_content_disposition_filename(r#"attachment; filename*=UTF-8''space%20name.txt"#),
             Some("space name.txt".to_string())
+        );
+    }
+
+    #[test]
+    fn content_disposition_filename_prefers_extended_value() {
+        assert_eq!(
+            parse_content_disposition_filename(
+                r#"attachment; filename="legacy.txt"; filename*=UTF-8''extended.txt"#
+            ),
+            Some("extended.txt".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- Fix `Content-Disposition` filename selection to prefer `filename*` when both parameters are present
- Add a regression test covering headers that include both legacy and extended filename parameters

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- Focused unit test for the new precedence case