### PR TITLE
Stream response bodies end to end for non-formatted output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "async-compression",
  "base64",
  "brotli",
  "bytes",
@@ -718,6 +719,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
+ "tokio-util",
  "tower",
  "url",
  "webpki-roots 1.0.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ strip = true
 
 [dependencies]
 anyhow = "1"
+async-compression = { version = "0.4", features = ["brotli", "gzip", "tokio", "zstd"] }
 base64 = "0.22"
 brotli = "8.0.2"
 bytes = "1"
@@ -55,6 +56,7 @@ time = "0.3"
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+tokio-util = { version = "0.7", features = ["io"] }
 tower = "0.5"
 url = "2"
 webpki-roots = "1"

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -12,9 +12,15 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant, SystemTime};
 
+use async_compression::tokio::bufread::{
+    BrotliDecoder as AsyncBrotliDecoder, GzipDecoder as AsyncGzipDecoder,
+    ZstdDecoder as AsyncZstdDecoder,
+};
 use base64::Engine;
 use bytes::Bytes;
+#[cfg(test)]
 use flate2::read::GzDecoder;
+use futures_util::stream;
 use http_body_util::BodyExt;
 use reqwest::header::{
     ACCEPT, ACCEPT_ENCODING, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, RANGE, RETRY_AFTER,
@@ -22,6 +28,8 @@ use reqwest::header::{
 };
 use reqwest::redirect;
 use reqwest::{Client, Method, RequestBuilder, Response, StatusCode};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio_util::io::StreamReader;
 use tower::{Layer, Service};
 use url::Url;
 
@@ -52,6 +60,9 @@ mod edit;
 pub mod multipart;
 
 pub(crate) type RequestBody = Option<(Vec<u8>, Option<String>)>;
+type AsyncReadBox = Pin<Box<dyn AsyncRead + Send>>;
+
+const MAX_BUFFERED_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 
 pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let http_version =
@@ -917,12 +928,18 @@ async fn finish_response(
     let response_timing = timing.and_then(AttemptTiming::response_timing);
     if cli.discard {
         let body_start = Instant::now();
-        let (bytes, trailers) = read_response_body(response).await?;
-        let body_duration = body_duration(method_is_head, bytes.as_ref(), body_start);
-        let _ = decode_response_bytes(compression, &response_headers, bytes.as_ref())?;
+        let streamed =
+            stream_response_to_discard(response, response_headers.clone(), compression).await?;
+        let body_duration =
+            body_duration_from_len(method_is_head, streamed.bytes_written, body_start);
         print_timing(cli, response_timing, body_duration);
         let code = exit_code(status.as_u16(), cli.ignore_status);
-        return Ok(check_grpc_status(cli, &response_headers, &trailers, code));
+        return Ok(check_grpc_status(
+            cli,
+            &response_headers,
+            &streamed.trailers,
+            code,
+        ));
     }
 
     let output_path = output::resolve_output_path(
@@ -973,9 +990,34 @@ async fn finish_response(
         ))
     } else {
         let body_start = Instant::now();
-        let (bytes, trailers) = read_response_body(response).await?;
+        let stdout_is_terminal = std::io::stdout().is_terminal();
+        if let Some(target) = stdout_stream_target(cli, &response_headers, stdout_is_terminal) {
+            let streamed = stream_response_to_stdout(
+                response,
+                response_headers.clone(),
+                compression,
+                cli.copy,
+                target,
+            )
+            .await?;
+            handle_optional_clipboard_outcome(cli, streamed.clipboard);
+            let body_duration =
+                body_duration_from_len(method_is_head, streamed.bytes_written, body_start);
+            print_timing(cli, response_timing, body_duration);
+
+            let code = exit_code(status.as_u16(), cli.ignore_status);
+            return Ok(check_grpc_status(
+                cli,
+                &response_headers,
+                &streamed.trailers,
+                code,
+            ));
+        }
+
+        let (bytes, trailers) =
+            read_decoded_response_body_limited(response, response_headers.clone(), compression)
+                .await?;
         let body_duration = body_duration(method_is_head, bytes.as_ref(), body_start);
-        let bytes = decode_response_bytes(compression, &response_headers, bytes.as_ref())?;
         if cli.copy {
             handle_clipboard_outcome(cli, clipboard::copy_bytes(&bytes));
         }
@@ -1059,17 +1101,123 @@ fn write_stdout_bytes_with_pager(bytes: &[u8]) -> Result<(), FetchError> {
     Ok(())
 }
 
-async fn read_response_body(response: Response) -> Result<(Vec<u8>, HeaderMap), FetchError> {
-    let response: http::Response<reqwest::Body> = response.into();
-    let collected = response.into_body().collect().await?;
-    let trailers = collected.trailers().cloned().unwrap_or_default();
-    Ok((collected.to_bytes().to_vec(), trailers))
+#[derive(Clone, Copy)]
+enum StdoutStreamTarget {
+    Direct,
+    Pager,
+}
+
+fn stdout_stream_target(
+    cli: &Cli,
+    headers: &HeaderMap,
+    stdout_is_terminal: bool,
+) -> Option<StdoutStreamTarget> {
+    if format_enabled(cli.format.as_deref(), stdout_is_terminal) {
+        return None;
+    }
+
+    let is_image = response_header_content_type(headers) == ContentType::Image;
+    match crate::cli::PagerMode::from_cli(cli) {
+        crate::cli::PagerMode::Auto if stdout_is_terminal && !is_image => {
+            Some(StdoutStreamTarget::Pager)
+        }
+        crate::cli::PagerMode::On if !is_image => Some(StdoutStreamTarget::Pager),
+        crate::cli::PagerMode::Auto | crate::cli::PagerMode::Off | crate::cli::PagerMode::On => {
+            Some(StdoutStreamTarget::Direct)
+        }
+    }
+}
+
+fn response_header_content_type(headers: &HeaderMap) -> ContentType {
+    let content_type = headers
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok());
+    content_type::get_content_type(content_type).0
+}
+
+async fn read_decoded_response_body_limited(
+    response: Response,
+    response_headers: HeaderMap,
+    compression: CompressionMode,
+) -> Result<(Vec<u8>, HeaderMap), FetchError> {
+    let (reader, trailers) = async_response_reader(response);
+    let mut reader = decoded_async_response_reader(reader, compression, &response_headers)?;
+    let mut bytes = Vec::new();
+    let mut buf = vec![0; 16 * 1024];
+    loop {
+        let n = reader.read(&mut buf).await?;
+        if n == 0 {
+            let trailers = trailers
+                .lock()
+                .map(|trailers| trailers.clone())
+                .unwrap_or_default();
+            return Ok((bytes, trailers));
+        }
+        if bytes.len().saturating_add(n) > MAX_BUFFERED_RESPONSE_BYTES {
+            return Err(FetchError::Message(format!(
+                "response body exceeds {} bytes and cannot be buffered; use '--format off' or write to a file to stream it",
+                MAX_BUFFERED_RESPONSE_BYTES
+            )));
+        }
+        bytes.extend_from_slice(&buf[..n]);
+    }
 }
 
 struct StreamedOutput {
     trailers: HeaderMap,
     bytes_written: i64,
     clipboard: Option<clipboard::CopyOutcome>,
+}
+
+async fn stream_response_to_discard(
+    response: Response,
+    response_headers: HeaderMap,
+    compression: CompressionMode,
+) -> Result<StreamedOutput, FetchError> {
+    let (reader, trailers) = async_response_reader(response);
+    let mut reader = decoded_async_response_reader(reader, compression, &response_headers)?;
+    let mut sink = tokio::io::sink();
+    let bytes_written = copy_async_reader_to_writer(&mut reader, &mut sink, None).await?;
+    let trailers = trailers
+        .lock()
+        .map(|trailers| trailers.clone())
+        .unwrap_or_default();
+    Ok(StreamedOutput {
+        trailers,
+        bytes_written,
+        clipboard: None,
+    })
+}
+
+async fn stream_response_to_stdout(
+    response: Response,
+    response_headers: HeaderMap,
+    compression: CompressionMode,
+    copy: bool,
+    target: StdoutStreamTarget,
+) -> Result<StreamedOutput, FetchError> {
+    let (reader, trailers) = async_response_reader(response);
+    let mut reader = decoded_async_response_reader(reader, compression, &response_headers)?;
+    let mut capture = copy.then(clipboard::Capture::default);
+    let bytes_written = match target {
+        StdoutStreamTarget::Direct => {
+            let mut stdout = tokio::io::stdout();
+            copy_async_reader_to_writer(&mut reader, &mut stdout, capture.as_mut()).await?
+        }
+        StdoutStreamTarget::Pager => {
+            stream_async_reader_to_pager(&mut reader, capture.as_mut()).await?
+        }
+    };
+    let clipboard = capture.map(clipboard::Capture::copy);
+    let trailers = trailers
+        .lock()
+        .map(|trailers| trailers.clone())
+        .unwrap_or_default();
+    Ok(StreamedOutput {
+        trailers,
+        bytes_written,
+        clipboard,
+    })
 }
 
 async fn stream_response_to_output(
@@ -1081,56 +1229,146 @@ async fn stream_response_to_output(
     progress: output::WriteProgress,
     copy: bool,
 ) -> Result<StreamedOutput, FetchError> {
-    let response: http::Response<reqwest::Body> = response.into();
-    let body = response.into_body();
-    let trailers = Arc::new(Mutex::new(HeaderMap::new()));
-    let reader = BlockingBodyReader {
-        body,
-        buffer: Bytes::new(),
-        trailers: trailers.clone(),
-        handle: tokio::runtime::Handle::current(),
-        done: false,
+    let (reader, trailers) = async_response_reader(response);
+    let mut reader = decoded_async_response_reader(reader, compression, &response_headers)?;
+    let mut capture = copy.then(clipboard::Capture::default);
+    let bytes_written = if let Some(capture) = capture.as_mut() {
+        let mut reader = AsyncClipboardTeeReader { reader, capture };
+        output::write_output_async_reader(&path, &mut reader, clobber, progress)
+            .await
+            .map_err(|err| FetchError::Message(err.to_string()))?
+    } else {
+        output::write_output_async_reader(&path, &mut reader, clobber, progress)
+            .await
+            .map_err(|err| FetchError::Message(err.to_string()))?
     };
-
-    let result = tokio::task::spawn_blocking(move || -> Result<StreamedOutput, FetchError> {
-        let mut reader = decoded_response_reader(reader, compression, &response_headers)?;
-        let mut capture = copy.then(clipboard::Capture::default);
-        let bytes_written = if let Some(capture) = capture.as_mut() {
-            let mut reader = ClipboardTeeReader { reader, capture };
-            output::write_output_reader(&path, &mut reader, clobber, progress)
-                .map_err(|err| FetchError::Message(err.to_string()))?
-        } else {
-            output::write_output_reader(&path, &mut reader, clobber, progress)
-                .map_err(|err| FetchError::Message(err.to_string()))?
-        };
-        let clipboard = capture.map(clipboard::Capture::copy);
-        let trailers = trailers
-            .lock()
-            .map(|trailers| trailers.clone())
-            .unwrap_or_default();
-        Ok(StreamedOutput {
-            trailers,
-            bytes_written,
-            clipboard,
-        })
+    let clipboard = capture.map(clipboard::Capture::copy);
+    let trailers = trailers
+        .lock()
+        .map(|trailers| trailers.clone())
+        .unwrap_or_default();
+    Ok(StreamedOutput {
+        trailers,
+        bytes_written,
+        clipboard,
     })
-    .await
-    .map_err(|err| FetchError::Message(err.to_string()))??;
-
-    Ok(result)
 }
 
-struct ClipboardTeeReader<'a> {
-    reader: Box<dyn Read + Send>,
+struct AsyncClipboardTeeReader<'a> {
+    reader: AsyncReadBox,
     capture: &'a mut clipboard::Capture,
 }
 
-impl Read for ClipboardTeeReader<'_> {
-    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
-        let n = self.reader.read(out)?;
-        self.capture.push(&out[..n]);
-        Ok(n)
+impl AsyncRead for AsyncClipboardTeeReader<'_> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let filled_before = buf.filled().len();
+        match self.reader.as_mut().poll_read(cx, buf) {
+            Poll::Ready(Ok(())) => {
+                let filled = buf.filled();
+                self.capture.push(&filled[filled_before..]);
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
     }
+}
+
+fn async_response_reader(response: Response) -> (AsyncReadBox, Arc<Mutex<HeaderMap>>) {
+    let response: http::Response<reqwest::Body> = response.into();
+    let body = response.into_body();
+    let trailers = Arc::new(Mutex::new(HeaderMap::new()));
+    let stream_trailers = trailers.clone();
+    let stream = stream::try_unfold(body, move |mut body| {
+        let stream_trailers = stream_trailers.clone();
+        async move {
+            loop {
+                let Some(frame) = body.frame().await else {
+                    return Ok::<Option<(Bytes, reqwest::Body)>, std::io::Error>(None);
+                };
+                let frame = frame.map_err(|err| std::io::Error::other(err.to_string()))?;
+                match frame.into_data() {
+                    Ok(data) => {
+                        if data.is_empty() {
+                            continue;
+                        }
+                        return Ok(Some((data, body)));
+                    }
+                    Err(frame) => {
+                        if let Ok(trailers) = frame.into_trailers()
+                            && let Ok(mut stored) = stream_trailers.lock()
+                        {
+                            *stored = trailers;
+                        }
+                    }
+                }
+            }
+        }
+    });
+    (Box::pin(StreamReader::new(stream)), trailers)
+}
+
+async fn copy_async_reader_to_writer<W>(
+    reader: &mut AsyncReadBox,
+    writer: &mut W,
+    mut capture: Option<&mut clipboard::Capture>,
+) -> std::io::Result<i64>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = vec![0; 16 * 1024];
+    let mut written = 0i64;
+    loop {
+        let n = reader.read(&mut buf).await?;
+        if n == 0 {
+            writer.flush().await?;
+            return Ok(written);
+        }
+        if let Some(capture) = capture.as_mut() {
+            capture.push(&buf[..n]);
+        }
+        writer.write_all(&buf[..n]).await?;
+        written = written.saturating_add(i64::try_from(n).unwrap_or(i64::MAX));
+    }
+}
+
+async fn stream_async_reader_to_pager(
+    reader: &mut AsyncReadBox,
+    capture: Option<&mut clipboard::Capture>,
+) -> Result<i64, FetchError> {
+    let mut child = match tokio::process::Command::new("less")
+        .arg("-FIRX")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            let mut stdout = tokio::io::stdout();
+            return Ok(copy_async_reader_to_writer(reader, &mut stdout, capture).await?);
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    let mut bytes_written = 0;
+    if let Some(mut stdin) = child.stdin.take() {
+        match copy_async_reader_to_writer(reader, &mut stdin, capture).await {
+            Ok(n) => bytes_written = n,
+            Err(err) if err.kind() == ErrorKind::BrokenPipe => {}
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    let status = child.wait().await?;
+    if !status.success() {
+        return Err(FetchError::Runtime(format!("pager exited with {status}")));
+    }
+
+    Ok(bytes_written)
 }
 
 fn handle_optional_clipboard_outcome(cli: &Cli, outcome: Option<clipboard::CopyOutcome>) {
@@ -1146,54 +1384,16 @@ fn handle_clipboard_outcome(cli: &Cli, outcome: clipboard::CopyOutcome) {
     }
 }
 
-struct BlockingBodyReader {
-    body: reqwest::Body,
-    buffer: Bytes,
-    trailers: Arc<Mutex<HeaderMap>>,
-    handle: tokio::runtime::Handle,
-    done: bool,
-}
-
-impl Read for BlockingBodyReader {
-    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
-        loop {
-            if !self.buffer.is_empty() {
-                let n = out.len().min(self.buffer.len());
-                out[..n].copy_from_slice(&self.buffer[..n]);
-                let _ = self.buffer.split_to(n);
-                return Ok(n);
-            }
-            if self.done {
-                return Ok(0);
-            }
-
-            let next = self.handle.block_on(async { self.body.frame().await });
-            let Some(frame) = next else {
-                self.done = true;
-                return Ok(0);
-            };
-            let frame = frame.map_err(|err| std::io::Error::other(err.to_string()))?;
-            match frame.into_data() {
-                Ok(data) => {
-                    if data.is_empty() {
-                        continue;
-                    }
-                    self.buffer = data;
-                }
-                Err(frame) => {
-                    if let Ok(trailers) = frame.into_trailers()
-                        && let Ok(mut stored) = self.trailers.lock()
-                    {
-                        *stored = trailers;
-                    }
-                }
-            }
-        }
-    }
-}
-
 fn body_duration(method_is_head: bool, bytes: &[u8], start: Instant) -> Option<Duration> {
-    if method_is_head || bytes.is_empty() {
+    body_duration_from_len(
+        method_is_head,
+        i64::try_from(bytes.len()).unwrap_or(i64::MAX),
+        start,
+    )
+}
+
+fn body_duration_from_len(method_is_head: bool, len: i64, start: Instant) -> Option<Duration> {
+    if method_is_head || len == 0 {
         None
     } else {
         Some(start.elapsed())
@@ -2197,6 +2397,7 @@ fn apply_accept_encoding(headers: &mut HeaderMap, cli: &Cli, method: &Method) ->
     compression
 }
 
+#[cfg(test)]
 fn decode_response_bytes(
     compression: CompressionMode,
     headers: &HeaderMap,
@@ -2223,15 +2424,11 @@ fn decode_response_bytes(
     Ok(decoded)
 }
 
-fn decoded_response_reader<R>(
-    reader: R,
+fn decoded_async_response_reader(
+    mut reader: AsyncReadBox,
     compression: CompressionMode,
     headers: &HeaderMap,
-) -> Result<Box<dyn Read + Send>, FetchError>
-where
-    R: Read + Send + 'static,
-{
-    let mut reader: Box<dyn Read + Send> = Box::new(reader);
+) -> Result<AsyncReadBox, FetchError> {
     if compression == CompressionMode::Off {
         return Ok(reader);
     }
@@ -2242,22 +2439,18 @@ where
 
     for encoding in encodings {
         reader = match encoding.as_str() {
-            "br" => Box::new(PrefixedReadError {
+            "br" => Box::pin(AsyncPrefixedReadError {
                 prefix: "br",
-                inner: brotli::Decompressor::new(reader, 4096),
+                inner: AsyncBrotliDecoder::new(tokio::io::BufReader::new(reader)),
             }),
-            "gzip" => Box::new(PrefixedReadError {
+            "gzip" => Box::pin(AsyncPrefixedReadError {
                 prefix: "gzip",
-                inner: GzDecoder::new(reader),
+                inner: AsyncGzipDecoder::new(tokio::io::BufReader::new(reader)),
             }),
-            "zstd" => {
-                let decoder = zstd::stream::read::Decoder::new(reader)
-                    .map_err(|err| FetchError::Message(format!("zstd: {err}")))?;
-                Box::new(PrefixedReadError {
-                    prefix: "zstd",
-                    inner: decoder,
-                })
-            }
+            "zstd" => Box::pin(AsyncPrefixedReadError {
+                prefix: "zstd",
+                inner: AsyncZstdDecoder::new(tokio::io::BufReader::new(reader)),
+            }),
             "aws-chunked" => reader,
             _ => unreachable!("unsupported encodings are filtered"),
         };
@@ -2280,16 +2473,21 @@ fn output_progress_total_bytes(
     }
 }
 
-struct PrefixedReadError<R> {
+struct AsyncPrefixedReadError<R> {
     prefix: &'static str,
     inner: R,
 }
 
-impl<R: Read> Read for PrefixedReadError<R> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner
-            .read(buf)
-            .map_err(|err| std::io::Error::new(err.kind(), format!("{}: {err}", self.prefix)))
+impl<R: AsyncRead + Unpin> AsyncRead for AsyncPrefixedReadError<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let prefix = self.prefix;
+        Pin::new(&mut self.inner)
+            .poll_read(cx, buf)
+            .map_err(|err| std::io::Error::new(err.kind(), format!("{prefix}: {err}")))
     }
 }
 
@@ -2321,6 +2519,7 @@ fn content_encodings(headers: &HeaderMap) -> Vec<String> {
         .collect()
 }
 
+#[cfg(test)]
 fn decode_gzip(bytes: &[u8]) -> Result<Vec<u8>, FetchError> {
     let mut decoder = GzDecoder::new(bytes);
     let mut decoded = Vec::new();
@@ -2330,6 +2529,7 @@ fn decode_gzip(bytes: &[u8]) -> Result<Vec<u8>, FetchError> {
     Ok(decoded)
 }
 
+#[cfg(test)]
 fn decode_brotli(bytes: &[u8]) -> Result<Vec<u8>, FetchError> {
     let mut decoder = brotli::Decompressor::new(bytes, 4096);
     let mut decoded = Vec::new();
@@ -2339,6 +2539,7 @@ fn decode_brotli(bytes: &[u8]) -> Result<Vec<u8>, FetchError> {
     Ok(decoded)
 }
 
+#[cfg(test)]
 fn decode_zstd(bytes: &[u8]) -> Result<Vec<u8>, FetchError> {
     zstd::stream::decode_all(bytes).map_err(|err| FetchError::Message(format!("zstd: {err}")))
 }
@@ -2912,6 +3113,66 @@ mod tests {
             b"{\"ok\":true}\n",
             ContentType::Json,
             true,
+        ));
+    }
+
+    #[test]
+    fn stdout_streaming_follows_format_and_pager_modes() {
+        let headers = HeaderMap::new();
+        let cli = Cli::try_parse_from(["fetch", "https://example.com"]).unwrap();
+        assert!(matches!(
+            stdout_stream_target(&cli, &headers, false),
+            Some(StdoutStreamTarget::Direct)
+        ));
+        assert!(stdout_stream_target(&cli, &headers, true).is_none());
+
+        let cli = Cli::try_parse_from(["fetch", "--format", "off", "https://example.com"]).unwrap();
+        assert!(matches!(
+            stdout_stream_target(&cli, &headers, false),
+            Some(StdoutStreamTarget::Direct)
+        ));
+        assert!(matches!(
+            stdout_stream_target(&cli, &headers, true),
+            Some(StdoutStreamTarget::Pager)
+        ));
+
+        let cli = Cli::try_parse_from([
+            "fetch",
+            "--format",
+            "off",
+            "--pager",
+            "off",
+            "https://example.com",
+        ])
+        .unwrap();
+        assert!(matches!(
+            stdout_stream_target(&cli, &headers, true),
+            Some(StdoutStreamTarget::Direct)
+        ));
+
+        let cli = Cli::try_parse_from([
+            "fetch",
+            "--format",
+            "off",
+            "--pager",
+            "on",
+            "https://example.com",
+        ])
+        .unwrap();
+        assert!(matches!(
+            stdout_stream_target(&cli, &headers, false),
+            Some(StdoutStreamTarget::Pager)
+        ));
+
+        let cli = Cli::try_parse_from(["fetch", "--format", "on", "https://example.com"]).unwrap();
+        assert!(stdout_stream_target(&cli, &headers, false).is_none());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("image/png"));
+        let cli = Cli::try_parse_from(["fetch", "--format", "off", "https://example.com"]).unwrap();
+        assert!(matches!(
+            stdout_stream_target(&cli, &headers, true),
+            Some(StdoutStreamTarget::Direct)
         ));
     }
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -5,11 +5,13 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use reqwest::header::{CONTENT_DISPOSITION, HeaderMap};
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use url::Url;
 
 use crate::fileutil;
 use crate::output::progress::{
-    Bar, ProgressPrinter, Spinner, emit_native_progress, write_final_progress,
+    Bar, BarCounter, ProgressPrinter, Spinner, SpinnerCounter, emit_native_progress,
+    write_final_progress,
 };
 
 pub mod clipboard;
@@ -190,6 +192,67 @@ pub fn write_output_reader<R: Read>(
     }
 }
 
+pub async fn write_output_async_reader<R: AsyncRead + Unpin>(
+    path: &str,
+    reader: &mut R,
+    clobber: bool,
+    progress: WriteProgress,
+) -> Result<i64, OutputError> {
+    let target = Path::new(path);
+    if !clobber {
+        check_output_file(target)?;
+    }
+
+    let absolute_target = absolute_path(target)?;
+    let (temp_path, temp_file) = create_download_temp(&absolute_target)?;
+    let mut temp_file = tokio::fs::File::from_std(temp_file);
+
+    let progress_summary = match write_temp_body_async(
+        &mut temp_file,
+        reader,
+        &progress,
+        absolute_target.to_string_lossy().as_ref(),
+    )
+    .await
+    {
+        Ok(summary) => summary,
+        Err(err) => {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(err);
+        }
+    };
+    if let Err(err) = temp_file.sync_all().await {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(OutputError::Io(err));
+    }
+    drop(temp_file);
+
+    let install_result = if clobber {
+        fileutil::atomic_replace_file(&temp_path, &absolute_target)
+    } else {
+        fileutil::atomic_write_new_file(&temp_path, &absolute_target)
+    };
+    match install_result {
+        Ok(()) => {
+            if let Some(summary) = progress_summary.summary {
+                summary.finish();
+            }
+            Ok(progress_summary.bytes_written)
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            let _ = std::fs::remove_file(&temp_path);
+            Err(OutputError::FileExists(path.to_string()))
+        }
+        Err(err) => {
+            let _ = std::fs::remove_file(&temp_path);
+            Err(OutputError::FileCheck {
+                path: path.to_string(),
+                source: err,
+            })
+        }
+    }
+}
+
 fn check_output_file(path: &Path) -> Result<(), OutputError> {
     match std::fs::metadata(path) {
         Ok(_) => Err(OutputError::FileExists(path.to_string_lossy().into_owned())),
@@ -286,6 +349,44 @@ fn write_temp_body<R: Read>(
     })
 }
 
+async fn write_temp_body_async<R: AsyncRead + Unpin>(
+    file: &mut tokio::fs::File,
+    reader: &mut R,
+    progress: &WriteProgress,
+    display_path: &str,
+) -> Result<WriteOutcome, OutputError> {
+    let Some(printer) = progress.printer.clone() else {
+        let bytes_written = tokio::io::copy(reader, file).await?;
+        file.flush().await?;
+        return Ok(WriteOutcome {
+            bytes_written: i64::try_from(bytes_written).unwrap_or(i64::MAX),
+            summary: None,
+        });
+    };
+
+    let start = Instant::now();
+    let summary = if progress.stderr_is_terminal {
+        write_with_terminal_progress_async(file, reader, progress, &printer, display_path).await?
+    } else {
+        let bytes_written = tokio::io::copy(reader, file).await?;
+        let bytes_written = i64::try_from(bytes_written).unwrap_or(i64::MAX);
+        ProgressSummary {
+            printer,
+            bytes_read: bytes_written,
+            elapsed: start.elapsed(),
+            to_clear: -1,
+            display_path: display_path.to_string(),
+            clear_native: false,
+        }
+    };
+    let bytes_written = summary.bytes_read;
+    file.flush().await?;
+    Ok(WriteOutcome {
+        bytes_written,
+        summary: Some(summary),
+    })
+}
+
 struct ProgressSummary {
     printer: ProgressPrinter,
     bytes_read: i64,
@@ -312,6 +413,82 @@ impl ProgressSummary {
             self.to_clear,
             &self.display_path,
         );
+    }
+}
+
+async fn write_with_terminal_progress_async<R: AsyncRead + Unpin>(
+    file: &mut tokio::fs::File,
+    reader: &mut R,
+    progress: &WriteProgress,
+    printer: &ProgressPrinter,
+    display_path: &str,
+) -> Result<ProgressSummary, OutputError> {
+    if progress.total_bytes.unwrap_or(-1) > 0 {
+        let native_printer = printer.clone();
+        let stdout_is_terminal = progress.stdout_is_terminal;
+        let mut counter = BarCounter::new_with_on_render(
+            printer.clone(),
+            progress.total_bytes.unwrap_or(-1),
+            Some(move |percent| {
+                if stdout_is_terminal {
+                    emit_native_progress(&native_printer, 1, percent);
+                }
+            }),
+        );
+        copy_async_with_progress(reader, file, |bytes| counter.add(bytes)).await?;
+        let (bytes_read, elapsed) = counter.stop();
+        Ok(ProgressSummary {
+            printer: printer.clone(),
+            bytes_read,
+            elapsed,
+            to_clear: 32,
+            display_path: display_path.to_string(),
+            clear_native: progress.stdout_is_terminal,
+        })
+    } else {
+        let native_printer = printer.clone();
+        let stdout_is_terminal = progress.stdout_is_terminal;
+        let mut counter = SpinnerCounter::new_with_on_start(
+            printer.clone(),
+            Some(move || {
+                if stdout_is_terminal {
+                    emit_native_progress(&native_printer, 3, 0);
+                }
+            }),
+        );
+        copy_async_with_progress(reader, file, |bytes| counter.add(bytes)).await?;
+        let (bytes_read, elapsed) = counter.stop();
+        Ok(ProgressSummary {
+            printer: printer.clone(),
+            bytes_read,
+            elapsed,
+            to_clear: 20,
+            display_path: display_path.to_string(),
+            clear_native: progress.stdout_is_terminal,
+        })
+    }
+}
+
+async fn copy_async_with_progress<R, W, F>(
+    reader: &mut R,
+    writer: &mut W,
+    mut on_chunk: F,
+) -> std::io::Result<u64>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    F: FnMut(i64),
+{
+    let mut buf = vec![0; 16 * 1024];
+    let mut written = 0u64;
+    loop {
+        let n = reader.read(&mut buf).await?;
+        if n == 0 {
+            return Ok(written);
+        }
+        writer.write_all(&buf[..n]).await?;
+        written = written.saturating_add(n as u64);
+        on_chunk(i64::try_from(n).unwrap_or(i64::MAX));
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3256,6 +3256,11 @@ fn additional_formatting_sse_charset_image_and_compression_cases() {
     let mut gzip = GzEncoder::new(Vec::new(), Compression::default());
     gzip.write_all(b"this is the test data").unwrap();
     let gzip_body = gzip.finish().unwrap();
+    let mut huge_gzip = GzEncoder::new(Vec::new(), Compression::default());
+    huge_gzip
+        .write_all(&vec![b' '; 16 * 1024 * 1024 + 1])
+        .unwrap();
+    let huge_gzip_body = huge_gzip.finish().unwrap();
     let mut brotli_body = Vec::new();
     {
         let mut brotli = brotli::CompressorWriter::new(&mut brotli_body, 4096, 5, 22);
@@ -3268,6 +3273,9 @@ fn additional_formatting_sse_charset_image_and_compression_cases() {
         }
         "gzip, br, zstd" if req.path == "/zstd" => {
             TestResponse::ok(zstd_body.clone()).header("Content-Encoding", "zstd")
+        }
+        "gzip, br, zstd" if req.path == "/too-large" => {
+            TestResponse::ok(huge_gzip_body.clone()).header("Content-Encoding", "gzip")
         }
         "gzip, br, zstd" | "gzip" => {
             TestResponse::ok(gzip_body.clone()).header("Content-Encoding", "gzip")
@@ -3285,6 +3293,14 @@ fn additional_formatting_sse_charset_image_and_compression_cases() {
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "this is the test data");
     assert!(res.stderr.contains("gzip"));
+    let res = run_fetch(&[&compressed.url, "--discard"]);
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(res.stderr.contains("200 OK"));
+    let res = run_fetch(&[&format!("{}/too-large", compressed.url), "--format", "on"]);
+    assert_exit(&res, 1);
+    assert!(res.stdout.is_empty());
+    assert!(res.stderr.contains("cannot be buffered"));
     let res = run_fetch(&[&format!("{}/zstd", compressed.url), "-v"]);
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "this is the test data");


### PR DESCRIPTION
## Summary
- Streamed `--discard`, stdout, pager, and file output directly from the response body instead of buffering the full payload first.
- Added async decompression for `gzip`, `br`, and `zstd` so decoded bytes flow through the same streaming pipeline.
- Kept formatted stdout buffered, but capped that path with a decoded-size limit to avoid decompression bombs.
- Preserved trailers, timing, clipboard capture, and file progress behavior across the new async paths.

## Testing
- Added unit coverage for stdout routing decisions and the bounded buffered-format path.
- Added an integration case for a compressed response that expands past the formatting buffer limit.
- Ran formatting, clippy, the full Rust test suite, and the serial integration test suite successfully.