### PR TITLE
Enforce gRPC message limits before buffering frames

### DIFF
--- a/src/format/grpc.rs
+++ b/src/format/grpc.rs
@@ -43,7 +43,7 @@ mod tests {
     #[test]
     fn test_format_grpc_stream_single_frame() {
         let proto_data = append_bytes(append_varint(Vec::new(), 1, 42), 2, b"hello");
-        let output = format_grpc_stream(&frame(&proto_data, false)).unwrap();
+        let output = format_grpc_stream(&frame(&proto_data, false).unwrap()).unwrap();
         assert!(output.contains("1:"));
         assert!(output.contains("42"));
         assert!(output.contains("2:"));
@@ -52,9 +52,9 @@ mod tests {
 
     #[test]
     fn test_format_grpc_stream_multiple_frames() {
-        let frame1 = frame(&append_varint(Vec::new(), 1, 100), false);
-        let frame2 = frame(&append_varint(Vec::new(), 1, 200), false);
-        let frame3 = frame(&append_varint(Vec::new(), 1, 300), false);
+        let frame1 = frame(&append_varint(Vec::new(), 1, 100), false).unwrap();
+        let frame2 = frame(&append_varint(Vec::new(), 1, 200), false).unwrap();
+        let frame3 = frame(&append_varint(Vec::new(), 1, 300), false).unwrap();
 
         let mut stream = Vec::new();
         stream.extend_from_slice(&frame1);
@@ -70,12 +70,12 @@ mod tests {
     #[test]
     fn test_format_grpc_stream_empty_stream_and_message() {
         assert_eq!(format_grpc_stream(&[]).unwrap(), "");
-        assert_eq!(format_grpc_stream(&frame(&[], false)).unwrap(), "");
+        assert_eq!(format_grpc_stream(&frame(&[], false).unwrap()).unwrap(), "");
     }
 
     #[test]
     fn test_format_grpc_stream_compressed_frame() {
-        let err = format_grpc_stream(&frame(b"compressed payload", true)).unwrap_err();
+        let err = format_grpc_stream(&frame(b"compressed payload", true).unwrap()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("compressed gRPC messages are not supported")
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn test_format_grpc_stream_error_mid_stream() {
-        let mut stream = frame(&append_varint(Vec::new(), 1, 42), false);
+        let mut stream = frame(&append_varint(Vec::new(), 1, 42), false).unwrap();
         stream.extend_from_slice(&[0x00, 0x00]);
         assert!(format_grpc_stream(&stream).is_err());
     }
@@ -95,8 +95,8 @@ mod tests {
         let msg2 = append_bytes(append_varint(Vec::new(), 1, 20), 2, b"second");
 
         let mut stream = Vec::new();
-        stream.extend_from_slice(&frame(&msg1, false));
-        stream.extend_from_slice(&frame(&msg2, false));
+        stream.extend_from_slice(&frame(&msg1, false).unwrap());
+        stream.extend_from_slice(&frame(&msg2, false).unwrap());
 
         let output = format_grpc_stream(&stream).unwrap();
         assert!(output.contains("10"));

--- a/src/grpc/framing.rs
+++ b/src/grpc/framing.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
-const MAX_MESSAGE_SIZE: u32 = 64 * 1024 * 1024;
+pub const MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+const FRAME_HEADER_LEN: usize = 5;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Frame {
@@ -19,16 +20,19 @@ impl fmt::Display for FrameError {
 
 impl std::error::Error for FrameError {}
 
-pub fn frame(data: &[u8], compressed: bool) -> Vec<u8> {
+pub fn frame(data: &[u8], compressed: bool) -> Result<Vec<u8>, FrameError> {
+    validate_length(data.len())?;
+    let length = u32::try_from(data.len())
+        .map_err(|_| FrameError(format!("gRPC message too large: {} bytes", data.len())))?;
     let mut out = Vec::with_capacity(5 + data.len());
     out.push(u8::from(compressed));
-    out.extend_from_slice(&(data.len() as u32).to_be_bytes());
+    out.extend_from_slice(&length.to_be_bytes());
     out.extend_from_slice(data);
-    out
+    Ok(out)
 }
 
 pub fn unframe(data: &[u8]) -> Result<Frame, FrameError> {
-    if data.len() < 5 {
+    if data.len() < FRAME_HEADER_LEN {
         return Err(FrameError(
             "failed to read gRPC frame header: insufficient data".to_string(),
         ));
@@ -36,7 +40,7 @@ pub fn unframe(data: &[u8]) -> Result<Frame, FrameError> {
 
     let compressed = data[0] != 0;
     let length = u32::from_be_bytes([data[1], data[2], data[3], data[4]]);
-    validate_length(length)?;
+    validate_length(length as usize)?;
 
     let end = 5 + length as usize;
     if data.len() < end {
@@ -51,36 +55,100 @@ pub fn unframe(data: &[u8]) -> Result<Frame, FrameError> {
     })
 }
 
-pub fn read_frames(mut data: &[u8]) -> Result<Vec<Frame>, FrameError> {
-    let mut frames = Vec::new();
-    while !data.is_empty() {
-        if data.len() < 5 {
+pub fn read_frames(data: &[u8]) -> Result<Vec<Frame>, FrameError> {
+    let mut decoder = FrameDecoder::new();
+    let frames = decoder.push(data)?;
+    decoder.finish()?;
+    Ok(frames)
+}
+
+#[derive(Debug, Default)]
+pub struct FrameDecoder {
+    header: [u8; FRAME_HEADER_LEN],
+    header_len: usize,
+    current: Option<PartialFrame>,
+}
+
+#[derive(Debug)]
+struct PartialFrame {
+    data: Vec<u8>,
+    len: usize,
+    compressed: bool,
+}
+
+impl FrameDecoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, mut chunk: &[u8]) -> Result<Vec<Frame>, FrameError> {
+        let mut frames = Vec::new();
+        while !chunk.is_empty() {
+            if let Some(partial) = self.current.as_mut() {
+                let remaining = partial.len - partial.data.len();
+                let take = remaining.min(chunk.len());
+                partial.data.extend_from_slice(&chunk[..take]);
+                chunk = &chunk[take..];
+
+                if partial.data.len() == partial.len {
+                    let partial = self.current.take().expect("partial frame exists");
+                    frames.push(Frame {
+                        data: partial.data,
+                        compressed: partial.compressed,
+                    });
+                }
+                continue;
+            }
+
+            let take = (FRAME_HEADER_LEN - self.header_len).min(chunk.len());
+            self.header[self.header_len..self.header_len + take].copy_from_slice(&chunk[..take]);
+            self.header_len += take;
+            chunk = &chunk[take..];
+
+            if self.header_len == FRAME_HEADER_LEN {
+                let compressed = self.header[0] != 0;
+                let length = u32::from_be_bytes([
+                    self.header[1],
+                    self.header[2],
+                    self.header[3],
+                    self.header[4],
+                ]) as usize;
+                validate_length(length)?;
+                self.header_len = 0;
+
+                if length == 0 {
+                    frames.push(Frame {
+                        data: Vec::new(),
+                        compressed,
+                    });
+                } else {
+                    self.current = Some(PartialFrame {
+                        data: Vec::new(),
+                        len: length,
+                        compressed,
+                    });
+                }
+            }
+        }
+        Ok(frames)
+    }
+
+    pub fn finish(&self) -> Result<(), FrameError> {
+        if self.header_len > 0 {
             return Err(FrameError(
                 "failed to read gRPC frame header: incomplete header".to_string(),
             ));
         }
-
-        let compressed = data[0] != 0;
-        let length = u32::from_be_bytes([data[1], data[2], data[3], data[4]]);
-        validate_length(length)?;
-
-        let end = 5 + length as usize;
-        if data.len() < end {
+        if self.current.is_some() {
             return Err(FrameError(
                 "failed to read gRPC message: incomplete data".to_string(),
             ));
         }
-
-        frames.push(Frame {
-            data: data[5..end].to_vec(),
-            compressed,
-        });
-        data = &data[end..];
+        Ok(())
     }
-    Ok(frames)
 }
 
-fn validate_length(length: u32) -> Result<(), FrameError> {
+fn validate_length(length: usize) -> Result<(), FrameError> {
     if length > MAX_MESSAGE_SIZE {
         return Err(FrameError(format!(
             "gRPC message too large: {length} bytes"
@@ -117,13 +185,20 @@ mod tests {
         ];
 
         for (name, data, compressed, want) in cases {
-            assert_eq!(frame(&data, compressed), want, "{name}");
+            assert_eq!(frame(&data, compressed).unwrap(), want, "{name}");
         }
 
         let large = vec![0xab; 256];
         let mut want = vec![0x00, 0x00, 0x00, 0x01, 0x00];
         want.extend_from_slice(&large);
-        assert_eq!(frame(&large, false), want, "larger message");
+        assert_eq!(frame(&large, false).unwrap(), want, "larger message");
+    }
+
+    #[test]
+    fn test_frame_large_message_rejected() {
+        let large = vec![0xab; MAX_MESSAGE_SIZE + 1];
+        let err = frame(&large, false).unwrap_err();
+        assert!(err.to_string().contains("gRPC message too large"));
     }
 
     #[test]
@@ -174,7 +249,7 @@ mod tests {
             vec![0x01, 0x02, 0x03, 0x04, 0x05],
             vec![0xab; 1000],
         ] {
-            let framed = frame(&data, false);
+            let framed = frame(&data, false).unwrap();
             let unframed = unframe(&framed).unwrap();
             assert!(!unframed.compressed);
             assert_eq!(unframed.data, data);
@@ -190,8 +265,8 @@ mod tests {
 
     #[test]
     fn test_read_frames() {
-        let one = frame(&[0x01, 0x02, 0x03], false);
-        let two = frame(&[0x04], true);
+        let one = frame(&[0x01, 0x02, 0x03], false).unwrap();
+        let two = frame(&[0x04], true).unwrap();
         let mut stream = one.clone();
         stream.extend_from_slice(&two);
 
@@ -205,5 +280,27 @@ mod tests {
         assert!(read_frames(&[]).unwrap().is_empty());
         assert!(read_frames(&[0x00, 0x00]).is_err());
         assert!(read_frames(&[0x00, 0x00, 0x00, 0x00, 0x05, 0x01]).is_err());
+    }
+
+    #[test]
+    fn test_frame_decoder_rejects_large_message_after_header() {
+        let mut decoder = FrameDecoder::new();
+        let header = [0x00, 0x04, 0x00, 0x00, 0x01];
+        let err = decoder.push(&header).unwrap_err();
+        assert!(err.to_string().contains("gRPC message too large"));
+    }
+
+    #[test]
+    fn test_frame_decoder_accepts_split_frames() {
+        let framed = frame(&[0x01, 0x02, 0x03], false).unwrap();
+        let mut decoder = FrameDecoder::new();
+        assert!(decoder.push(&framed[..2]).unwrap().is_empty());
+        assert!(decoder.push(&framed[2..6]).unwrap().is_empty());
+        let frames = decoder.push(&framed[6..]).unwrap();
+        decoder.finish().unwrap();
+
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].data, vec![0x01, 0x02, 0x03]);
+        assert!(!frames[0].compressed);
     }
 }

--- a/src/grpc/reflection.rs
+++ b/src/grpc/reflection.rs
@@ -126,11 +126,13 @@ async fn invoke(
     url.set_path(path);
     url.set_query(None);
     url.set_fragment(None);
+    let request_body =
+        framing::frame(&payload, false).map_err(|err| FetchError::Message(err.to_string()))?;
 
     let response = client
         .post(url)
         .headers(reflection_headers(cli)?)
-        .body(framing::frame(&payload, false))
+        .body(request_body)
         .send()
         .await?;
     let status_code = response.status();
@@ -145,24 +147,49 @@ async fn invoke(
 
     let headers = response.headers().clone();
     let response: http::Response<reqwest::Body> = response.into();
-    let collected = response.into_body().collect().await?;
-    let trailers = collected.trailers().cloned().unwrap_or_default();
+    let (out, trailers) = read_reflection_frames(response.into_body()).await?;
     if let Some(grpc_status) =
         grpc_status_from_headers(&trailers).or_else(|| grpc_status_from_headers(&headers))
     {
         return Err(grpc_status.to_string().into());
     }
 
-    let frames = framing::read_frames(&collected.to_bytes())
-        .map_err(|err| FetchError::Message(err.to_string()))?;
-    let mut out = Vec::with_capacity(frames.len());
-    for frame in frames {
-        if frame.compressed {
-            return Err("compressed gRPC messages are not supported".into());
-        }
-        out.push(frame.data);
-    }
     Ok(out)
+}
+
+async fn read_reflection_frames(
+    mut body: reqwest::Body,
+) -> Result<(Vec<Vec<u8>>, HeaderMap), FetchError> {
+    let mut decoder = framing::FrameDecoder::new();
+    let mut out = Vec::new();
+    let mut trailers = HeaderMap::new();
+
+    while let Some(frame) = body.frame().await {
+        let frame = frame?;
+        match frame.into_data() {
+            Ok(data) => {
+                for frame in decoder
+                    .push(&data)
+                    .map_err(|err| FetchError::Message(err.to_string()))?
+                {
+                    if frame.compressed {
+                        return Err("compressed gRPC messages are not supported".into());
+                    }
+                    out.push(frame.data);
+                }
+            }
+            Err(frame) => {
+                if let Ok(frame_trailers) = frame.into_trailers() {
+                    trailers = frame_trailers;
+                }
+            }
+        }
+    }
+
+    decoder
+        .finish()
+        .map_err(|err| FetchError::Message(err.to_string()))?;
+    Ok((out, trailers))
 }
 
 fn reflection_client(cli: &Cli) -> Result<Client, FetchError> {
@@ -509,5 +536,17 @@ mod tests {
             normalize_reflection_symbol("grpc.health.v1.Health/Check"),
             "grpc.health.v1.Health.Check"
         );
+    }
+
+    #[tokio::test]
+    async fn reflection_reader_rejects_oversized_message_from_header() {
+        let body =
+            reqwest::Body::wrap_stream(futures_util::stream::iter([Ok::<_, std::io::Error>(
+                bytes::Bytes::from_static(&[0x00, 0x04, 0x00, 0x00, 0x01]),
+            )]));
+
+        let err = read_reflection_frames(body).await.unwrap_err();
+
+        assert!(err.to_string().contains("gRPC message too large"));
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -4196,7 +4196,7 @@ mod tests {
     fn grpc_request_body_frames_empty_and_raw_bodies() {
         let empty = proto::grpc_request_body(None, None).unwrap();
         let empty = request_body_into_bytes(empty).unwrap().unwrap();
-        assert_eq!(empty.0, crate::grpc::framing::frame(&[], false));
+        assert_eq!(empty.0, crate::grpc::framing::frame(&[], false).unwrap());
         assert_eq!(empty.1.as_deref(), Some("application/grpc+proto"));
 
         let framed = proto::grpc_request_body(
@@ -4205,7 +4205,10 @@ mod tests {
         )
         .unwrap();
         let framed = request_body_into_bytes(framed).unwrap().unwrap();
-        assert_eq!(framed.0, crate::grpc::framing::frame(b"hello", false));
+        assert_eq!(
+            framed.0,
+            crate::grpc::framing::frame(b"hello", false).unwrap()
+        );
     }
 
     #[test]

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -217,7 +217,7 @@ pub(crate) fn grpc_request_body(
         Vec::new()
     };
     Ok(Some(crate::http::RequestBodyPayload::from_bytes(
-        framing::frame(&raw, false),
+        framing::frame(&raw, false).map_err(|err| FetchError::Message(err.to_string()))?,
         Some(grpc_content_type()),
     )))
 }
@@ -369,7 +369,7 @@ fn frame_raw_body(body: crate::http::RequestBody) -> Result<crate::http::Request
         .map(|(bytes, _)| bytes)
         .unwrap_or_default();
     Ok(Some(crate::http::RequestBodyPayload::from_bytes(
-        framing::frame(&raw, false),
+        framing::frame(&raw, false).map_err(|err| FetchError::Message(err.to_string()))?,
         Some(grpc_content_type()),
     )))
 }
@@ -444,7 +444,9 @@ pub fn stream_json_to_grpc_frames(
         deserializer
             .end()
             .map_err(|err| ProtoError::Message(format!("failed to decode JSON message: {err}")))?;
-        out.extend_from_slice(&framing::frame(&msg.encode_to_vec(), false));
+        let frame = framing::frame(&msg.encode_to_vec(), false)
+            .map_err(|err| ProtoError::Message(err.to_string()))?;
+        out.extend_from_slice(&frame);
     }
     Ok(out)
 }
@@ -959,7 +961,7 @@ mod tests {
         let method = schema
             .find_method("streampkg.StreamService/ClientStream")
             .unwrap();
-        let body = framing::frame(b"\x08\x03", false);
+        let body = framing::frame(b"\x08\x03", false).unwrap();
 
         let out = format_grpc_stream_with_descriptor(&body, &method.output()).unwrap();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -335,7 +335,7 @@ impl PartialBodyReplayServer {
                             }
                             let _ = write!(
                                 stream,
-                                "Content-Length: 1073741824\r\nConnection: keep-alive\r\n\r\n"
+                                "Content-Length: 1073741824\r\nConnection: close\r\n\r\n"
                             );
                             let chunk = vec![b'x'; 16 * 1024];
                             for _ in 0..128 {


### PR DESCRIPTION
## Summary
- Enforce the 64 MiB gRPC message cap before outbound framing writes the length prefix.
- Stream reflection responses through a frame decoder so oversized messages are rejected before the full body is collected.
- Update gRPC call sites and tests for the new checked framing API.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`