### PR TITLE
Use Bash for Windows release asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,7 @@ jobs:
 
       - name: Upload release archive
         if: github.event_name == 'release' || inputs.upload_release
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "$RELEASE_VERSION" "$ASSET" "$ASSET.sha256" --clobber


### PR DESCRIPTION
## Summary
- Force the release upload step to run under Bash so `RELEASE_VERSION` and `ASSET` expand correctly on Windows runners.
- Prevent `gh release upload` from receiving empty arguments during Windows release jobs.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`