### PR TITLE
Simplify the default Accept header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - Image rendering defaults (`auto`) use built-in Rust decoders only; external adapters (`vips`, `magick`, `ffmpeg`) require `--image external` or `image = external` and run with bounded stdin/stdout/stderr and timeout handling.
 - Response compression negotiation is controlled by `--compress auto|br|gzip|zstd|off` or `compress = ...`; `brotli` is accepted as an alias for `br`, `auto` requests and decodes gzip/brotli/zstd, single-algorithm modes only request/decode that algorithm, and `off` leaves compressed bodies untouched.
 - `--sort-headers` or `sort-headers = true` sorts displayed request/response headers alphabetically by name in verbose output without changing the actual request header order.
+- Default HTTP requests send `Accept: application/json, */*;q=0.5`, preferring JSON while allowing any other response type as a lower-priority fallback.
 
 Retryable requests use replayable request bodies so retries and 307/308 redirects can resend data without holding unrelated state.
 Multipart `-F` request bodies are produced with a stable boundary so redirected requests preserve the original body shape.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -155,7 +155,7 @@ name without changing the request itself.
 
 ```
 > GET /json HTTP/1.1
-> accept: application/json,application/vnd.msgpack,application/xml,image/webp,*/*
+> accept: application/json, */*;q=0.5
 > accept-encoding: gzip, br, zstd
 > host: httpbin.org
 > user-agent: fetch/v0.17.3
@@ -189,7 +189,7 @@ fetch -vvv httpbin.org/json
 
 ```
 > GET /json HTTP/1.1
-> accept: application/json,application/vnd.msgpack,application/xml,image/webp,*/*
+> accept: application/json, */*;q=0.5
 > accept-encoding: gzip, br, zstd
 > host: httpbin.org
 > user-agent: fetch/v0.17.3
@@ -225,7 +225,7 @@ fetch --dry-run -vv -j '{"hello":"world"}' -m POST httpbin.org/post
 
 ```
 > POST /post HTTP/1.1
-> accept: application/json,application/vnd.msgpack,application/xml,image/webp,*/*
+> accept: application/json, */*;q=0.5
 > accept-encoding: gzip, br, zstd
 > content-length: 17
 > content-type: application/json

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::io::IsTerminal;
 
+pub const DEFAULT_ACCEPT_HEADER: &str = "application/json, */*;q=0.5";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Color {
     Unknown,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -142,9 +142,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     } else {
         headers.insert(
             ACCEPT,
-            HeaderValue::from_static(
-                "application/json,application/vnd.msgpack,application/xml,image/webp,*/*",
-            ),
+            HeaderValue::from_static(core::DEFAULT_ACCEPT_HEADER),
         );
         apply_headers(&mut headers, &cli.headers)?;
     }

--- a/src/update.rs
+++ b/src/update.rs
@@ -233,10 +233,7 @@ fn update_get(client: &reqwest::Client, url: impl reqwest::IntoUrl) -> reqwest::
     client
         .get(url)
         .header(USER_AGENT, core::user_agent())
-        .header(
-            ACCEPT,
-            "application/json,application/vnd.msgpack,application/xml,image/webp,*/*",
-        )
+        .header(ACCEPT, core::DEFAULT_ACCEPT_HEADER)
 }
 
 enum UpdateDownloadProgress {
@@ -1118,7 +1115,7 @@ mod tests {
         );
         assert_eq!(
             request.headers().get(ACCEPT).and_then(|v| v.to_str().ok()),
-            Some("application/json,application/vnd.msgpack,application/xml,image/webp,*/*")
+            Some(core::DEFAULT_ACCEPT_HEADER)
         );
     }
 

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -198,9 +198,7 @@ fn handshake_headers(cli: &Cli, url: &Url) -> Result<HeaderMap, FetchError> {
     let mut headers = HeaderMap::new();
     headers.insert(
         ACCEPT,
-        HeaderValue::from_static(
-            "application/json,application/vnd.msgpack,application/xml,image/webp,*/*",
-        ),
+        HeaderValue::from_static(core::DEFAULT_ACCEPT_HEADER),
     );
     headers.insert(
         USER_AGENT,
@@ -362,6 +360,10 @@ mod tests {
         let cli = Cli::try_parse_from(["fetch", "--bearer", "token", "ws://example.com"]).unwrap();
         let headers = handshake_headers(&cli, &Url::parse("ws://example.com").unwrap()).unwrap();
 
+        assert_eq!(
+            headers.get(ACCEPT).and_then(|value| value.to_str().ok()),
+            Some(core::DEFAULT_ACCEPT_HEADER)
+        );
         assert_eq!(
             headers
                 .get(AUTHORIZATION)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2227,7 +2227,7 @@ fn dry_run_prints_effective_request_without_network() {
     assert_exit(&res, 0);
     assert!(res.stdout.is_empty());
     assert!(res.stderr.contains("GET / HTTP/1.1\n"));
-    assert!(res.stderr.contains("accept: application/json"));
+    assert!(res.stderr.contains("accept: application/json, */*;q=0.5"));
     assert!(res.stderr.contains("accept-encoding: gzip, br, zstd\n"));
     assert!(res.stderr.contains("content-length: 14\n"));
     assert!(res.stderr.contains("content-type: application/json\n"));
@@ -2245,7 +2245,10 @@ fn dry_run_prints_effective_request_without_network() {
         "--sort-headers",
     ]);
     assert_exit(&res, 0);
-    let accept = res.stderr.find("accept: application/json").unwrap();
+    let accept = res
+        .stderr
+        .find("accept: application/json, */*;q=0.5")
+        .unwrap();
     let accept_encoding = res.stderr.find("accept-encoding: gzip, br, zstd").unwrap();
     let content_length = res.stderr.find("content-length: 14").unwrap();
     let content_type = res.stderr.find("content-type: application/json").unwrap();


### PR DESCRIPTION
## Summary
- Change the default `Accept` header to `application/json, */*;q=0.5` so JSON is preferred while keeping a generic fallback.
- Centralize the value in `src/core.rs` and reuse it in HTTP requests, WebSocket handshakes, and update checks.
- Update docs, integration expectations, and the WebSocket/update tests to match the new default.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`