### PR TITLE
Reject legacy TLS 1.0 and 1.1 consistently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - `--inspect-tls --http 3` performs QUIC/TLS inspection with `h3` ALPN instead of the TCP TLS path.
 - Rust `--inspect-tls` renders a verified certificate chain when verification succeeds, appending omitted trusted roots or replacing server-sent cross-signed roots with the matching platform/custom trusted root for expiry display; `--insecure` keeps the raw peer chain.
 - `--tls` remains a compatibility alias for setting the minimum TLS version; prefer `--min-tls` in new docs/examples, and use `--max-tls` to cap negotiation or combine min/max for an exact TLS version.
+- Rust TLS version options accept only TLS 1.2 and TLS 1.3; legacy TLS 1.0/1.1 values are rejected consistently for CLI flags, config, WebSocket, and inspection paths.
 - WebSocket terminal sessions use the interactive prompt by default and can be controlled with `--ws-interactive auto|on|off`; output-file/clipboard/retry flags are rejected because the WebSocket path streams through the message loop instead of the normal response pipeline.
 - `wss://` WebSocket handshakes build a rustls client config so `--ca-cert`, `--cert`/`--key`, `--insecure`, and TLS min/max settings apply; plain `ws://` rejects TLS flags, and WebSocket requests reject `--dns-server`/`--proxy` until custom WebSocket dialing supports them.
 - Metadata-only commands (`--help`, `--version`, `--buildinfo`) perform best-effort config parsing for presentation settings, but config errors and background auto-updates cannot block them.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -646,7 +646,7 @@ fetch --from-curl 'https://example.com'
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Request      | `-X`, `-H`, `-d`, `--data-raw`, `--data-binary`, `--data-urlencode`, `--json`, `-F`, `-T`, `-I`, `-G`                                         |
 | Auth         | `-u`, `--digest`, `--aws-sigv4`, `--oauth2-bearer`                                                                                            |
-| TLS          | `-k`, `--cacert`, `-E`/`--cert`, `--key`, `--tlsv1.x`, `--tls-max`                                                                            |
+| TLS          | `-k`, `--cacert`, `-E`/`--cert`, `--key`, `--tlsv1.2`, `--tlsv1.3`, `--tls-max`                                                               |
 | Output       | `-o`, `-O`, `-J`                                                                                                                              |
 | Network      | `-L`, `--max-redirs`, `-m`/`--max-time`, `--connect-timeout`, `-x`, `--unix-socket`, `--doh-url`, `--retry`, `--retry-delay`, `-r`            |
 | HTTP version | `-0`, `--http1.1`, `--http2`, `--http3`                                                                                                       |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1036,8 +1036,6 @@ fn url_hostname(raw: &str) -> Option<String> {
 
 fn tls_order(value: &str) -> Option<u8> {
     match value {
-        "1.0" => Some(10),
-        "1.1" => Some(11),
         "1.2" => Some(12),
         "1.3" => Some(13),
         _ => None,
@@ -1149,6 +1147,22 @@ mod tests {
         assert!(err.contains("line 1"));
         assert!(err.contains("invalid value 'deflate' for option 'compress'"));
         assert!(err.contains("must be one of [auto, br, brotli, gzip, zstd, off]"));
+    }
+
+    #[test]
+    fn parse_file_rejects_legacy_tls_versions() {
+        let path = PathBuf::from("test/config");
+        let err = parse_file(&path, "min-tls = 1.0\n").unwrap_err();
+
+        assert!(err.contains("line 1"));
+        assert!(err.contains("invalid value '1.0' for option 'min-tls'"));
+        assert!(err.contains("must be one of [1.2, 1.3]"));
+
+        let err = parse_file(&path, "max-tls = 1.1\n").unwrap_err();
+
+        assert!(err.contains("line 1"));
+        assert!(err.contains("invalid value '1.1' for option 'max-tls'"));
+        assert!(err.contains("must be one of [1.2, 1.3]"));
     }
 
     #[test]
@@ -1422,6 +1436,22 @@ mod tests {
         let err = validate(&cli).unwrap_err();
         assert!(err.to_string().contains("invalid value '1.4'"));
         assert!(err.to_string().contains("--min-tls"));
+
+        let cli =
+            Cli::try_parse_from(["fetch", "--min-tls", "1.0", "https://example.com"]).unwrap();
+        let err = validate(&cli).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid value '1.0' for option '--min-tls': must be one of [1.2, 1.3]"
+        );
+
+        let cli =
+            Cli::try_parse_from(["fetch", "--max-tls", "1.1", "https://example.com"]).unwrap();
+        let err = validate(&cli).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid value '1.1' for option '--max-tls': must be one of [1.2, 1.3]"
+        );
     }
 
     #[test]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -4278,22 +4278,25 @@ mod tests {
     }
 
     #[test]
-    fn regular_http_rejects_legacy_tls_only_range_on_rustls_path() {
-        let cli = Cli::try_parse_from([
-            "fetch",
-            "--min-tls",
-            "1.0",
-            "--max-tls",
-            "1.1",
-            "https://example.com",
-        ])
-        .unwrap();
+    fn regular_http_rejects_legacy_tls_versions_on_rustls_path() {
+        let cli =
+            Cli::try_parse_from(["fetch", "--min-tls", "1.0", "https://example.com"]).unwrap();
 
         let err = configure_tls(Client::builder().use_rustls_tls(), &cli).unwrap_err();
 
         assert_eq!(
             err.to_string(),
-            "TLS versions 1.0 and 1.1 are not supported"
+            "invalid value '1.0' for option '--min-tls': must be one of [1.2, 1.3]"
+        );
+
+        let cli =
+            Cli::try_parse_from(["fetch", "--max-tls", "1.1", "https://example.com"]).unwrap();
+
+        let err = configure_tls(Client::builder().use_rustls_tls(), &cli).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "invalid value '1.1' for option '--max-tls': must be one of [1.2, 1.3]"
         );
     }
 

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -1483,7 +1483,23 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
     }
 
     #[test]
-    fn inspection_protocol_versions_document_rustls_legacy_limit() {
+    fn inspection_protocol_versions_reject_legacy_tls_versions() {
+        let cli = Cli::try_parse_from([
+            "fetch",
+            "--inspect-tls",
+            "--min-tls",
+            "1.0",
+            "https://example.com",
+        ])
+        .unwrap();
+
+        let err = inspection_protocol_versions(&cli).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "invalid value '1.0' for option '--min-tls': must be one of [1.2, 1.3]"
+        );
+
         let cli = Cli::try_parse_from([
             "fetch",
             "--inspect-tls",
@@ -1495,7 +1511,10 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
 
         let err = inspection_protocol_versions(&cli).unwrap_err();
 
-        assert_eq!(err.to_string(), "TLS version 1.1 is not supported");
+        assert_eq!(
+            err.to_string(),
+            "invalid value '1.1' for option '--max-tls': must be one of [1.2, 1.3]"
+        );
     }
 
     #[test]

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -21,8 +21,6 @@ pub fn default_min_tls_version() -> Version {
 
 pub fn reqwest_tls_version(option: &str, value: &str) -> Result<Version, FetchError> {
     match value {
-        "1.0" => Ok(Version::TLS_1_0),
-        "1.1" => Ok(Version::TLS_1_1),
         "1.2" => Ok(Version::TLS_1_2),
         "1.3" => Ok(Version::TLS_1_3),
         _ => Err(format!(
@@ -112,8 +110,6 @@ pub fn rustls_client_config(
 
 pub(crate) fn tls_order(option: &str, value: &str) -> Result<u8, FetchError> {
     match value {
-        "1.0" => Ok(10),
-        "1.1" => Ok(11),
         "1.2" => Ok(12),
         "1.3" => Ok(13),
         _ => Err(format!(
@@ -516,7 +512,6 @@ mod tests {
     #[test]
     fn tls_version_bounds_match_go_defaults_and_supported_values() {
         assert_eq!(default_min_tls_version(), Version::TLS_1_2);
-        assert_eq!(reqwest_tls_version("tls", "1.0").unwrap(), Version::TLS_1_0);
         assert_eq!(
             reqwest_tls_version("min-tls", "1.2").unwrap(),
             Version::TLS_1_2
@@ -532,17 +527,23 @@ mod tests {
     }
 
     #[test]
-    fn rustls_supported_range_documents_legacy_tls_limit() {
-        ensure_rustls_supported_range(Some(("min-tls", "1.0")), None).unwrap();
-        ensure_rustls_supported_range(Some(("min-tls", "1.1")), Some("1.2")).unwrap();
-
-        let err = ensure_rustls_supported_range(Some(("min-tls", "1.0")), Some("1.1")).unwrap_err();
+    fn tls_version_bounds_reject_legacy_tls_versions() {
+        let err = reqwest_tls_version("tls", "1.0").unwrap_err();
         assert_eq!(
             err.to_string(),
-            "TLS versions 1.0 and 1.1 are not supported"
+            "invalid value '1.0' for option '--tls': must be one of [1.2, 1.3]"
+        );
+
+        let err = ensure_rustls_supported_range(Some(("min-tls", "1.1")), Some("1.2")).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid value '1.1' for option '--min-tls': must be one of [1.2, 1.3]"
         );
 
         let err = ensure_rustls_supported_range(None, Some("1.1")).unwrap_err();
-        assert_eq!(err.to_string(), "TLS version 1.1 is not supported");
+        assert_eq!(
+            err.to_string(),
+            "invalid value '1.1' for option '--max-tls': must be one of [1.2, 1.3]"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Removed legacy TLS 1.0/1.1 acceptance from the shared TLS parsing helpers so Rust only accepts TLS 1.2 and 1.3.
- Updated CLI, config, HTTP, and `--inspect-tls` validation to fail consistently on `1.0`/`1.1` instead of partially accepting them.
- Adjusted the curl docs and repository notes to reflect the TLS 1.2/1.3-only behavior.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`