### PR TITLE
Include effective WebSocket handshake headers in dry-run output

### DIFF
--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -40,8 +40,9 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let interactive = should_use_interactive(cli)?;
 
     let initial_message = websocket_initial_message(cli)?;
+    let request = build_handshake_request(cli, &url)?;
     if cli.dry_run {
-        print_request_metadata(cli, method, &url, None);
+        print_request_metadata(cli, method, &url, Some(request.headers()));
         return Ok(0);
     }
     let stdin_messages = if interactive {
@@ -50,7 +51,6 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
         read_stdin_messages()?
     };
 
-    let request = build_handshake_request(cli, &url)?;
     if cli.verbose >= 2 && !cli.silent {
         print_request_metadata(cli, method, &url, Some(request.headers()));
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4608,6 +4608,26 @@ fn websocket_noninteractive_go_cases() {
     assert!(res.stderr.contains("GET") || res.stderr.contains("method"));
 }
 
+#[test]
+fn websocket_dry_run_prints_effective_handshake_headers() {
+    let res = run_fetch(&[
+        "ws://example.com/socket",
+        "--dry-run",
+        "-H",
+        "X-Test: yes",
+        "--bearer",
+        "token",
+    ]);
+
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(res.stderr.contains("> GET /socket HTTP/1.1"));
+    assert!(res.stderr.contains("> x-test: yes"));
+    assert!(res.stderr.contains("> authorization: Bearer token"));
+    assert!(res.stderr.contains("> accept: application/json, */*;q=0.5"));
+    assert!(res.stderr.contains("> user-agent: fetch/"));
+}
+
 #[cfg(unix)]
 #[test]
 fn websocket_interactive_pty_go_case() {


### PR DESCRIPTION
## Summary
- Build the WebSocket handshake request before the dry-run branch so dry-run prints the effective request headers.
- Preserve the existing verbose path while reusing the constructed request.
- Add integration coverage for `ws://... --dry-run` with custom and bearer headers.

## Testing
- Added an integration test that verifies dry-run output includes `X-Test`, `Authorization`, `Accept`, and `User-Agent` headers.
- Not run (not requested)