### PR TITLE
Rename timing connect phase label to Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A modern HTTP(S) client for the command line.
 - **Compression** - Automatic gzip, brotli, and zstd response body decompression
 - **TLS inspection** - Inspect TLS certificate chains, expiry, SANs, and OCSP status
 - **DNS inspection** - Inspect hostname resolution, record families, TTLs, and resolver timing
-- **Timing waterfall** - Visualize request timing phases (DNS, TCP, TLS, TTFB, transfer) with a waterfall chart
+- **Timing waterfall** - Visualize request timing phases (DNS, Connect, TTFB, transfer) with a waterfall chart
 - **Configuration** - Global and per-host configuration file support
 
 ## Quick Start

--- a/src/timing/mod.rs
+++ b/src/timing/mod.rs
@@ -187,7 +187,7 @@ pub fn print_debug_lines(timing: &AttemptTiming, target: &str, color: Option<&st
         .unwrap_or_default();
     let mut out = Printer::new(core::color_enabled(color, std::io::stderr().is_terminal()));
     out.write_info_prefix();
-    out.write_styled("TCP", &[Sequence::Bold, Sequence::Yellow]);
+    out.write_styled("Connect", &[Sequence::Bold, Sequence::Yellow]);
     out.push_str(": ");
     out.push_str(target);
     out.push_str(" ");
@@ -218,7 +218,7 @@ fn build_phases(timing: ResponseTiming) -> Vec<Phase> {
     }
     if let Some(connect) = timing.connect {
         phases.push(Phase {
-            label: "TCP",
+            label: "Connect",
             color: Sequence::Green,
             duration: connect,
         });
@@ -352,7 +352,7 @@ mod tests {
         );
 
         assert!(out.contains("\x1b[1m\x1b[36mDNS  "));
-        assert!(out.contains("\x1b[1m\x1b[32mTCP"));
+        assert!(out.contains("\x1b[1m\x1b[32mConnect"));
         assert!(out.contains("\x1b[1m\x1b[35mTTFB "));
         assert!(out.contains("\x1b[34m█\x1b[0m"));
         assert!(out.contains("\x1b[2mTotal"));
@@ -375,7 +375,7 @@ mod tests {
                 .char_indices()
                 .find_map(|(index, ch)| (ch == '█' || ch == '░').then_some(index))
                 .expect("waterfall line has a bar");
-            assert_eq!(bar_start, 9, "{line}");
+            assert_eq!(bar_start, 11, "{line}");
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2667,7 +2667,7 @@ fn verbosity_and_color_output() {
 
     let res = run_fetch(&[&server.url, "-vvv"]);
     assert_exit(&res, 0);
-    assert!(res.stderr.contains("* TCP:"));
+    assert!(res.stderr.contains("* Connect:"));
     assert!(res.stderr.contains("* TTFB:"));
 }
 
@@ -5236,7 +5236,7 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "udp dns ok");
     assert!(res.stderr.contains("DNS"));
-    assert!(res.stderr.contains("TCP"));
+    assert!(res.stderr.contains("Connect"));
     assert!(res.stderr.contains("TTFB"));
 
     let redirect_location = Arc::new(Mutex::new(String::new()));
@@ -5333,10 +5333,10 @@ fn socks_proxy_unix_socket_timing_and_grpc_binary_cases() {
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "timed");
     assert!(res.stderr.contains("Total") || res.stderr.contains("Timing"));
-    assert!(res.stderr.contains("TCP"));
+    assert!(res.stderr.contains("Connect"));
     assert!(res.stderr.contains("█"));
     assert!(res.stderr.contains("─"));
-    assert!(!res.stderr.contains("* TCP:"));
+    assert!(!res.stderr.contains("* Connect:"));
     assert!(!res.stderr.contains("* TTFB:"));
     let res = run_fetch(&[&format!("{}/timing", server.url), "-T"]);
     assert_exit(&res, 0);
@@ -5345,7 +5345,7 @@ fn socks_proxy_unix_socket_timing_and_grpc_binary_cases() {
     assert!(res.stderr.contains("█"));
     let res = run_fetch(&[&format!("{}/timing", server.url), "-T", "-vvv"]);
     assert_exit(&res, 0);
-    assert!(res.stderr.contains("* TCP:"));
+    assert!(res.stderr.contains("* Connect:"));
     assert!(res.stderr.contains("* TTFB:"));
     assert!(res.stderr.contains("Total") || res.stderr.contains("Timing"));
 


### PR DESCRIPTION
## Summary
- Render the timing connect phase as `Connect` instead of `TCP` in the waterfall and verbose debug output.
- Update the README wording and timing-related tests to match the new label.
- Adjust the timing unit test alignment expectation because the longer label shifts the bar start.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features timing`
- `cargo test --all-features --test integration socks_proxy_unix_socket_timing_and_grpc_binary_cases -- --test-threads=1`