### PR TITLE
Print AWS SigV4 headers in verbose stderr output

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -207,6 +207,16 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
             if !auth_allowed {
                 strip_cross_origin_sensitive_headers(&mut attempt_headers);
             }
+            if auth_allowed && let Some(config) = &aws_config {
+                apply_aws_sigv4(
+                    cli,
+                    request_method.as_str(),
+                    &request_url,
+                    &mut attempt_headers,
+                    &request_body,
+                    config,
+                )?;
+            }
             if cli.verbose >= 2 && !cli.silent {
                 print_request_metadata(
                     cli,
@@ -225,16 +235,6 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                     .and_then(|resolution| resolution.timing.as_ref())
             {
                 print_dns_debug(cli, dns);
-            }
-            if auth_allowed && let Some(config) = &aws_config {
-                apply_aws_sigv4(
-                    cli,
-                    request_method.as_str(),
-                    &request_url,
-                    &mut attempt_headers,
-                    &request_body,
-                    config,
-                )?;
             }
 
             let req = build_request(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2779,6 +2779,7 @@ fn basic_bearer_and_aws_auth_headers() {
             &format!("{}/aws", server.url),
             "--aws-sigv4",
             "us-east-1/s3",
+            "-vv",
         ],
     );
     assert_exit(&res, 0);
@@ -2786,6 +2787,12 @@ fn basic_bearer_and_aws_auth_headers() {
         res.stdout,
         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     );
+    assert!(res.stderr.contains("> authorization: AWS4-HMAC-SHA256 "));
+    assert!(res.stderr.contains("> x-amz-date: "));
+    assert!(res.stderr.contains("> x-amz-security-token: session-token"));
+    assert!(res.stderr.contains(
+        "> x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Sign AWS-authenticated requests before verbose request metadata is printed so stderr shows the final outgoing headers.
- Add an integration regression that checks `-vv` output includes the AWS SigV4 authorization, date, session token, and payload hash headers.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`