### PR TITLE
Mirror reqwest NO_PROXY CIDR handling for HTTP/2 and HTTP/3 env proxy checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - `--sort-headers` or `sort-headers = true` sorts displayed request/response headers alphabetically by name in verbose output without changing the actual request header order.
 - Default HTTP requests send `Accept: application/json, */*;q=0.5`, preferring JSON while allowing any other response type as a lower-priority fallback.
 - `--basic` and `--digest` credentials preserve exact bytes around the first colon; leading/trailing spaces in usernames or passwords are significant and are not trimmed after CLI or `--from-curl` parsing.
+- The HTTP/2/3 environment-proxy guard mirrors reqwest `NO_PROXY` matching for hosts, domains, IP literals, CIDR ranges, and `*` so env proxies do not incorrectly block direct private-network requests.
 
 Retryable requests use replayable request bodies so retries and 307/308 redirects can resend data without holding unrelated state.
 Multipart `-F` request bodies are produced with a stable boundary so redirected requests preserve the original body shape.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "http-body-util",
  "httpdate",
  "image",
+ "ipnet",
  "libc",
  "md-5",
  "mimalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ http = "1"
 http-body-util = "0.1"
 httpdate = "1"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "tiff", "webp"] }
+ipnet = "2"
 libc = "0.2"
 md-5 = "0.11"
 mime = "0.3"

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -97,10 +97,12 @@ fetch --proxy http://user:password@proxy.example.com:8080 example.com
 ```sh
 export HTTP_PROXY="http://proxy.example.com:8080"
 export HTTPS_PROXY="http://proxy.example.com:8080"
-export NO_PROXY="localhost,127.0.0.1,.internal.com"
+export NO_PROXY="localhost,127.0.0.1,192.168.0.0/16,.internal.com"
 
 fetch example.com  # Uses proxy from environment
 ```
+
+`NO_PROXY` entries may be hosts, domains, IP addresses, CIDR ranges, or `*`.
 
 ### Configuration File
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -709,7 +709,7 @@ fetch --update --dry-run
 | `VISUAL` / `EDITOR`     | Editor for `--edit` option                                |
 | `HTTPS_PROXY`           | HTTPS proxy URL                                           |
 | `HTTP_PROXY`            | HTTP proxy URL                                            |
-| `NO_PROXY`              | Hosts to bypass proxy                                     |
+| `NO_PROXY`              | Hosts, domains, IPs, or CIDR ranges to bypass proxy       |
 
 ## File References
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
+use ipnet::IpNet;
 use reqwest::{Client, redirect};
 use tower::{Layer, Service};
 use url::Url;
@@ -444,6 +445,7 @@ pub(crate) fn no_proxy_matches_url(url: &Url, no_proxy: Option<&str>) -> bool {
         .trim_start_matches('[')
         .trim_end_matches(']')
         .to_ascii_lowercase();
+    let host_ip = host.parse::<IpAddr>().ok();
     no_proxy.split(',').any(|entry| {
         let entry = entry.trim();
         if entry == "*" {
@@ -451,6 +453,12 @@ pub(crate) fn no_proxy_matches_url(url: &Url, no_proxy: Option<&str>) -> bool {
         }
         if entry.is_empty() {
             return false;
+        }
+        if let Some(host_ip) = host_ip {
+            return entry
+                .parse::<IpNet>()
+                .is_ok_and(|network| network.contains(&host_ip))
+                || entry.parse::<IpAddr>().is_ok_and(|ip| ip == host_ip);
         }
         let entry = entry.trim_start_matches('.').to_ascii_lowercase();
         host == entry
@@ -631,6 +639,25 @@ mod tests {
         assert!(!no_proxy_matches_url(&url, Some("notexample.com")));
         assert!(!no_proxy_matches_url(&url, Some("")));
         assert!(!no_proxy_matches_url(&url, None));
+    }
+
+    #[test]
+    fn no_proxy_matching_supports_ip_and_cidr_entries() {
+        let ipv4_url = Url::parse("https://192.168.1.42/api").unwrap();
+        let ipv6_url = Url::parse("https://[fd00::42]/api").unwrap();
+
+        assert!(no_proxy_matches_url(&ipv4_url, Some("192.168.1.42")));
+        assert!(no_proxy_matches_url(&ipv4_url, Some("192.168.1.0/24")));
+        assert!(!no_proxy_matches_url(&ipv4_url, Some(".192.168.1.42")));
+        assert!(no_proxy_matches_url(
+            &ipv4_url,
+            Some("10.0.0.0/8, 192.168.0.0/16")
+        ));
+        assert!(!no_proxy_matches_url(&ipv4_url, Some("192.168.2.0/24")));
+
+        assert!(no_proxy_matches_url(&ipv6_url, Some("fd00::42")));
+        assert!(no_proxy_matches_url(&ipv6_url, Some("fd00::/8")));
+        assert!(!no_proxy_matches_url(&ipv6_url, Some("fe80::/10")));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5848,7 +5848,7 @@ fn grpc_reflection_h2c_go_cases() {
                     "HTTP_PROXY".to_string(),
                     "http://proxy.example:8080".to_string(),
                 ),
-                ("NO_PROXY".to_string(), "127.0.0.1".to_string()),
+                ("NO_PROXY".to_string(), "127.0.0.0/8".to_string()),
             ],
             ..Default::default()
         },


### PR DESCRIPTION
## Summary
- Extended the HTTP/2 and HTTP/3 env-proxy guard to recognize `NO_PROXY` IP literals and CIDR ranges, matching reqwest’s documented rules more closely.
- Added focused unit coverage for IPv4, IPv6, and CIDR matches, plus a non-match case for numeric-looking domain syntax.
- Updated the gRPC integration case to verify a CIDR-based `NO_PROXY` bypass against an env proxy.
- Kept the proxy documentation and repo guidance in sync with the broader `NO_PROXY` behavior.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`