### PR TITLE
Preserve Basic and Digest credential whitespace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - Response compression negotiation is controlled by `--compress auto|br|gzip|zstd|off` or `compress = ...`; `brotli` is accepted as an alias for `br`, `auto` requests and decodes gzip/brotli/zstd, single-algorithm modes only request/decode that algorithm, and `off` leaves compressed bodies untouched.
 - `--sort-headers` or `sort-headers = true` sorts displayed request/response headers alphabetically by name in verbose output without changing the actual request header order.
 - Default HTTP requests send `Accept: application/json, */*;q=0.5`, preferring JSON while allowing any other response type as a lower-priority fallback.
+- `--basic` and `--digest` credentials preserve exact bytes around the first colon; leading/trailing spaces in usernames or passwords are significant and are not trimmed after CLI or `--from-curl` parsing.
 
 Retryable requests use replayable request bodies so retries and 307/308 redirects can resend data without holding unrelated state.
 Multipart `-F` request bodies are produced with a stable boundary so redirected requests preserve the original body shape.

--- a/src/app.rs
+++ b/src/app.rs
@@ -249,7 +249,7 @@ async fn run_inner(cli: &mut Cli) -> Result<i32, FetchError> {
     crate::cli::normalize_range_values(&mut cli.ranges).map_err(FetchError::Message)?;
     validate_proto_schema_files(cli)?;
     validate_client_certificate_flags(direct_cli_sources)?;
-    normalize_auth_credentials(cli)?;
+    validate_auth_credentials(cli)?;
     print_config_debug(cli, config_path.as_deref());
 
     if cli.update {
@@ -347,12 +347,12 @@ fn validate_client_certificate_flags(sources: DirectCliSources) -> Result<(), Fe
     Ok(())
 }
 
-fn normalize_auth_credentials(cli: &mut Cli) -> Result<(), FetchError> {
+fn validate_auth_credentials(cli: &mut Cli) -> Result<(), FetchError> {
     if let Some(value) = cli.basic.take() {
-        cli.basic = Some(normalize_user_password_option("basic", &value)?);
+        cli.basic = Some(validate_user_password_option("basic", &value)?);
     }
     if let Some(value) = cli.digest.take() {
-        cli.digest = Some(normalize_user_password_option("digest", &value)?);
+        cli.digest = Some(validate_user_password_option("digest", &value)?);
     }
     Ok(())
 }
@@ -377,14 +377,14 @@ fn print_config_debug(cli: &Cli, path: Option<&std::path::Path>) {
     let _ = printer.flush_to(&mut stderr);
 }
 
-fn normalize_user_password_option(option: &str, value: &str) -> Result<String, FetchError> {
-    let Some((username, password)) = value.split_once(':') else {
+fn validate_user_password_option(option: &str, value: &str) -> Result<String, FetchError> {
+    if !value.contains(':') {
         return Err(format!(
             "invalid value '{value}' for option '--{option}': format must be <USERNAME:PASSWORD>"
         )
         .into());
-    };
-    Ok(format!("{}:{}", username.trim(), password.trim()))
+    }
+    Ok(value.to_string())
 }
 
 fn check_file_exists(path: &str) -> Result<(), FetchError> {
@@ -1153,14 +1153,14 @@ mod tests {
     }
 
     #[test]
-    fn basic_auth_parsing_trims_like_go() {
+    fn basic_auth_parsing_preserves_spaces() {
         let mut cli =
             Cli::try_parse_from(["fetch", "--basic", " user : pass ", "http://example.com"])
                 .unwrap();
 
-        normalize_auth_credentials(&mut cli).unwrap();
+        validate_auth_credentials(&mut cli).unwrap();
 
-        assert_eq!(cli.basic.as_deref(), Some("user:pass"));
+        assert_eq!(cli.basic.as_deref(), Some(" user : pass "));
     }
 
     #[test]
@@ -1168,9 +1168,7 @@ mod tests {
         let mut cli =
             Cli::try_parse_from(["fetch", "--basic", "nocolon", "http://example.com"]).unwrap();
 
-        let err = normalize_auth_credentials(&mut cli)
-            .unwrap_err()
-            .to_string();
+        let err = validate_auth_credentials(&mut cli).unwrap_err().to_string();
 
         assert_eq!(
             err,
@@ -1203,7 +1201,18 @@ mod tests {
     }
 
     #[test]
-    fn from_curl_basic_auth_trims_like_go_application() {
+    fn digest_auth_parsing_preserves_spaces() {
+        let mut cli =
+            Cli::try_parse_from(["fetch", "--digest", " user : pass ", "http://example.com"])
+                .unwrap();
+
+        validate_auth_credentials(&mut cli).unwrap();
+
+        assert_eq!(cli.digest.as_deref(), Some(" user : pass "));
+    }
+
+    #[test]
+    fn from_curl_basic_auth_preserves_spaces() {
         let mut cli = Cli::try_parse_from([
             "fetch",
             "--from-curl",
@@ -1212,9 +1221,9 @@ mod tests {
         .unwrap();
 
         apply_from_curl(&mut cli).unwrap();
-        normalize_auth_credentials(&mut cli).unwrap();
+        validate_auth_credentials(&mut cli).unwrap();
 
-        assert_eq!(cli.basic.as_deref(), Some("user:pass"));
+        assert_eq!(cli.basic.as_deref(), Some(" user : pass "));
     }
 
     #[test]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -2831,11 +2831,10 @@ pub(crate) fn basic_header(value: Option<&str>) -> Result<Option<String>, FetchE
     let Some(value) = value else {
         return Ok(None);
     };
-    let Some((username, password)) = value.split_once(':') else {
+    if !value.contains(':') {
         return Err("basic format must be <USERNAME:PASSWORD>".into());
-    };
-    let normalized = format!("{}:{}", username.trim(), password.trim());
-    let encoded = base64::engine::general_purpose::STANDARD.encode(normalized.as_bytes());
+    }
+    let encoded = base64::engine::general_purpose::STANDARD.encode(value.as_bytes());
     Ok(Some(format!("Basic {encoded}")))
 }
 
@@ -3568,6 +3567,10 @@ mod tests {
             digest_credentials(Some("user:pass")).unwrap(),
             Some(("user".to_string(), "pass".to_string()))
         );
+        assert_eq!(
+            digest_credentials(Some(" user : pass ")).unwrap(),
+            Some((" user ".to_string(), " pass ".to_string()))
+        );
         assert!(digest_credentials(Some("nocolon")).is_err());
         assert_eq!(digest_credentials(None).unwrap(), None);
     }
@@ -3605,10 +3608,10 @@ mod tests {
     }
 
     #[test]
-    fn basic_header_encodes_credentials_like_go() {
+    fn basic_header_preserves_credential_spaces() {
         assert_eq!(
             basic_header(Some(" user : pass ")).unwrap(),
-            Some("Basic dXNlcjpwYXNz".to_string())
+            Some("Basic IHVzZXIgOiBwYXNzIA==".to_string())
         );
         assert!(basic_header(Some("nocolon")).is_err());
         assert_eq!(basic_header(None).unwrap(), None);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2612,6 +2612,15 @@ fn basic_bearer_and_aws_auth_headers() {
             assert_eq!(String::from_utf8_lossy(&decoded), "user:pass");
             return TestResponse::ok("");
         }
+        if req.path == "/basic-spaces" {
+            let auth = req.header("authorization");
+            let raw = auth.strip_prefix("Basic ").unwrap_or_default();
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(raw)
+                .unwrap_or_default();
+            assert_eq!(String::from_utf8_lossy(&decoded), " user : pass ");
+            return TestResponse::ok("");
+        }
         if req.path == "/bearer" {
             assert_eq!(req.header("authorization"), "Bearer token");
             return TestResponse::ok("");
@@ -2630,6 +2639,13 @@ fn basic_bearer_and_aws_auth_headers() {
     });
 
     let res = run_fetch(&[&format!("{}/basic", server.url), "--basic", "user:pass"]);
+    assert_exit(&res, 0);
+
+    let res = run_fetch(&[
+        &format!("{}/basic-spaces", server.url),
+        "--basic",
+        " user : pass ",
+    ]);
     assert_exit(&res, 0);
 
     let res = run_fetch(&[&format!("{}/bearer", server.url), "--bearer", "token"]);


### PR DESCRIPTION
## Summary
- Stop trimming Basic and Digest credentials after CLI and `--from-curl` parsing.
- Encode Basic auth from the exact supplied bytes after the first colon.
- Add regression coverage for spaced credentials in CLI, header construction, and integration tests.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features --lib`
- `cargo test --all-features --test integration basic_bearer_and_aws_auth_headers -- --test-threads=1`