### PR TITLE
Centralize auto-update duration parsing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,9 @@ auto-update = false
 
 # Custom update interval
 auto-update = 4h
+auto-update = 1.5h
 auto-update = 30m
+auto-update = +30m
 auto-update = 1d
 ```
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -615,7 +615,7 @@ fn parse_bool_go(value: &str) -> Option<bool> {
 }
 
 fn validate_auto_update(path: &Path, line_num: usize, value: &str) -> Result<String, String> {
-    if parse_bool_go(value).is_some() || is_go_duration(value) {
+    if parse_bool_go(value).is_some() || crate::duration::parse_duration_interval(value).is_some() {
         Ok(value.to_string())
     } else {
         Err(value_error(
@@ -626,46 +626,6 @@ fn validate_auto_update(path: &Path, line_num: usize, value: &str) -> Result<Str
             "must be either a boolean or interval",
         ))
     }
-}
-
-fn is_go_duration(value: &str) -> bool {
-    let rest = value.strip_prefix(['+', '-']).unwrap_or(value);
-    if rest.is_empty() {
-        return false;
-    }
-
-    let mut rest = rest;
-    while !rest.is_empty() {
-        let before_digits = rest.len();
-        let digits = rest
-            .bytes()
-            .take_while(|byte| byte.is_ascii_digit())
-            .count();
-        rest = &rest[digits..];
-        let mut saw_digit = digits > 0;
-
-        if let Some(after_dot) = rest.strip_prefix('.') {
-            let frac_digits = after_dot
-                .bytes()
-                .take_while(|byte| byte.is_ascii_digit())
-                .count();
-            saw_digit |= frac_digits > 0;
-            rest = &after_dot[frac_digits..];
-        }
-
-        if !saw_digit || rest.len() == before_digits {
-            return false;
-        }
-
-        let Some(unit) = ["ns", "us", "\u{00B5}s", "\u{03BC}s", "ms", "s", "m", "h"]
-            .iter()
-            .find(|unit| rest.starts_with(**unit))
-        else {
-            return false;
-        };
-        rest = &rest[unit.len()..];
-    }
-    true
 }
 
 fn parse_duration_seconds(
@@ -1312,6 +1272,27 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn auto_update_validation_matches_duration_parser() {
+        let path = PathBuf::from("test/config");
+        for value in ["1.5h", "+30m", "1d"] {
+            assert_eq!(
+                parse_file(&path, &format!("auto-update = {value}\n"))
+                    .unwrap()
+                    .global
+                    .auto_update,
+                Some(value.to_string())
+            );
+        }
+
+        let err = parse_file(&path, "auto-update = -1h\n").unwrap_err();
+        assert!(err.contains("invalid value"), "{err}");
+        assert!(
+            err.contains("must be either a boolean or interval"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,0 +1,140 @@
+use std::time::Duration;
+
+const NANOS_PER_MICRO: u128 = 1_000;
+const NANOS_PER_MILLI: u128 = 1_000_000;
+const NANOS_PER_SECOND: u128 = 1_000_000_000;
+const NANOS_PER_MINUTE: u128 = 60 * NANOS_PER_SECOND;
+const NANOS_PER_HOUR: u128 = 60 * NANOS_PER_MINUTE;
+const NANOS_PER_DAY: u128 = 24 * NANOS_PER_HOUR;
+
+pub(crate) fn parse_duration_interval(value: &str) -> Option<Duration> {
+    let mut rest = value.trim();
+    if rest.is_empty() || rest.starts_with('-') {
+        return None;
+    }
+    rest = rest.strip_prefix('+').unwrap_or(rest);
+    if rest.is_empty() {
+        return None;
+    }
+
+    let mut total = 0u128;
+    while !rest.is_empty() {
+        let (nanos, next) = parse_duration_part(rest)?;
+        total = total.checked_add(nanos)?;
+        rest = next;
+    }
+
+    u64::try_from(total).ok().map(Duration::from_nanos)
+}
+
+fn parse_duration_part(value: &str) -> Option<(u128, &str)> {
+    let whole_len = value
+        .bytes()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    let mut rest = &value[whole_len..];
+    let whole = if whole_len == 0 {
+        0
+    } else {
+        value[..whole_len].parse::<u128>().ok()?
+    };
+
+    let mut fraction = 0u128;
+    let mut scale = 1u128;
+    if let Some(after_dot) = rest.strip_prefix('.') {
+        let frac_len = after_dot
+            .bytes()
+            .take_while(|byte| byte.is_ascii_digit())
+            .count();
+        if whole_len == 0 && frac_len == 0 {
+            return None;
+        }
+        for byte in after_dot[..frac_len].bytes() {
+            fraction = fraction
+                .checked_mul(10)?
+                .checked_add(u128::from(byte - b'0'))?;
+            scale = scale.checked_mul(10)?;
+        }
+        rest = &after_dot[frac_len..];
+    } else if whole_len == 0 {
+        return None;
+    }
+
+    let (unit, multiplier) = duration_unit(rest)?;
+    rest = &rest[unit.len()..];
+    let nanos = whole
+        .checked_mul(multiplier)?
+        .checked_add(fraction.checked_mul(multiplier)?.checked_div(scale)?)?;
+
+    Some((nanos, rest))
+}
+
+fn duration_unit(value: &str) -> Option<(&'static str, u128)> {
+    for (unit, nanos) in [
+        ("ms", NANOS_PER_MILLI),
+        ("us", NANOS_PER_MICRO),
+        ("\u{00B5}s", NANOS_PER_MICRO),
+        ("\u{03BC}s", NANOS_PER_MICRO),
+        ("ns", 1),
+        ("d", NANOS_PER_DAY),
+        ("h", NANOS_PER_HOUR),
+        ("m", NANOS_PER_MINUTE),
+        ("s", NANOS_PER_SECOND),
+    ] {
+        if value.starts_with(unit) {
+            return Some((unit, nanos));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_fractional_positive_and_day_durations() {
+        assert_eq!(
+            parse_duration_interval("1.5h"),
+            Some(Duration::from_secs(90 * 60))
+        );
+        assert_eq!(
+            parse_duration_interval("+30m"),
+            Some(Duration::from_secs(30 * 60))
+        );
+        assert_eq!(
+            parse_duration_interval("1d"),
+            Some(Duration::from_secs(24 * 60 * 60))
+        );
+    }
+
+    #[test]
+    fn parses_compound_and_subsecond_durations() {
+        assert_eq!(
+            parse_duration_interval("1h30m"),
+            Some(Duration::from_secs(90 * 60))
+        );
+        assert_eq!(
+            parse_duration_interval(".5s"),
+            Some(Duration::from_millis(500))
+        );
+        assert_eq!(
+            parse_duration_interval("250ms"),
+            Some(Duration::from_millis(250))
+        );
+        assert_eq!(
+            parse_duration_interval("1.5ms"),
+            Some(Duration::from_micros(1500))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_or_negative_durations() {
+        assert_eq!(parse_duration_interval(""), None);
+        assert_eq!(parse_duration_interval("+"), None);
+        assert_eq!(parse_duration_interval("0"), None);
+        assert_eq!(parse_duration_interval("-1h"), None);
+        assert_eq!(parse_duration_interval("1sec"), None);
+        assert_eq!(parse_duration_interval("garbage"), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod config;
 pub mod core;
 pub mod dns;
+pub(crate) mod duration;
 pub mod error;
 pub mod fileutil;
 pub mod format;

--- a/src/update.rs
+++ b/src/update.rs
@@ -852,50 +852,7 @@ fn parse_auto_update_interval(value: &str) -> Option<Duration> {
         _ => {}
     }
 
-    parse_go_duration(value)
-}
-
-fn parse_go_duration(value: &str) -> Option<Duration> {
-    if value.starts_with('-') {
-        return None;
-    }
-
-    let mut rest = value;
-    let mut total = Duration::ZERO;
-    while !rest.is_empty() {
-        let value_len = rest
-            .bytes()
-            .take_while(|byte| byte.is_ascii_digit())
-            .count();
-        if value_len == 0 {
-            return None;
-        }
-        let amount = rest[..value_len].parse::<u64>().ok()?;
-        rest = &rest[value_len..];
-
-        let (unit, multiplier) = duration_unit(rest)?;
-        rest = &rest[unit.len()..];
-        total = total.checked_add(Duration::from_nanos(amount.checked_mul(multiplier)?))?;
-    }
-
-    Some(total)
-}
-
-fn duration_unit(value: &str) -> Option<(&'static str, u64)> {
-    for (unit, nanos) in [
-        ("ms", 1_000_000),
-        ("us", 1_000),
-        ("µs", 1_000),
-        ("ns", 1),
-        ("h", 60 * 60 * 1_000_000_000),
-        ("m", 60 * 1_000_000_000),
-        ("s", 1_000_000_000),
-    ] {
-        if value.starts_with(unit) {
-            return Some((unit, nanos));
-        }
-    }
-    None
+    crate::duration::parse_duration_interval(value)
 }
 
 fn changelog_compare_ref(old_version: &str) -> String {
@@ -1493,6 +1450,18 @@ mod tests {
         assert_eq!(
             parse_auto_update_interval("1h30m"),
             Some(Duration::from_secs(90 * 60))
+        );
+        assert_eq!(
+            parse_auto_update_interval("1.5h"),
+            Some(Duration::from_secs(90 * 60))
+        );
+        assert_eq!(
+            parse_auto_update_interval("+30m"),
+            Some(Duration::from_secs(30 * 60))
+        );
+        assert_eq!(
+            parse_auto_update_interval("1d"),
+            Some(Duration::from_secs(24 * 60 * 60))
         );
         assert_eq!(
             parse_auto_update_interval("250ms"),


### PR DESCRIPTION
## Summary
- Added a shared duration parser in `src/duration.rs` and wired both config validation and auto-update execution to it.
- Extended auto-update intervals to accept fractional units, leading `+`, and `d` for day-sized intervals.
- Updated the configuration docs to match the supported syntax.
- Added tests covering `1.5h`, `+30m`, `1d`, and negative-duration rejection.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`