### PR TITLE
Replace `--no-encode` with `--compress` modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - Rust default config discovery on Windows honors `XDG_CONFIG_HOME/fetch/config` and `HOME/.config/fetch/config` before falling back to `AppData/fetch/config`; Windows mTLS integration fixtures use RSA test certificates to stay compatible with reqwest/rustls platform verification.
 - `--copy` tees decoded response bodies to the system clipboard for both stdout and output-file responses, using platform clipboard commands (`pbcopy`, `wl-copy`, `xclip`, `xsel`, or `clip.exe`) and skipping clipboard writes when the decoded body exceeds 1 MiB.
 - Image rendering defaults (`auto`) use built-in Rust decoders only; external adapters (`vips`, `magick`, `ffmpeg`) require `--image external` or `image = external` and run with bounded stdin/stdout/stderr and timeout handling.
+- Response compression negotiation is controlled by `--compress auto|gzip|zstd|off` or `compress = ...`; `auto` requests and decodes gzip/zstd, single-algorithm modes only request/decode that algorithm, and `off` leaves compressed bodies untouched.
 
 Retryable requests use replayable request bodies so retries and 307/308 redirects can resend data without holding unrelated state.
 Multipart `-F` request bodies are produced with a stable boundary so redirected requests preserve the original body shape.

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -279,12 +279,15 @@ insecure = true
 
 ## Compression
 
-### `--no-encode`
+### `--compress MODE`
 
-Disable automatic compression negotiation:
+Control automatic compression negotiation:
 
 ```sh
-fetch --no-encode example.com
+fetch --compress auto example.com
+fetch --compress gzip example.com
+fetch --compress zstd example.com
+fetch --compress off example.com
 ```
 
 By default, `fetch`:
@@ -292,7 +295,14 @@ By default, `fetch`:
 - Sends `Accept-Encoding: gzip, zstd` header
 - Automatically decompresses responses
 
-Disabling is useful when:
+Compression modes:
+
+- `auto` requests gzip or zstd and decompresses either response encoding
+- `gzip` requests and decompresses gzip only
+- `zstd` requests and decompresses zstd only
+- `off` sends no automatic `Accept-Encoding` header and leaves compressed response bodies untouched
+
+Using `off` is useful when:
 
 - Testing compression behavior
 - Server has compression bugs

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -451,12 +451,18 @@ fetch --grpc --http 2 http://localhost:50051/pkg.Svc/Method  # uses h2c
 
 ## Compression
 
-### `--no-encode`
+### `--compress MODE`
 
-Disable automatic gzip/zstd compression.
+Control response compression negotiation. Values: `auto`, `gzip`, `zstd`, `off`.
+
+- `auto` - request gzip or zstd compression (default)
+- `gzip` - request gzip compression only
+- `zstd` - request zstd compression only
+- `off` - disable automatic compression negotiation and decompression
 
 ```sh
-fetch --no-encode example.com
+fetch --compress gzip example.com
+fetch --compress off example.com
 ```
 
 ## Range Requests

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -452,19 +452,23 @@ ca-cert = /path/to/api-ca.crt
 - If the private key cannot be found, an error will be displayed
 - Encrypted private keys are not supported
 
-#### `no-encode`
+#### `compress`
 
-**Type**: Boolean
-**Default**: `false`
+**Type**: String
+**Default**: `auto`
 
-Disable automatic gzip and zstd compression for requests and responses.
+Control automatic compression negotiation and decompression.
 
 ```ini
-# Disable compression
-no-encode = true
+# Request gzip or zstd compression (default)
+compress = auto
 
-# Enable compression (default)
-no-encode = false
+# Request one algorithm only
+compress = gzip
+compress = zstd
+
+# Disable compression negotiation
+compress = off
 ```
 
 ### Session Options

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,54 @@ impl HttpVersion {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CompressionMode {
+    Auto,
+    Gzip,
+    Zstd,
+    Off,
+}
+
+impl CompressionMode {
+    pub const VALUES: &[&str] = &["auto", "gzip", "zstd", "off"];
+
+    pub fn from_cli(cli: &Cli) -> Self {
+        if cli.no_encode {
+            return Self::Off;
+        }
+        Self::from_value(cli.compress.as_deref().unwrap_or("auto"))
+            .expect("compression mode is validated by clap/config")
+    }
+
+    pub fn from_value(value: &str) -> Option<Self> {
+        match value {
+            "auto" => Some(Self::Auto),
+            "gzip" => Some(Self::Gzip),
+            "zstd" => Some(Self::Zstd),
+            "off" => Some(Self::Off),
+            _ => None,
+        }
+    }
+
+    pub fn accept_encoding(self) -> Option<&'static str> {
+        match self {
+            Self::Auto => Some("gzip, zstd"),
+            Self::Gzip => Some("gzip"),
+            Self::Zstd => Some("zstd"),
+            Self::Off => None,
+        }
+    }
+
+    pub fn decodes(self, encoding: &str) -> bool {
+        matches!(
+            (self, encoding),
+            (Self::Auto, "gzip" | "zstd" | "aws-chunked")
+                | (Self::Gzip, "gzip" | "aws-chunked")
+                | (Self::Zstd, "zstd" | "aws-chunked")
+        )
+    }
+}
+
 #[derive(Debug, Parser)]
 #[command(
     name = "fetch",
@@ -85,6 +133,16 @@ pub struct Cli {
 
     #[arg(long, value_name = "SHELL", help = "Output shell completion")]
     pub complete: Option<String>,
+
+    #[arg(
+        long,
+        value_name = "MODE",
+        value_parser = ["auto", "gzip", "zstd", "off"],
+        hide_possible_values = true,
+        conflicts_with = "no_encode",
+        help = "Compression mode [auto, gzip, zstd, off]"
+    )]
+    pub compress: Option<String>,
 
     #[arg(short = 'c', long, value_name = "PATH", help = "Path to config file")]
     pub config: Option<String>,
@@ -258,7 +316,7 @@ pub struct Cli {
     )]
     pub multipart: Vec<String>,
 
-    #[arg(long = "no-encode", help = "Avoid requesting gzip/zstd encoding")]
+    #[arg(long = "no-encode", hide = true)]
     pub no_encode: bool,
 
     #[arg(

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -54,6 +54,24 @@ const COMPLETE_VALUES: &[FlagValue] = &[
         value: "",
     },
 ];
+const COMPRESS_VALUES: &[FlagValue] = &[
+    FlagValue {
+        key: "auto",
+        value: "Request gzip or zstd",
+    },
+    FlagValue {
+        key: "gzip",
+        value: "Request gzip compression",
+    },
+    FlagValue {
+        key: "zstd",
+        value: "Request zstd compression",
+    },
+    FlagValue {
+        key: "off",
+        value: "Disable compression negotiation",
+    },
+];
 const FORMAT_VALUES: &[FlagValue] = &[
     FlagValue {
         key: "auto",
@@ -154,6 +172,14 @@ const FLAGS: &[Flag] = &[
         description: "Output shell completion",
         aliases: &[],
         values: COMPLETE_VALUES,
+    },
+    Flag {
+        short: None,
+        long: "compress",
+        args: "MODE",
+        description: "Control compression negotiation",
+        aliases: &[],
+        values: COMPRESS_VALUES,
     },
     flag(Some('c'), "config", "PATH", "Path to config file"),
     flag(
@@ -276,7 +302,6 @@ const FLAGS: &[Flag] = &[
         "NAME=[@]VALUE",
         "Send a multipart form body",
     ),
-    flag(None, "no-encode", "", "Avoid requesting gzip/zstd encoding"),
     flag(
         None,
         "no-pager",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,7 @@ struct ConfigValues {
     ca_cert: Vec<String>,
     cert: Option<String>,
     color: Option<String>,
+    compress: Option<String>,
     connect_timeout: Option<f64>,
     copy: Option<bool>,
     dns_server: Option<String>,
@@ -24,7 +25,6 @@ struct ConfigValues {
     key: Option<String>,
     max_tls: Option<String>,
     min_tls: Option<String>,
-    no_encode: Option<bool>,
     no_pager: Option<bool>,
     proxy: Option<String>,
     query: Vec<String>,
@@ -47,10 +47,10 @@ struct ConfigFile {
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct CliConfigSources {
+    compress: bool,
     copy: bool,
     ignore_status: bool,
     insecure: bool,
-    no_encode: bool,
     no_pager: bool,
     silent: bool,
     timing: bool,
@@ -60,10 +60,10 @@ struct CliConfigSources {
 impl CliConfigSources {
     fn capture(cli: &Cli) -> Self {
         Self {
+            compress: cli.compress.is_some() || cli.no_encode,
             copy: cli.copy,
             ignore_status: cli.ignore_status,
             insecure: cli.insecure,
-            no_encode: cli.no_encode,
             no_pager: cli.no_pager,
             silent: cli.silent,
             timing: cli.timing,
@@ -101,6 +101,9 @@ pub fn validate(cli: &Cli) -> Result<(), FetchError> {
     }
     if let Some(value) = cli.image.as_deref() {
         validate_cli_choice("image", value, &["auto", "external", "off"])?;
+    }
+    if let Some(value) = cli.compress.as_deref() {
+        validate_cli_choice("compress", value, crate::cli::CompressionMode::VALUES)?;
     }
     if let Some(value) = cli.proxy.as_deref() {
         validate_proxy_value(value).map_err(|usage| {
@@ -179,6 +182,9 @@ fn apply_file(cli: &mut Cli, file: &ConfigFile, sources: CliConfigSources) {
     if cli.color.is_none() {
         cli.color = values.color;
     }
+    if cli.compress.is_none() && !sources.compress {
+        cli.compress = values.compress;
+    }
     if cli.connect_timeout.is_none() {
         cli.connect_timeout = values.connect_timeout;
     }
@@ -212,9 +218,6 @@ fn apply_file(cli: &mut Cli, file: &ConfigFile, sources: CliConfigSources) {
     }
     if cli.min_tls.is_none() && cli.tls.is_none() {
         cli.min_tls = values.min_tls;
-    }
-    if !sources.no_encode {
-        cli.no_encode = values.no_encode.unwrap_or(false);
     }
     if !sources.no_pager {
         cli.no_pager = values.no_pager.unwrap_or(false);
@@ -341,6 +344,16 @@ fn set_value(
             validate_choice(path, line_num, "color", value, &["auto", "off", "on"])?;
             config.color = Some(value.to_string());
         }
+        "compress" => {
+            validate_choice(
+                path,
+                line_num,
+                "compress",
+                value,
+                crate::cli::CompressionMode::VALUES,
+            )?;
+            config.compress = Some(value.to_string());
+        }
         "connect-timeout" => {
             config.connect_timeout = Some(parse_duration_seconds(
                 path,
@@ -409,7 +422,8 @@ fn set_value(
             config.min_tls = Some(value.to_string());
         }
         "no-encode" => {
-            config.no_encode = Some(parse_bool_value(path, line_num, "no-encode", value)?);
+            let no_encode = parse_bool_value(path, line_num, "no-encode", value)?;
+            config.compress = Some(if no_encode { "off" } else { "auto" }.to_string());
         }
         "no-pager" => {
             config.no_pager = Some(parse_bool_value(path, line_num, "no-pager", value)?);
@@ -907,6 +921,7 @@ impl ConfigValues {
         self.ca_cert.extend(higher.ca_cert.iter().cloned());
         choose(&mut self.cert, &higher.cert);
         choose(&mut self.color, &higher.color);
+        choose(&mut self.compress, &higher.compress);
         choose(&mut self.connect_timeout, &higher.connect_timeout);
         choose(&mut self.copy, &higher.copy);
         choose(&mut self.dns_server, &higher.dns_server);
@@ -919,7 +934,6 @@ impl ConfigValues {
         choose(&mut self.key, &higher.key);
         choose(&mut self.max_tls, &higher.max_tls);
         choose(&mut self.min_tls, &higher.min_tls);
-        choose(&mut self.no_encode, &higher.no_encode);
         choose(&mut self.no_pager, &higher.no_pager);
         choose(&mut self.proxy, &higher.proxy);
         self.query.extend(higher.query.iter().cloned());
@@ -1066,6 +1080,7 @@ mod tests {
             &path,
             "
               timeout = 10
+              compress = zstd
               connect-timeout = 0.5
               retry = 2
               retry-delay = 0
@@ -1083,6 +1098,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(file.global.timeout, Some(10.0));
+        assert_eq!(file.global.compress.as_deref(), Some("zstd"));
         assert_eq!(file.global.connect_timeout, Some(0.5));
         assert_eq!(file.global.retry, Some(2));
         assert_eq!(file.global.retry_delay, Some(0.0));
@@ -1135,6 +1151,26 @@ mod tests {
 
         assert!(err.contains("line 1"));
         assert!(err.contains("invalid value 'nope' for option 'format'"));
+    }
+
+    #[test]
+    fn parse_file_rejects_invalid_compress_value() {
+        let path = PathBuf::from("test/config");
+        let err = parse_file(&path, "compress = brotli\n").unwrap_err();
+
+        assert!(err.contains("line 1"));
+        assert!(err.contains("invalid value 'brotli' for option 'compress'"));
+        assert!(err.contains("must be one of [auto, gzip, zstd, off]"));
+    }
+
+    #[test]
+    fn parse_file_maps_legacy_no_encode_to_compress_mode() {
+        let path = PathBuf::from("test/config");
+        let file = parse_file(&path, "no-encode = true\n").unwrap();
+        assert_eq!(file.global.compress.as_deref(), Some("off"));
+
+        let file = parse_file(&path, "no-encode = false\n").unwrap();
+        assert_eq!(file.global.compress.as_deref(), Some("auto"));
     }
 
     #[test]
@@ -1443,6 +1479,7 @@ mod tests {
             &path,
             "
               color = on
+              compress = zstd
               format = on
               retry = 2
               retry-delay = 0.5
@@ -1453,6 +1490,8 @@ mod tests {
             "fetch",
             "--color",
             "off",
+            "--compress",
+            "gzip",
             "--format",
             "off",
             "--retry",
@@ -1467,6 +1506,7 @@ mod tests {
         apply_file(&mut cli, &file, sources);
 
         assert_eq!(cli.color.as_deref(), Some("off"));
+        assert_eq!(cli.compress.as_deref(), Some("gzip"));
         assert_eq!(cli.format.as_deref(), Some("off"));
         assert_eq!(cli.retry, Some(0));
         assert_eq!(cli.retry_delay, Some(1.0));

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -27,7 +27,7 @@ use url::Url;
 
 use crate::auth::aws_sigv4;
 use crate::auth::digest;
-use crate::cli::{Cli, HttpVersion};
+use crate::cli::{Cli, CompressionMode, HttpVersion};
 use crate::core;
 use crate::error::{FetchError, write_error_with_color, write_warning_with_color};
 use crate::format::content_type::{self, ContentType};
@@ -145,7 +145,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
         apply_headers(&mut headers, &cli.headers)?;
     }
     apply_ranges(&mut headers, &cli.ranges);
-    let encoding_requested = apply_accept_encoding(&mut headers, cli, &method);
+    let compression = apply_accept_encoding(&mut headers, cli, &method);
     let mut body = request_body(cli)?;
     apply_body_content_type(&mut headers, &body);
     if cli.edit {
@@ -268,7 +268,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                 break finish_response(
                     cli,
                     response,
-                    encoding_requested,
+                    compression,
                     Some(timing),
                     grpc_method.as_ref(),
                 )
@@ -900,7 +900,7 @@ fn validate_proxy_for_http_version(
 async fn finish_response(
     cli: &Cli,
     response: Response,
-    encoding_requested: bool,
+    compression: CompressionMode,
     timing: Option<AttemptTiming>,
     grpc_method: Option<&prost_reflect::MethodDescriptor>,
 ) -> Result<i32, FetchError> {
@@ -911,18 +911,15 @@ async fn finish_response(
     let response_content_length = response
         .content_length()
         .and_then(|len| i64::try_from(len).ok());
-    let output_progress_total = output_progress_total_bytes(
-        encoding_requested,
-        &response_headers,
-        response_content_length,
-    );
+    let output_progress_total =
+        output_progress_total_bytes(compression, &response_headers, response_content_length);
     let method_is_head = cli.method().eq_ignore_ascii_case("HEAD");
     let response_timing = timing.and_then(AttemptTiming::response_timing);
     if cli.discard {
         let body_start = Instant::now();
         let (bytes, trailers) = read_response_body(response).await?;
         let body_duration = body_duration(method_is_head, bytes.as_ref(), body_start);
-        let _ = decode_response_bytes(encoding_requested, &response_headers, bytes.as_ref())?;
+        let _ = decode_response_bytes(compression, &response_headers, bytes.as_ref())?;
         print_timing(cli, response_timing, body_duration);
         let code = exit_code(status.as_u16(), cli.ignore_status);
         return Ok(check_grpc_status(cli, &response_headers, &trailers, code));
@@ -952,7 +949,7 @@ async fn finish_response(
         let streamed = stream_response_to_output(
             response,
             response_headers.clone(),
-            encoding_requested,
+            compression,
             path,
             cli.clobber,
             progress,
@@ -978,7 +975,7 @@ async fn finish_response(
         let body_start = Instant::now();
         let (bytes, trailers) = read_response_body(response).await?;
         let body_duration = body_duration(method_is_head, bytes.as_ref(), body_start);
-        let bytes = decode_response_bytes(encoding_requested, &response_headers, bytes.as_ref())?;
+        let bytes = decode_response_bytes(compression, &response_headers, bytes.as_ref())?;
         if cli.copy {
             handle_clipboard_outcome(cli, clipboard::copy_bytes(&bytes));
         }
@@ -1072,7 +1069,7 @@ struct StreamedOutput {
 async fn stream_response_to_output(
     response: Response,
     response_headers: HeaderMap,
-    encoding_requested: bool,
+    compression: CompressionMode,
     path: String,
     clobber: bool,
     progress: output::WriteProgress,
@@ -1090,7 +1087,7 @@ async fn stream_response_to_output(
     };
 
     let result = tokio::task::spawn_blocking(move || -> Result<StreamedOutput, FetchError> {
-        let mut reader = decoded_response_reader(reader, encoding_requested, &response_headers)?;
+        let mut reader = decoded_response_reader(reader, compression, &response_headers)?;
         let mut capture = copy.then(clipboard::Capture::default);
         let bytes_written = if let Some(capture) = capture.as_mut() {
             let mut reader = ClipboardTeeReader { reader, capture };
@@ -2178,24 +2175,28 @@ fn apply_ranges(headers: &mut HeaderMap, ranges: &[String]) {
     );
 }
 
-fn apply_accept_encoding(headers: &mut HeaderMap, cli: &Cli, method: &Method) -> bool {
-    if cli.no_encode || method == Method::HEAD || headers.contains_key(ACCEPT_ENCODING) {
-        return false;
+fn apply_accept_encoding(headers: &mut HeaderMap, cli: &Cli, method: &Method) -> CompressionMode {
+    let compression = CompressionMode::from_cli(cli);
+    let Some(accept_encoding) = compression.accept_encoding() else {
+        return CompressionMode::Off;
+    };
+    if method == Method::HEAD || headers.contains_key(ACCEPT_ENCODING) {
+        return CompressionMode::Off;
     }
-    headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("gzip, zstd"));
-    true
+    headers.insert(ACCEPT_ENCODING, HeaderValue::from_static(accept_encoding));
+    compression
 }
 
 fn decode_response_bytes(
-    encoding_requested: bool,
+    compression: CompressionMode,
     headers: &HeaderMap,
     bytes: &[u8],
 ) -> Result<Vec<u8>, FetchError> {
-    if !encoding_requested {
+    if compression == CompressionMode::Off {
         return Ok(bytes.to_vec());
     }
 
-    let Some(encodings) = content_encoding_decoders(headers) else {
+    let Some(encodings) = content_encoding_decoders(headers, compression) else {
         return Ok(bytes.to_vec());
     };
 
@@ -2213,18 +2214,18 @@ fn decode_response_bytes(
 
 fn decoded_response_reader<R>(
     reader: R,
-    encoding_requested: bool,
+    compression: CompressionMode,
     headers: &HeaderMap,
 ) -> Result<Box<dyn Read + Send>, FetchError>
 where
     R: Read + Send + 'static,
 {
     let mut reader: Box<dyn Read + Send> = Box::new(reader);
-    if !encoding_requested {
+    if compression == CompressionMode::Off {
         return Ok(reader);
     }
 
-    let Some(encodings) = content_encoding_decoders(headers) else {
+    let Some(encodings) = content_encoding_decoders(headers, compression) else {
         return Ok(reader);
     };
 
@@ -2250,12 +2251,13 @@ where
 }
 
 fn output_progress_total_bytes(
-    encoding_requested: bool,
+    compression: CompressionMode,
     headers: &HeaderMap,
     content_length: Option<i64>,
 ) -> Option<i64> {
-    if encoding_requested
-        && content_encoding_decoders(headers).is_some_and(|decoders| !decoders.is_empty())
+    if compression != CompressionMode::Off
+        && content_encoding_decoders(headers, compression)
+            .is_some_and(|decoders| !decoders.is_empty())
     {
         None
     } else {
@@ -2276,13 +2278,17 @@ impl<R: Read> Read for PrefixedReadError<R> {
     }
 }
 
-fn content_encoding_decoders(headers: &HeaderMap) -> Option<Vec<String>> {
+fn content_encoding_decoders(
+    headers: &HeaderMap,
+    compression: CompressionMode,
+) -> Option<Vec<String>> {
     let encodings = content_encodings(headers);
     let mut decoders = Vec::with_capacity(encodings.len());
     for encoding in encodings.into_iter().rev() {
-        match encoding.as_str() {
-            "gzip" | "zstd" | "aws-chunked" => decoders.push(encoding),
-            _ => return None,
+        if compression.decodes(&encoding) {
+            decoders.push(encoding);
+        } else {
+            return None;
         }
     }
     Some(decoders)
@@ -3555,6 +3561,63 @@ mod tests {
     }
 
     #[test]
+    fn apply_accept_encoding_uses_requested_compression_mode() {
+        for (args, expected_mode, expected_header) in [
+            (
+                vec!["fetch", "https://example.com"],
+                CompressionMode::Auto,
+                Some("gzip, zstd"),
+            ),
+            (
+                vec!["fetch", "--compress", "gzip", "https://example.com"],
+                CompressionMode::Gzip,
+                Some("gzip"),
+            ),
+            (
+                vec!["fetch", "--compress", "zstd", "https://example.com"],
+                CompressionMode::Zstd,
+                Some("zstd"),
+            ),
+            (
+                vec!["fetch", "--compress", "off", "https://example.com"],
+                CompressionMode::Off,
+                None,
+            ),
+        ] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            let mut headers = HeaderMap::new();
+
+            let mode = apply_accept_encoding(&mut headers, &cli, &Method::GET);
+
+            assert_eq!(mode, expected_mode);
+            assert_eq!(
+                headers
+                    .get(ACCEPT_ENCODING)
+                    .and_then(|value| value.to_str().ok()),
+                expected_header
+            );
+        }
+    }
+
+    #[test]
+    fn apply_accept_encoding_skips_head_and_custom_header() {
+        let cli = Cli::try_parse_from(["fetch", "https://example.com"]).unwrap();
+        let mut headers = HeaderMap::new();
+        assert_eq!(
+            apply_accept_encoding(&mut headers, &cli, &Method::HEAD),
+            CompressionMode::Off
+        );
+        assert!(!headers.contains_key(ACCEPT_ENCODING));
+
+        headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("br"));
+        assert_eq!(
+            apply_accept_encoding(&mut headers, &cli, &Method::GET),
+            CompressionMode::Off
+        );
+        assert_eq!(headers.get(ACCEPT_ENCODING).unwrap(), "br");
+    }
+
+    #[test]
     fn decodes_stacked_content_encoding_in_reverse_order() {
         let data = b"this is stacked encoded data";
         let body = zstd_encode(&gzip_encode(data));
@@ -3564,7 +3627,7 @@ mod tests {
             HeaderValue::from_static("gzip, zstd"),
         );
 
-        let decoded = decode_response_bytes(true, &headers, &body).unwrap();
+        let decoded = decode_response_bytes(CompressionMode::Auto, &headers, &body).unwrap();
 
         assert_eq!(decoded, data);
     }
@@ -3579,9 +3642,26 @@ mod tests {
             HeaderValue::from_static("aws-chunked, gzip"),
         );
 
-        let decoded = decode_response_bytes(true, &headers, &body).unwrap();
+        let decoded = decode_response_bytes(CompressionMode::Auto, &headers, &body).unwrap();
 
         assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn compression_mode_only_decodes_requested_algorithm() {
+        let data = b"this is gzip encoded data";
+        let body = gzip_encode(data);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::CONTENT_ENCODING,
+            HeaderValue::from_static("gzip"),
+        );
+
+        let decoded = decode_response_bytes(CompressionMode::Gzip, &headers, &body).unwrap();
+        assert_eq!(decoded, data);
+
+        let decoded = decode_response_bytes(CompressionMode::Zstd, &headers, &body).unwrap();
+        assert_eq!(decoded, body);
     }
 
     #[test]
@@ -3593,7 +3673,7 @@ mod tests {
             HeaderValue::from_static("br, gzip"),
         );
 
-        let decoded = decode_response_bytes(true, &headers, body).unwrap();
+        let decoded = decode_response_bytes(CompressionMode::Auto, &headers, body).unwrap();
 
         assert_eq!(decoded, body);
     }
@@ -3608,7 +3688,7 @@ mod tests {
             HeaderValue::from_static("gzip"),
         );
 
-        let decoded = decode_response_bytes(false, &headers, &body).unwrap();
+        let decoded = decode_response_bytes(CompressionMode::Off, &headers, &body).unwrap();
 
         assert_eq!(decoded, body);
     }
@@ -3621,14 +3701,17 @@ mod tests {
             HeaderValue::from_static("gzip"),
         );
 
-        assert_eq!(output_progress_total_bytes(true, &headers, Some(10)), None);
+        assert_eq!(
+            output_progress_total_bytes(CompressionMode::Auto, &headers, Some(10)),
+            None
+        );
     }
 
     #[test]
     fn output_progress_keeps_total_when_written_length_matches_wire_length() {
         let content_length = Some(10);
         assert_eq!(
-            output_progress_total_bytes(true, &HeaderMap::new(), content_length),
+            output_progress_total_bytes(CompressionMode::Auto, &HeaderMap::new(), content_length),
             content_length
         );
 
@@ -3638,7 +3721,7 @@ mod tests {
             HeaderValue::from_static("gzip"),
         );
         assert_eq!(
-            output_progress_total_bytes(false, &compressed_headers, content_length),
+            output_progress_total_bytes(CompressionMode::Off, &compressed_headers, content_length),
             content_length
         );
 
@@ -3648,7 +3731,11 @@ mod tests {
             HeaderValue::from_static("br"),
         );
         assert_eq!(
-            output_progress_total_bytes(true, &unsupported_headers, content_length),
+            output_progress_total_bytes(
+                CompressionMode::Auto,
+                &unsupported_headers,
+                content_length
+            ),
             content_length
         );
     }
@@ -3661,7 +3748,7 @@ mod tests {
             HeaderValue::from_static("gzip"),
         );
 
-        let err = decode_response_bytes(true, &headers, b"not gzip").unwrap_err();
+        let err = decode_response_bytes(CompressionMode::Auto, &headers, b"not gzip").unwrap_err();
 
         assert!(err.to_string().contains("gzip:"));
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3161,15 +3161,20 @@ fn additional_formatting_sse_charset_image_and_compression_cases() {
     gzip.write_all(b"this is the test data").unwrap();
     let gzip_body = gzip.finish().unwrap();
     let zstd_body = zstd::encode_all(&b"this is the test data"[..], 0).unwrap();
-    let compressed = TestServer::start(move |req| {
-        if req.header("accept-encoding") != "gzip, zstd" {
-            return TestResponse::ok("this is the test data");
-        }
-        if req.path == "/zstd" {
+    let compressed = TestServer::start(move |req| match req.header("accept-encoding").as_str() {
+        "gzip, zstd" if req.path == "/zstd" => {
             TestResponse::ok(zstd_body.clone()).header("Content-Encoding", "zstd")
-        } else {
+        }
+        "gzip, zstd" | "gzip" => {
             TestResponse::ok(gzip_body.clone()).header("Content-Encoding", "gzip")
         }
+        "zstd" => TestResponse::ok(zstd_body.clone()).header("Content-Encoding", "zstd"),
+        "" => TestResponse::ok("this is the test data"),
+        other => TestResponse::status(
+            400,
+            "Bad Request",
+            format!("unexpected accept-encoding: {other}"),
+        ),
     });
     let res = run_fetch(&[&compressed.url, "-v"]);
     assert_exit(&res, 0);
@@ -3179,10 +3184,27 @@ fn additional_formatting_sse_charset_image_and_compression_cases() {
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "this is the test data");
     assert!(res.stderr.contains("zstd"));
-    let res = run_fetch(&[&compressed.url, "-v", "--no-encode"]);
+    let res = run_fetch(&[&compressed.url, "-v", "--compress", "gzip"]);
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "this is the test data");
+    assert!(res.stderr.contains("gzip"));
+    let res = run_fetch(&[
+        &format!("{}/zstd", compressed.url),
+        "-v",
+        "--compress",
+        "zstd",
+    ]);
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "this is the test data");
+    assert!(res.stderr.contains("zstd"));
+    let res = run_fetch(&[&compressed.url, "-v", "--compress", "off"]);
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "this is the test data");
     assert!(!res.stderr.contains("gzip"));
+    assert!(!res.stderr.contains("zstd"));
+    let res = run_fetch(&[&compressed.url, "--compress", "bad"]);
+    assert_exit(&res, 1);
+    assert!(res.stderr.contains("invalid value 'bad'"));
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Added `--compress` with `auto`, `gzip`, `zstd`, and `off` modes for request compression negotiation.
- Wired compression mode through request headers, response decoding, and progress reporting.
- Updated config file support to use `compress = ...` while keeping legacy `no-encode` parsing mapped to the new behavior.
- Refreshed shell completion entries, docs, and agent notes to match the new flag.

## Testing
- Added unit coverage for CLI/config parsing and compression-mode-specific decode behavior.
- Expanded integration coverage for `--compress gzip`, `--compress zstd`, `--compress off`, and invalid values.
- Verified with `cargo fmt --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo test --all-features`, and `cargo test --all-features --test integration -- --test-threads=1`.