### PR TITLE
Add AWS_SESSION_TOKEN support to SigV4 signing

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -122,6 +122,10 @@ AWS SigV4 signs the request by:
 3. Computing an HMAC-SHA256 signature
 4. Adding the signature to the `Authorization` header
 
+When `AWS_SESSION_TOKEN` is set for temporary STS or role credentials, fetch
+adds it as `x-amz-security-token` before signing so AWS can validate the
+temporary credential scope.
+
 ## Mutual TLS (mTLS)
 
 mTLS provides two-way authentication where both client and server present certificates.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -136,7 +136,7 @@ fetch --bearer mysecrettoken example.com
 
 ### `--aws-sigv4 REGION/SERVICE`
 
-Sign requests with AWS Signature V4. Requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+Sign requests with AWS Signature V4. Requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. Temporary credentials can also set `AWS_SESSION_TOKEN`.
 
 ```sh
 fetch --aws-sigv4 us-east-1/s3 s3.amazonaws.com/bucket/key
@@ -626,7 +626,7 @@ fetch --from-curl 'https://example.com'
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Request      | `-X`, `-H`, `-d`, `--data-raw`, `--data-binary`, `--data-urlencode`, `--json`, `-F`, `-T`, `-I`, `-G`                                         |
 | Auth         | `-u`, `--digest`, `--aws-sigv4`, `--oauth2-bearer`                                                                                            |
-| TLS          | `-k`, `--cacert`, `-E`/`--cert`, `--key`, `--tlsv1.x`, `--tls-max`                                                                             |
+| TLS          | `-k`, `--cacert`, `-E`/`--cert`, `--key`, `--tlsv1.x`, `--tls-max`                                                                            |
 | Output       | `-o`, `-O`, `-J`                                                                                                                              |
 | Network      | `-L`, `--max-redirs`, `-m`/`--max-time`, `--connect-timeout`, `-x`, `--unix-socket`, `--doh-url`, `--retry`, `--retry-delay`, `-r`            |
 | HTTP version | `-0`, `--http1.1`, `--http2`, `--http3`                                                                                                       |
@@ -681,14 +681,15 @@ fetch --update --dry-run
 
 ## Environment Variables
 
-| Variable                | Description                      |
-| ----------------------- | -------------------------------- |
-| `AWS_ACCESS_KEY_ID`     | AWS access key for `--aws-sigv4` |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret key for `--aws-sigv4` |
-| `VISUAL` / `EDITOR`     | Editor for `--edit` option       |
-| `HTTPS_PROXY`           | HTTPS proxy URL                  |
-| `HTTP_PROXY`            | HTTP proxy URL                   |
-| `NO_PROXY`              | Hosts to bypass proxy            |
+| Variable                | Description                                               |
+| ----------------------- | --------------------------------------------------------- |
+| `AWS_ACCESS_KEY_ID`     | AWS access key for `--aws-sigv4`                          |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key for `--aws-sigv4`                          |
+| `AWS_SESSION_TOKEN`     | AWS session token for temporary `--aws-sigv4` credentials |
+| `VISUAL` / `EDITOR`     | Editor for `--edit` option                                |
+| `HTTPS_PROXY`           | HTTPS proxy URL                                           |
+| `HTTP_PROXY`            | HTTP proxy URL                                            |
+| `NO_PROXY`              | Hosts to bypass proxy                                     |
 
 ## File References
 

--- a/src/auth/aws_sigv4.rs
+++ b/src/auth/aws_sigv4.rs
@@ -17,6 +17,7 @@ type HmacSha256 = Hmac<Sha256>;
 pub struct Config {
     pub access_key: String,
     pub secret_key: String,
+    pub session_token: Option<String>,
     pub region: String,
     pub service: String,
 }
@@ -26,6 +27,7 @@ impl Config {
         Self {
             access_key: String::new(),
             secret_key: String::new(),
+            session_token: None,
             region: region.into(),
             service: service.into(),
         }
@@ -77,6 +79,13 @@ pub fn sign(
         HeaderValue::from_str(&payload)
             .map_err(|err| AwsSigV4Error::InvalidHeaderValue(err.to_string()))?,
     );
+    if let Some(token) = config.session_token.as_deref() {
+        headers.insert(
+            HeaderName::from_static("x-amz-security-token"),
+            HeaderValue::from_str(token)
+                .map_err(|err| AwsSigV4Error::InvalidHeaderValue(err.to_string()))?,
+        );
+    }
 
     let signed_headers = signed_headers(url, headers)?;
     let canonical_request = build_canonical_request(method, url, &signed_headers, &payload);
@@ -131,6 +140,12 @@ fn fill_env_credentials(config: &Config) -> Result<Config, AwsSigV4Error> {
         if out.secret_key.is_empty() {
             return Err(AwsSigV4Error::MissingEnvVar("AWS_SECRET_ACCESS_KEY"));
         }
+    }
+    if out.session_token.is_none()
+        && let Ok(token) = std::env::var("AWS_SESSION_TOKEN")
+        && !token.is_empty()
+    {
+        out.session_token = Some(token);
     }
     Ok(out)
 }
@@ -436,6 +451,7 @@ mod tests {
             service: service.to_string(),
             access_key: "AKIAIOSFODNN7EXAMPLE".to_string(),
             secret_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".to_string(),
+            session_token: None,
         }
     }
 
@@ -534,6 +550,33 @@ mod tests {
         assert_eq!(
             headers.get(AUTHORIZATION).unwrap(),
             "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=34b48302e7b5fa45bde8084f4b7868a86f0a534bc59db6670ed5711ef69dc6f7"
+        );
+    }
+
+    #[test]
+    fn test_sign_includes_session_token_in_signed_headers() {
+        let url = Url::parse("https://examplebucket.s3.amazonaws.com/test.txt").unwrap();
+        let mut headers = HeaderMap::new();
+        let mut config = example_config("s3");
+        config.session_token = Some("session-token".to_string());
+
+        sign("GET", &url, &mut headers, None, &config, fixed_now(), false).unwrap();
+
+        assert_eq!(
+            headers
+                .get(HeaderName::from_static("x-amz-security-token"))
+                .unwrap(),
+            "session-token"
+        );
+        assert!(
+            headers
+                .get(AUTHORIZATION)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains(
+                    "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token"
+                )
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2232,6 +2232,8 @@ fn basic_bearer_and_aws_auth_headers() {
         if req.path == "/aws" {
             if !req.header("authorization").starts_with("AWS4-HMAC-SHA256 ")
                 || req.header("x-amz-date").is_empty()
+                || req.header("x-amz-security-token") != "session-token"
+                || !req.header("authorization").contains("x-amz-security-token")
             {
                 return TestResponse::status(400, "Bad Request", "bad aws auth");
             }
@@ -2251,6 +2253,7 @@ fn basic_bearer_and_aws_auth_headers() {
             env: vec![
                 ("AWS_ACCESS_KEY_ID".to_string(), "1234".to_string()),
                 ("AWS_SECRET_ACCESS_KEY".to_string(), "5678".to_string()),
+                ("AWS_SESSION_TOKEN".to_string(), "session-token".to_string()),
             ],
             ..Default::default()
         },


### PR DESCRIPTION
## Summary
- Add `session_token` to the AWS SigV4 config model and load `AWS_SESSION_TOKEN` from the environment when present
- Include `x-amz-security-token` in the signed header set before canonical signing so temporary STS and role credentials work correctly
- Update AWS authentication docs and CLI reference to mention temporary credentials
- Add unit and integration coverage for session-token signing behavior

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`