### PR TITLE
Add `--sort-headers` for sorted verbose header output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - `--copy` tees decoded response bodies to the system clipboard for both stdout and output-file responses, using platform clipboard commands (`pbcopy`, `wl-copy`, `xclip`, `xsel`, or `clip.exe`) and skipping clipboard writes when the decoded body exceeds 1 MiB.
 - Image rendering defaults (`auto`) use built-in Rust decoders only; external adapters (`vips`, `magick`, `ffmpeg`) require `--image external` or `image = external` and run with bounded stdin/stdout/stderr and timeout handling.
 - Response compression negotiation is controlled by `--compress auto|gzip|zstd|off` or `compress = ...`; `auto` requests and decodes gzip/zstd, single-algorithm modes only request/decode that algorithm, and `off` leaves compressed bodies untouched.
+- `--sort-headers` or `sort-headers = true` sorts displayed request/response headers alphabetically by name in verbose output without changing the actual request header order.
 
 Retryable requests use replayable request bodies so retries and 307/308 redirects can resend data without holding unrelated state.
 Multipart `-F` request bodies are produced with a stable boundary so redirected requests preserve the original body shape.

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -528,6 +528,7 @@ timing = true
 ```sh
 fetch -v example.com    # Response headers
 fetch -vv example.com   # Request + response headers with direction prefixes
+fetch -vv --sort-headers example.com  # Sort displayed headers by name
 fetch -vvv example.com  # DNS + TLS details with direction prefixes
 ```
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -489,9 +489,11 @@ Increase output verbosity. Can be stacked.
 - `-v` - Show response headers
 - `-vv` - Show request and response headers with `> ` / `< ` prefixes
 - `-vvv` - Show DNS and TLS details with `> ` / `< ` / `* ` prefixes
+- `--sort-headers` - Sort displayed request/response headers alphabetically by name
 
 ```sh
 fetch -v example.com
+fetch -vv --sort-headers example.com
 fetch -vvv example.com
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,6 +205,18 @@ verbosity = 2
 verbosity = 3
 ```
 
+#### `sort-headers`
+
+**Type**: Boolean
+**Default**: `false`
+
+Sort displayed request and response headers alphabetically by name. This only
+changes verbose output; request headers are still sent in their normal order.
+
+```ini
+sort-headers = true
+```
+
 ### Network Options
 
 #### `ca-cert`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,6 +150,9 @@ Show the outgoing request headers followed by the response:
 fetch -vv httpbin.org/json
 ```
 
+Add `--sort-headers` to sort the displayed request and response headers by
+name without changing the request itself.
+
 ```
 > GET /json HTTP/1.1
 > accept: application/json,application/vnd.msgpack,application/xml,image/webp,*/*

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -456,6 +456,9 @@ pub struct Cli {
     #[arg(short = 's', long, help = "Print only errors to stderr")]
     pub silent: bool,
 
+    #[arg(long = "sort-headers", help = "Sort displayed headers by name")]
+    pub sort_headers: bool,
+
     #[arg(
         short = 't',
         long,
@@ -604,6 +607,7 @@ mod tests {
             )
         );
         assert!(help.contains("--pager <MODE>                Control pager use [auto, on, off]"));
+        assert!(help.contains("--sort-headers                Sort displayed headers by name"));
         assert!(
             help.contains("-m, --method <METHOD>             HTTP method to use [default: GET]")
         );

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -385,6 +385,7 @@ const FLAGS: &[Flag] = &[
         "Use a named session for cookies",
     ),
     flag(Some('s'), "silent", "", "Print only errors to stderr"),
+    flag(None, "sort-headers", "", "Sort displayed headers by name"),
     flag(
         Some('t'),
         "timeout",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -33,6 +33,7 @@ struct ConfigValues {
     retry_delay: Option<f64>,
     session: Option<String>,
     silent: Option<bool>,
+    sort_headers: Option<bool>,
     timeout: Option<f64>,
     timing: Option<bool>,
     verbosity: Option<u8>,
@@ -53,6 +54,7 @@ struct CliConfigSources {
     insecure: bool,
     pager: bool,
     silent: bool,
+    sort_headers: bool,
     timing: bool,
     verbosity: bool,
 }
@@ -66,6 +68,7 @@ impl CliConfigSources {
             insecure: cli.insecure,
             pager: cli.pager.is_some(),
             silent: cli.silent,
+            sort_headers: cli.sort_headers,
             timing: cli.timing,
             verbosity: cli.verbose > 0,
         }
@@ -243,6 +246,9 @@ fn apply_file(cli: &mut Cli, file: &ConfigFile, sources: CliConfigSources) {
     }
     if !sources.silent {
         cli.silent = values.silent.unwrap_or(false);
+    }
+    if !sources.sort_headers {
+        cli.sort_headers = values.sort_headers.unwrap_or(false);
     }
     if cli.timeout.is_none() {
         cli.timeout = values.timeout;
@@ -473,6 +479,9 @@ fn set_value(
             config.session = Some(value.to_string());
         }
         "silent" => config.silent = Some(parse_bool_value(path, line_num, "silent", value)?),
+        "sort-headers" => {
+            config.sort_headers = Some(parse_bool_value(path, line_num, "sort-headers", value)?);
+        }
         "timeout" => {
             config.timeout = Some(parse_duration_seconds(
                 path,
@@ -956,6 +965,7 @@ impl ConfigValues {
         choose(&mut self.retry_delay, &higher.retry_delay);
         choose(&mut self.session, &higher.session);
         choose(&mut self.silent, &higher.silent);
+        choose(&mut self.sort_headers, &higher.sort_headers);
         choose(&mut self.timeout, &higher.timeout);
         choose(&mut self.timing, &higher.timing);
         choose(&mut self.verbosity, &higher.verbosity);
@@ -1106,6 +1116,7 @@ mod tests {
               pager = off
               insecure = true
               session = abc_123
+              sort-headers = true
               verbosity = 3
             ",
         )
@@ -1124,6 +1135,7 @@ mod tests {
         assert_eq!(file.global.pager.as_deref(), Some("off"));
         assert_eq!(file.global.insecure, Some(true));
         assert_eq!(file.global.session.as_deref(), Some("abc_123"));
+        assert_eq!(file.global.sort_headers, Some(true));
         assert_eq!(file.global.verbosity, Some(3));
     }
 
@@ -1538,6 +1550,7 @@ mod tests {
               no-encode = false
               pager = auto
               silent = false
+              sort-headers = false
               timing = false
               verbosity = 0
             ",
@@ -1552,6 +1565,7 @@ mod tests {
             "--pager",
             "off",
             "--silent",
+            "--sort-headers",
             "--timing",
             "-vv",
             "http://example.com",
@@ -1567,6 +1581,7 @@ mod tests {
         assert!(cli.no_encode);
         assert_eq!(cli.pager.as_deref(), Some("off"));
         assert!(cli.silent);
+        assert!(cli.sort_headers);
         assert!(cli.timing);
         assert_eq!(cli.verbose, 2);
     }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -714,29 +714,10 @@ fn print_request_metadata(
     printer.push_str(" ");
     printer.write_styled(request_protocol_label(http_version), &[core::Sequence::Dim]);
     printer.push_str("\n");
-    for (name, value) in header_lines(headers) {
-        if name.eq_ignore_ascii_case("host") {
-            continue;
-        }
-        if debug {
-            printer.write_request_prefix();
-        }
-        printer.write_styled(&name, &[core::Sequence::Bold, core::Sequence::Blue]);
-        printer.push_str(": ");
-        printer.push_str(&value);
-        printer.push_str("\n");
-    }
+    let mut lines = header_lines(headers);
+    lines.retain(|(name, _)| !name.eq_ignore_ascii_case("host"));
     if let Some((bytes, _)) = body {
-        if debug {
-            printer.write_request_prefix();
-        }
-        printer.write_styled(
-            "content-length",
-            &[core::Sequence::Bold, core::Sequence::Blue],
-        );
-        printer.push_str(": ");
-        printer.push_str(&bytes.len().to_string());
-        printer.push_str("\n");
+        lines.push(("content-length".to_string(), bytes.len().to_string()));
     }
     let host = headers
         .get(reqwest::header::HOST)
@@ -749,12 +730,19 @@ fn print_request_metadata(
             })
         });
     if let Some(host) = host {
+        lines.push(("host".to_string(), host));
+    }
+    if cli.sort_headers {
+        sort_header_lines(&mut lines);
+    }
+
+    for (name, value) in lines {
         if debug {
             printer.write_request_prefix();
         }
-        printer.write_styled("host", &[core::Sequence::Bold, core::Sequence::Blue]);
+        printer.write_styled(&name, &[core::Sequence::Bold, core::Sequence::Blue]);
         printer.push_str(": ");
-        printer.push_str(host.as_str());
+        printer.push_str(&value);
         printer.push_str("\n");
     }
     if debug {
@@ -853,6 +841,16 @@ fn header_lines(headers: &HeaderMap) -> Vec<(String, String)> {
         }
     }
     out
+}
+
+fn sort_header_lines(lines: &mut [(String, String)]) {
+    lines.sort_by(
+        |(left, _), (right, _)| match (left.starts_with(':'), right.starts_with(':')) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => left.cmp(right),
+        },
+    );
 }
 
 fn configure_http_version(
@@ -1548,7 +1546,11 @@ fn print_response_metadata(cli: &Cli, response: &Response) {
     printer.push_str("\n");
 
     if cli.verbose > 0 {
-        for (name, value) in header_lines(response.headers()) {
+        let mut lines = header_lines(response.headers());
+        if cli.sort_headers {
+            sort_header_lines(&mut lines);
+        }
+        for (name, value) in lines {
             if cli.verbose >= 2 {
                 printer.write_response_prefix();
             }
@@ -2749,6 +2751,28 @@ mod tests {
                 ("x-zeta".to_string(), "first".to_string()),
                 ("x-zeta".to_string(), "third".to_string()),
                 ("accept".to_string(), "second".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn sort_header_lines_orders_by_name_and_preserves_duplicates() {
+        let mut lines = vec![
+            ("x-zeta".to_string(), "first".to_string()),
+            ("accept".to_string(), "second".to_string()),
+            ("x-zeta".to_string(), "third".to_string()),
+            ("content-type".to_string(), "fourth".to_string()),
+        ];
+
+        sort_header_lines(&mut lines);
+
+        assert_eq!(
+            lines,
+            [
+                ("accept".to_string(), "second".to_string()),
+                ("content-type".to_string(), "fourth".to_string()),
+                ("x-zeta".to_string(), "first".to_string()),
+                ("x-zeta".to_string(), "third".to_string()),
             ]
         );
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2160,6 +2160,24 @@ fn verbosity_and_color_output() {
     assert!(res.stderr.contains("> user-agent"));
     assert!(res.stderr.contains("< x-custom-header"));
 
+    let sort_server = TestServer::start(|_| {
+        TestResponse::ok("sorted")
+            .header("X-Zeta", "last")
+            .header("Accept-Ranges", "bytes")
+            .header("X-Zeta", "duplicate")
+    });
+    let res = run_fetch(&[&sort_server.url, "-v", "--sort-headers"]);
+    assert_exit(&res, 0);
+    let accept = res.stderr.find("accept-ranges: bytes").unwrap();
+    let connection = res.stderr.find("connection: keep-alive").unwrap();
+    let content_length = res.stderr.find("content-length: 6").unwrap();
+    let zeta = res.stderr.find("x-zeta: last").unwrap();
+    let duplicate_zeta = res.stderr.find("x-zeta: duplicate").unwrap();
+    assert!(accept < connection);
+    assert!(connection < content_length);
+    assert!(content_length < zeta);
+    assert!(zeta < duplicate_zeta);
+
     let res = run_fetch(&[&server.url, "-vv", "--color", "on"]);
     assert_exit(&res, 0);
     assert!(res.stderr.contains("\x1b[1m\x1b[33mGET\x1b[0m"));
@@ -2216,6 +2234,30 @@ fn dry_run_prints_effective_request_without_network() {
     assert!(res.stderr.contains("host: localhost:3000\n"));
     assert!(res.stderr.contains("\n\n{\"key\":\"val1\"}"));
     assert!(!res.stderr.contains("> GET"));
+
+    let res = run_fetch(&[
+        "-j",
+        r#"{"key":"val1"}"#,
+        "-H",
+        "X-Zeta: last",
+        "localhost:3000",
+        "--dry-run",
+        "--sort-headers",
+    ]);
+    assert_exit(&res, 0);
+    let accept = res.stderr.find("accept: application/json").unwrap();
+    let accept_encoding = res.stderr.find("accept-encoding: gzip, zstd").unwrap();
+    let content_length = res.stderr.find("content-length: 14").unwrap();
+    let content_type = res.stderr.find("content-type: application/json").unwrap();
+    let host = res.stderr.find("host: localhost:3000").unwrap();
+    let user_agent = res.stderr.find("user-agent: fetch/").unwrap();
+    let zeta = res.stderr.find("x-zeta: last").unwrap();
+    assert!(accept < accept_encoding);
+    assert!(accept_encoding < content_length);
+    assert!(content_length < content_type);
+    assert!(content_type < host);
+    assert!(host < user_agent);
+    assert!(user_agent < zeta);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Added `--sort-headers` and `sort-headers = true` config support to sort displayed request and response headers alphabetically.
- Kept wire/request construction unchanged; sorting only affects rendered verbose and dry-run header output.
- Updated completion metadata, docs, and repo guidance to describe the new behavior.
- Added unit and integration coverage for sorted ordering and duplicate header preservation.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`