### PR TITLE
Add brotli compression negotiation and decoding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - Rust default config discovery on Windows honors `XDG_CONFIG_HOME/fetch/config` and `HOME/.config/fetch/config` before falling back to `AppData/fetch/config`; Windows mTLS integration fixtures use RSA test certificates to stay compatible with reqwest/rustls platform verification.
 - `--copy` tees decoded response bodies to the system clipboard for both stdout and output-file responses, using platform clipboard commands (`pbcopy`, `wl-copy`, `xclip`, `xsel`, or `clip.exe`) and skipping clipboard writes when the decoded body exceeds 1 MiB.
 - Image rendering defaults (`auto`) use built-in Rust decoders only; external adapters (`vips`, `magick`, `ffmpeg`) require `--image external` or `image = external` and run with bounded stdin/stdout/stderr and timeout handling.
-- Response compression negotiation is controlled by `--compress auto|gzip|zstd|off` or `compress = ...`; `auto` requests and decodes gzip/zstd, single-algorithm modes only request/decode that algorithm, and `off` leaves compressed bodies untouched.
+- Response compression negotiation is controlled by `--compress auto|br|gzip|zstd|off` or `compress = ...`; `brotli` is accepted as an alias for `br`, `auto` requests and decodes gzip/brotli/zstd, single-algorithm modes only request/decode that algorithm, and `off` leaves compressed bodies untouched.
 - `--sort-headers` or `sort-headers = true` sorts displayed request/response headers alphabetically by name in verbose output without changing the actual request header order.
 
 Retryable requests use replayable request bodies so retries and 307/308 redirects can resend data without holding unrelated state.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +229,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +396,7 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
+ "brotli",
  "compression-core",
  "flate2",
  "memchr",
@@ -637,6 +674,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "base64",
+ "brotli",
  "bytes",
  "clap",
  "cookie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ strip = true
 [dependencies]
 anyhow = "1"
 base64 = "0.22"
+brotli = "8.0.2"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 cookie = "0.18"
@@ -42,7 +43,7 @@ psl = "2"
 rand = "0.10"
 quick-xml = "0.40"
 quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-aws-lc-rs"] }
-reqwest = { version = "0.13", default-features = false, features = ["cookies", "gzip", "http2", "http3", "json", "multipart", "rustls-no-provider", "socks", "stream", "system-proxy", "zstd"] }
+reqwest = { version = "0.13", default-features = false, features = ["brotli", "cookies", "gzip", "http2", "http3", "json", "multipart", "rustls-no-provider", "socks", "stream", "system-proxy", "zstd"] }
 rustls = { version = "0.23", default-features = false, features = ["std", "aws-lc-rs", "tls12"] }
 rustls-native-certs = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A modern HTTP(S) client for the command line.
 - **WebSocket support** - Bidirectional WebSocket connections with automatic JSON formatting
 - **gRPC support** - Make gRPC calls with automatic reflection, discovery, and JSON-to-protobuf conversion
 - **Authentication** - Built-in support for Basic Auth, Bearer Token, AWS Signature V4, and mTLS
-- **Compression** - Automatic gzip and zstd response body decompression
+- **Compression** - Automatic gzip, brotli, and zstd response body decompression
 - **TLS inspection** - Inspect TLS certificate chains, expiry, SANs, and OCSP status
 - **DNS inspection** - Inspect hostname resolution, record families, TTLs, and resolver timing
 - **Timing waterfall** - Visualize request timing phases (DNS, TCP, TLS, TTFB, transfer) with a waterfall chart

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -285,6 +285,7 @@ Control automatic compression negotiation:
 
 ```sh
 fetch --compress auto example.com
+fetch --compress br example.com
 fetch --compress gzip example.com
 fetch --compress zstd example.com
 fetch --compress off example.com
@@ -292,12 +293,13 @@ fetch --compress off example.com
 
 By default, `fetch`:
 
-- Sends `Accept-Encoding: gzip, zstd` header
+- Sends `Accept-Encoding: gzip, br, zstd` header
 - Automatically decompresses responses
 
 Compression modes:
 
-- `auto` requests gzip or zstd and decompresses either response encoding
+- `auto` requests gzip, brotli, or zstd and decompresses any of those response encodings
+- `br`/`brotli` requests and decompresses brotli only
 - `gzip` requests and decompresses gzip only
 - `zstd` requests and decompresses zstd only
 - `off` sends no automatic `Accept-Encoding` header and leaves compressed response bodies untouched

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -457,14 +457,16 @@ fetch --grpc --http 2 http://localhost:50051/pkg.Svc/Method  # uses h2c
 
 ### `--compress MODE`
 
-Control response compression negotiation. Values: `auto`, `gzip`, `zstd`, `off`.
+Control response compression negotiation. Values: `auto`, `br`/`brotli`, `gzip`, `zstd`, `off`.
 
-- `auto` - request gzip or zstd compression (default)
+- `auto` - request gzip, brotli, or zstd compression (default)
+- `br`/`brotli` - request brotli compression only
 - `gzip` - request gzip compression only
 - `zstd` - request zstd compression only
 - `off` - disable automatic compression negotiation and decompression
 
 ```sh
+fetch --compress br example.com
 fetch --compress gzip example.com
 fetch --compress off example.com
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -475,10 +475,13 @@ ca-cert = /path/to/api-ca.crt
 Control automatic compression negotiation and decompression.
 
 ```ini
-# Request gzip or zstd compression (default)
+# Request gzip, brotli, or zstd compression (default)
 compress = auto
 
 # Request one algorithm only
+compress = br
+# The brotli alias is also accepted:
+compress = brotli
 compress = gzip
 compress = zstd
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,7 +156,7 @@ name without changing the request itself.
 ```
 > GET /json HTTP/1.1
 > accept: application/json,application/vnd.msgpack,application/xml,image/webp,*/*
-> accept-encoding: gzip, zstd
+> accept-encoding: gzip, br, zstd
 > host: httpbin.org
 > user-agent: fetch/v0.17.3
 >
@@ -190,7 +190,7 @@ fetch -vvv httpbin.org/json
 ```
 > GET /json HTTP/1.1
 > accept: application/json,application/vnd.msgpack,application/xml,image/webp,*/*
-> accept-encoding: gzip, zstd
+> accept-encoding: gzip, br, zstd
 > host: httpbin.org
 > user-agent: fetch/v0.17.3
 >
@@ -226,7 +226,7 @@ fetch --dry-run -vv -j '{"hello":"world"}' -m POST httpbin.org/post
 ```
 > POST /post HTTP/1.1
 > accept: application/json,application/vnd.msgpack,application/xml,image/webp,*/*
-> accept-encoding: gzip, zstd
+> accept-encoding: gzip, br, zstd
 > content-length: 17
 > content-type: application/json
 > host: httpbin.org

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,13 +23,14 @@ impl HttpVersion {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CompressionMode {
     Auto,
+    Brotli,
     Gzip,
     Zstd,
     Off,
 }
 
 impl CompressionMode {
-    pub const VALUES: &[&str] = &["auto", "gzip", "zstd", "off"];
+    pub const VALUES: &[&str] = &["auto", "br", "brotli", "gzip", "zstd", "off"];
 
     pub fn from_cli(cli: &Cli) -> Self {
         if cli.no_encode {
@@ -42,6 +43,7 @@ impl CompressionMode {
     pub fn from_value(value: &str) -> Option<Self> {
         match value {
             "auto" => Some(Self::Auto),
+            "br" | "brotli" => Some(Self::Brotli),
             "gzip" => Some(Self::Gzip),
             "zstd" => Some(Self::Zstd),
             "off" => Some(Self::Off),
@@ -51,7 +53,8 @@ impl CompressionMode {
 
     pub fn accept_encoding(self) -> Option<&'static str> {
         match self {
-            Self::Auto => Some("gzip, zstd"),
+            Self::Auto => Some("gzip, br, zstd"),
+            Self::Brotli => Some("br"),
             Self::Gzip => Some("gzip"),
             Self::Zstd => Some("zstd"),
             Self::Off => None,
@@ -61,7 +64,8 @@ impl CompressionMode {
     pub fn decodes(self, encoding: &str) -> bool {
         matches!(
             (self, encoding),
-            (Self::Auto, "gzip" | "zstd" | "aws-chunked")
+            (Self::Auto, "br" | "gzip" | "zstd" | "aws-chunked")
+                | (Self::Brotli, "br" | "aws-chunked")
                 | (Self::Gzip, "gzip" | "aws-chunked")
                 | (Self::Zstd, "zstd" | "aws-chunked")
         )
@@ -162,10 +166,10 @@ pub struct Cli {
     #[arg(
         long,
         value_name = "MODE",
-        value_parser = ["auto", "gzip", "zstd", "off"],
+        value_parser = ["auto", "br", "brotli", "gzip", "zstd", "off"],
         hide_possible_values = true,
         conflicts_with = "no_encode",
-        help = "Compression mode [auto, gzip, zstd, off]"
+        help = "Compression mode [auto, br, gzip, zstd, off]"
     )]
     pub compress: Option<String>,
 

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -57,7 +57,15 @@ const COMPLETE_VALUES: &[FlagValue] = &[
 const COMPRESS_VALUES: &[FlagValue] = &[
     FlagValue {
         key: "auto",
-        value: "Request gzip or zstd",
+        value: "Request gzip, brotli, or zstd",
+    },
+    FlagValue {
+        key: "br",
+        value: "Request brotli compression",
+    },
+    FlagValue {
+        key: "brotli",
+        value: "Request brotli compression",
     },
     FlagValue {
         key: "gzip",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1182,11 +1182,11 @@ mod tests {
     #[test]
     fn parse_file_rejects_invalid_compress_value() {
         let path = PathBuf::from("test/config");
-        let err = parse_file(&path, "compress = brotli\n").unwrap_err();
+        let err = parse_file(&path, "compress = deflate\n").unwrap_err();
 
         assert!(err.contains("line 1"));
-        assert!(err.contains("invalid value 'brotli' for option 'compress'"));
-        assert!(err.contains("must be one of [auto, gzip, zstd, off]"));
+        assert!(err.contains("invalid value 'deflate' for option 'compress'"));
+        assert!(err.contains("must be one of [auto, br, brotli, gzip, zstd, off]"));
     }
 
     #[test]

--- a/src/grpc/reflection.rs
+++ b/src/grpc/reflection.rs
@@ -168,6 +168,7 @@ async fn invoke(
 fn reflection_client(cli: &Cli) -> Result<Client, FetchError> {
     let mut builder = Client::builder()
         .use_rustls_tls()
+        .no_brotli()
         .no_gzip()
         .no_zstd()
         .http2_prior_knowledge()

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -87,7 +87,11 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
 
     crate::tls::install_default_crypto_provider();
 
-    let mut builder = Client::builder().use_rustls_tls().no_gzip().no_zstd();
+    let mut builder = Client::builder()
+        .use_rustls_tls()
+        .no_brotli()
+        .no_gzip()
+        .no_zstd();
     let connect_timing = ConnectionTiming::default();
     builder = configure_http_version(builder, http_version);
     builder = configure_unix_socket(builder, cli.unix.as_deref())?;
@@ -2211,6 +2215,7 @@ fn decode_response_bytes(
     let mut decoded = bytes.to_vec();
     for encoding in encodings {
         decoded = match encoding.as_str() {
+            "br" => decode_brotli(&decoded)?,
             "gzip" => decode_gzip(&decoded)?,
             "zstd" => decode_zstd(&decoded)?,
             "aws-chunked" => decoded,
@@ -2239,6 +2244,10 @@ where
 
     for encoding in encodings {
         reader = match encoding.as_str() {
+            "br" => Box::new(PrefixedReadError {
+                prefix: "br",
+                inner: brotli::Decompressor::new(reader, 4096),
+            }),
             "gzip" => Box::new(PrefixedReadError {
                 prefix: "gzip",
                 inner: GzDecoder::new(reader),
@@ -2320,6 +2329,15 @@ fn decode_gzip(bytes: &[u8]) -> Result<Vec<u8>, FetchError> {
     decoder
         .read_to_end(&mut decoded)
         .map_err(|err| FetchError::Message(format!("gzip: {err}")))?;
+    Ok(decoded)
+}
+
+fn decode_brotli(bytes: &[u8]) -> Result<Vec<u8>, FetchError> {
+    let mut decoder = brotli::Decompressor::new(bytes, 4096);
+    let mut decoded = Vec::new();
+    decoder
+        .read_to_end(&mut decoded)
+        .map_err(|err| FetchError::Message(format!("br: {err}")))?;
     Ok(decoded)
 }
 
@@ -3624,7 +3642,17 @@ mod tests {
             (
                 vec!["fetch", "https://example.com"],
                 CompressionMode::Auto,
-                Some("gzip, zstd"),
+                Some("gzip, br, zstd"),
+            ),
+            (
+                vec!["fetch", "--compress", "br", "https://example.com"],
+                CompressionMode::Brotli,
+                Some("br"),
+            ),
+            (
+                vec!["fetch", "--compress", "brotli", "https://example.com"],
+                CompressionMode::Brotli,
+                Some("br"),
             ),
             (
                 vec!["fetch", "--compress", "gzip", "https://example.com"],
@@ -3691,6 +3719,21 @@ mod tests {
     }
 
     #[test]
+    fn decodes_brotli_content_encoding() {
+        let data = b"this is brotli encoded data";
+        let body = brotli_encode(data);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::CONTENT_ENCODING,
+            HeaderValue::from_static("br"),
+        );
+
+        let decoded = decode_response_bytes(CompressionMode::Brotli, &headers, &body).unwrap();
+
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
     fn decodes_aws_chunked_plus_gzip() {
         let data = b"this is gzip encoded data";
         let body = gzip_encode(data);
@@ -3718,6 +3761,9 @@ mod tests {
         let decoded = decode_response_bytes(CompressionMode::Gzip, &headers, &body).unwrap();
         assert_eq!(decoded, data);
 
+        let decoded = decode_response_bytes(CompressionMode::Brotli, &headers, &body).unwrap();
+        assert_eq!(decoded, body);
+
         let decoded = decode_response_bytes(CompressionMode::Zstd, &headers, &body).unwrap();
         assert_eq!(decoded, body);
     }
@@ -3728,7 +3774,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(
             reqwest::header::CONTENT_ENCODING,
-            HeaderValue::from_static("br, gzip"),
+            HeaderValue::from_static("deflate, gzip"),
         );
 
         let decoded = decode_response_bytes(CompressionMode::Auto, &headers, body).unwrap();
@@ -3786,7 +3832,7 @@ mod tests {
         let mut unsupported_headers = HeaderMap::new();
         unsupported_headers.insert(
             reqwest::header::CONTENT_ENCODING,
-            HeaderValue::from_static("br"),
+            HeaderValue::from_static("deflate"),
         );
         assert_eq!(
             output_progress_total_bytes(
@@ -3811,10 +3857,33 @@ mod tests {
         assert!(err.to_string().contains("gzip:"));
     }
 
+    #[test]
+    fn brotli_decoder_errors_are_prefixed() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::CONTENT_ENCODING,
+            HeaderValue::from_static("br"),
+        );
+
+        let err =
+            decode_response_bytes(CompressionMode::Auto, &headers, b"not brotli").unwrap_err();
+
+        assert!(err.to_string().contains("br:"));
+    }
+
     fn gzip_encode(data: &[u8]) -> Vec<u8> {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         encoder.write_all(data).unwrap();
         encoder.finish().unwrap()
+    }
+
+    fn brotli_encode(data: &[u8]) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        {
+            let mut encoder = brotli::CompressorWriter::new(&mut encoded, 4096, 5, 22);
+            encoder.write_all(data).unwrap();
+        }
+        encoded
     }
 
     fn zstd_encode(data: &[u8]) -> Vec<u8> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2228,7 +2228,7 @@ fn dry_run_prints_effective_request_without_network() {
     assert!(res.stdout.is_empty());
     assert!(res.stderr.contains("GET / HTTP/1.1\n"));
     assert!(res.stderr.contains("accept: application/json"));
-    assert!(res.stderr.contains("accept-encoding: gzip, zstd\n"));
+    assert!(res.stderr.contains("accept-encoding: gzip, br, zstd\n"));
     assert!(res.stderr.contains("content-length: 14\n"));
     assert!(res.stderr.contains("content-type: application/json\n"));
     assert!(res.stderr.contains("host: localhost:3000\n"));
@@ -2246,7 +2246,7 @@ fn dry_run_prints_effective_request_without_network() {
     ]);
     assert_exit(&res, 0);
     let accept = res.stderr.find("accept: application/json").unwrap();
-    let accept_encoding = res.stderr.find("accept-encoding: gzip, zstd").unwrap();
+    let accept_encoding = res.stderr.find("accept-encoding: gzip, br, zstd").unwrap();
     let content_length = res.stderr.find("content-length: 14").unwrap();
     let content_type = res.stderr.find("content-type: application/json").unwrap();
     let host = res.stderr.find("host: localhost:3000").unwrap();
@@ -3253,14 +3253,23 @@ fn additional_formatting_sse_charset_image_and_compression_cases() {
     let mut gzip = GzEncoder::new(Vec::new(), Compression::default());
     gzip.write_all(b"this is the test data").unwrap();
     let gzip_body = gzip.finish().unwrap();
+    let mut brotli_body = Vec::new();
+    {
+        let mut brotli = brotli::CompressorWriter::new(&mut brotli_body, 4096, 5, 22);
+        brotli.write_all(b"this is the test data").unwrap();
+    }
     let zstd_body = zstd::encode_all(&b"this is the test data"[..], 0).unwrap();
     let compressed = TestServer::start(move |req| match req.header("accept-encoding").as_str() {
-        "gzip, zstd" if req.path == "/zstd" => {
+        "gzip, br, zstd" if req.path == "/br" => {
+            TestResponse::ok(brotli_body.clone()).header("Content-Encoding", "br")
+        }
+        "gzip, br, zstd" if req.path == "/zstd" => {
             TestResponse::ok(zstd_body.clone()).header("Content-Encoding", "zstd")
         }
-        "gzip, zstd" | "gzip" => {
+        "gzip, br, zstd" | "gzip" => {
             TestResponse::ok(gzip_body.clone()).header("Content-Encoding", "gzip")
         }
+        "br" => TestResponse::ok(brotli_body.clone()).header("Content-Encoding", "br"),
         "zstd" => TestResponse::ok(zstd_body.clone()).header("Content-Encoding", "zstd"),
         "" => TestResponse::ok("this is the test data"),
         other => TestResponse::status(
@@ -3277,6 +3286,10 @@ fn additional_formatting_sse_charset_image_and_compression_cases() {
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "this is the test data");
     assert!(res.stderr.contains("zstd"));
+    let res = run_fetch(&[&format!("{}/br", compressed.url), "-v"]);
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "this is the test data");
+    assert!(res.stderr.contains("br"));
     let res = run_fetch(&[&compressed.url, "-v", "--compress", "gzip"]);
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "this is the test data");
@@ -3290,9 +3303,18 @@ fn additional_formatting_sse_charset_image_and_compression_cases() {
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "this is the test data");
     assert!(res.stderr.contains("zstd"));
+    let res = run_fetch(&[&compressed.url, "-v", "--compress", "br"]);
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "this is the test data");
+    assert!(res.stderr.contains("br"));
+    let res = run_fetch(&[&compressed.url, "-v", "--compress", "brotli"]);
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "this is the test data");
+    assert!(res.stderr.contains("br"));
     let res = run_fetch(&[&compressed.url, "-v", "--compress", "off"]);
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "this is the test data");
+    assert!(!res.stderr.contains("br"));
     assert!(!res.stderr.contains("gzip"));
     assert!(!res.stderr.contains("zstd"));
     let res = run_fetch(&[&compressed.url, "--compress", "bad"]);


### PR DESCRIPTION
## Summary
- Add brotli to request compression negotiation and response decompression alongside gzip and zstd.
- Accept `--compress br` and `--compress brotli`, update completion metadata, and keep raw/unsupported encodings untouched.
- Refresh docs and repo notes to describe the new default `Accept-Encoding: gzip, br, zstd` behavior.

## Testing
- Added unit coverage for brotli negotiation, decoding, and error prefixing.
- Added integration coverage for brotli responses and CLI compression modes.
- Ran `cargo fmt`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo test --all-features`, and `cargo test --all-features --test integration -- --test-threads=1`.