### PR TITLE
Reject replay of stdin request bodies on retries and digest auth

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -303,7 +303,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                         client: &client,
                         method: request_method,
                         headers: headers.clone(),
-                        body: request_body,
+                        body: request_body.clone(),
                         cli,
                         redirect_statuses,
                     },
@@ -312,6 +312,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                 .await?;
                 let status = response.status();
                 if attempt < retry_count && should_retry_status(status) {
+                    ensure_request_body_replayable(&request_body, "retry")?;
                     let delay =
                         compute_delay(retry_delay, attempt, parse_retry_after(response.headers()));
                     print_retry(
@@ -340,6 +341,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                     break Err(FetchError::Runtime(message));
                 }
                 if attempt < retry_count && is_retryable_error(&err) {
+                    ensure_request_body_replayable(&request_body, "retry")?;
                     let delay = compute_delay(retry_delay, attempt, Duration::ZERO);
                     print_retry(cli, attempt + 2, total_attempts, delay, &err.to_string());
                     tokio::time::sleep(delay).await;
@@ -1681,6 +1683,7 @@ async fn apply_digest_challenge(
     let challenged_url = response.url().clone();
     let (challenged_method, challenged_body) =
         digest_challenged_request(context.method, context.body, &context.redirect_statuses);
+    ensure_request_body_replayable(&challenged_body, "digest authentication")?;
     let auth = match digest::response(
         challenged_method.as_str(),
         &request_target(&challenged_url),
@@ -2358,6 +2361,15 @@ fn request_body_replayable(body: &RequestBody) -> bool {
         body.as_ref().map(|body| &body.source),
         Some(RequestBodySource::Stdin)
     )
+}
+
+fn ensure_request_body_replayable(body: &RequestBody, action: &str) -> Result<(), FetchError> {
+    if request_body_replayable(body) {
+        return Ok(());
+    }
+    Err(FetchError::Runtime(format!(
+        "request body from stdin cannot be replayed for {action}"
+    )))
 }
 
 fn print_redirect_status(cli: &Cli, status: StatusCode) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2587,6 +2587,32 @@ fn digest_auth_replays_after_challenge() {
 }
 
 #[test]
+fn digest_auth_rejects_stdin_body_replay_after_challenge() {
+    let server = TestServer::start(|req| {
+        assert!(req.header("authorization").is_empty());
+        TestResponse::status(401, "Unauthorized", "").header(
+            "WWW-Authenticate",
+            r#"Digest realm="test", nonce="abc123", qop="auth", algorithm="MD5""#,
+        )
+    });
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            stdin: Some("hello=world".to_string()),
+            ..Default::default()
+        },
+        &[&server.url, "--digest", "user:pass", "--data", "@-"],
+    );
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr
+            .contains("request body from stdin cannot be replayed for digest authentication"),
+        "stderr:\n{}",
+        res.stderr
+    );
+}
+
+#[test]
 fn digest_auth_drain_is_bounded_for_large_challenge_body() {
     let server = PartialBodyReplayServer::start(
         401,
@@ -2695,6 +2721,36 @@ fn retry_statuses_and_request_body_replay() {
         "payload",
     ]);
     assert_exit(&res, 0);
+}
+
+#[test]
+fn retry_status_rejects_stdin_body_replay() {
+    let server = TestServer::start(|_| {
+        TestResponse::status(503, "Service Unavailable", "retry").header("Connection", "keep-alive")
+    });
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            stdin: Some("payload".to_string()),
+            ..Default::default()
+        },
+        &[
+            &server.url,
+            "--retry",
+            "1",
+            "--retry-delay",
+            FAST_RETRY_DELAY,
+            "--data",
+            "@-",
+        ],
+    );
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr
+            .contains("request body from stdin cannot be replayed for retry"),
+        "stderr:\n{}",
+        res.stderr
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Guard retry resends and digest-auth challenge replays against non-replayable stdin bodies.
- Return a clear runtime error instead of attempting to resend consumed stdin input.
- Add integration coverage for both retry and digest flows using `--data @-`.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`