### PR TITLE
Expand protobuf and gRPC test coverage

### DIFF
--- a/src/grpc/reflection.rs
+++ b/src/grpc/reflection.rs
@@ -526,6 +526,38 @@ mod tests {
     }
 
     #[test]
+    fn parses_reflection_error_responses() {
+        let mut error = Vec::new();
+        append_string(&mut error, 2, "symbol missing");
+        let mut response = Vec::new();
+        append_bytes(&mut response, 7, &error);
+
+        let list_err = parse_reflection_list_response(&response).unwrap_err();
+        assert_eq!(list_err.to_string(), "symbol missing");
+
+        let file_err = parse_reflection_file_descriptor_response(&response).unwrap_err();
+        assert_eq!(file_err.to_string(), "symbol missing");
+    }
+
+    #[test]
+    fn parses_reflection_descriptor_lists_and_missing_fields() {
+        let mut descriptors = Vec::new();
+        append_bytes(&mut descriptors, 1, b"first descriptor");
+        append_bytes(&mut descriptors, 1, b"second descriptor");
+        let mut response = Vec::new();
+        append_bytes(&mut response, 4, &descriptors);
+
+        let files = parse_reflection_file_descriptor_response(&response).unwrap();
+        assert_eq!(
+            files,
+            [b"first descriptor".to_vec(), b"second descriptor".to_vec()]
+        );
+
+        assert!(parse_reflection_list_response(&[]).is_err());
+        assert!(parse_reflection_file_descriptor_response(&[]).is_err());
+    }
+
+    #[test]
     fn normalize_reflection_symbol_replaces_method_slash() {
         assert_eq!(
             normalize_reflection_symbol("grpc.health.v1.Health/Check"),

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1577,10 +1577,15 @@ async fn apply_digest_challenge(
 
     #[cfg(windows)]
     {
-        let retry_response: Result<Response, FetchError> =
-            retry_request.send().await.map_err(Into::into);
-        drain_response_body_bounded(response).await;
-        retry_response
+        if response_connection_close(&response) {
+            drain_response_body_bounded(response).await;
+            retry_request.send().await.map_err(Into::into)
+        } else {
+            let retry_response: Result<Response, FetchError> =
+                retry_request.send().await.map_err(Into::into);
+            drain_response_body_bounded(response).await;
+            retry_response
+        }
     }
 
     #[cfg(not(windows))]
@@ -1588,6 +1593,17 @@ async fn apply_digest_challenge(
         drain_response_body_bounded(response).await;
         retry_request.send().await.map_err(Into::into)
     }
+}
+
+#[cfg(windows)]
+fn response_connection_close(response: &Response) -> bool {
+    response
+        .headers()
+        .get_all(reqwest::header::CONNECTION)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .any(|token| token.trim().eq_ignore_ascii_case("close"))
 }
 
 fn digest_challenged_request(

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -646,8 +646,9 @@ pub enum ProtoError {
 mod tests {
     use super::*;
     use prost_types::{
-        DescriptorProto, FieldDescriptorProto, FileDescriptorProto, FileDescriptorSet,
-        MethodDescriptorProto, ServiceDescriptorProto,
+        DescriptorProto, EnumDescriptorProto, EnumValueDescriptorProto, FieldDescriptorProto,
+        FileDescriptorProto, FileDescriptorSet, MessageOptions, MethodDescriptorProto,
+        OneofDescriptorProto, ServiceDescriptorProto,
         field_descriptor_proto::{Label, Type},
     };
     use std::path::Path;
@@ -806,6 +807,159 @@ mod tests {
                         ..Default::default()
                     },
                 ],
+                ..Default::default()
+            }],
+        };
+        fds.encode_to_vec()
+    }
+
+    fn edge_descriptor_set() -> Vec<u8> {
+        let fds = FileDescriptorSet {
+            file: vec![FileDescriptorProto {
+                name: Some("edge.proto".to_string()),
+                package: Some("edgepkg".to_string()),
+                syntax: Some("proto3".to_string()),
+                enum_type: vec![EnumDescriptorProto {
+                    name: Some("State".to_string()),
+                    value: vec![
+                        EnumValueDescriptorProto {
+                            name: Some("STATE_UNKNOWN".to_string()),
+                            number: Some(0),
+                            ..Default::default()
+                        },
+                        EnumValueDescriptorProto {
+                            name: Some("STATE_READY".to_string()),
+                            number: Some(1),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                }],
+                message_type: vec![
+                    DescriptorProto {
+                        name: Some("LabelsEntry".to_string()),
+                        field: vec![
+                            FieldDescriptorProto {
+                                name: Some("key".to_string()),
+                                number: Some(1),
+                                label: Some(Label::Optional as i32),
+                                r#type: Some(Type::String as i32),
+                                ..Default::default()
+                            },
+                            FieldDescriptorProto {
+                                name: Some("value".to_string()),
+                                number: Some(2),
+                                label: Some(Label::Optional as i32),
+                                r#type: Some(Type::Int32 as i32),
+                                ..Default::default()
+                            },
+                        ],
+                        options: Some(MessageOptions {
+                            map_entry: Some(true),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    DescriptorProto {
+                        name: Some("EdgeMessage".to_string()),
+                        field: vec![
+                            FieldDescriptorProto {
+                                name: Some("flag".to_string()),
+                                number: Some(1),
+                                label: Some(Label::Optional as i32),
+                                r#type: Some(Type::Bool as i32),
+                                ..Default::default()
+                            },
+                            FieldDescriptorProto {
+                                name: Some("blob".to_string()),
+                                number: Some(2),
+                                label: Some(Label::Optional as i32),
+                                r#type: Some(Type::Bytes as i32),
+                                ..Default::default()
+                            },
+                            FieldDescriptorProto {
+                                name: Some("state".to_string()),
+                                number: Some(3),
+                                label: Some(Label::Optional as i32),
+                                r#type: Some(Type::Enum as i32),
+                                type_name: Some(".edgepkg.State".to_string()),
+                                ..Default::default()
+                            },
+                            FieldDescriptorProto {
+                                name: Some("scores".to_string()),
+                                number: Some(4),
+                                label: Some(Label::Repeated as i32),
+                                r#type: Some(Type::Sint32 as i32),
+                                ..Default::default()
+                            },
+                            FieldDescriptorProto {
+                                name: Some("labels".to_string()),
+                                number: Some(5),
+                                label: Some(Label::Repeated as i32),
+                                r#type: Some(Type::Message as i32),
+                                type_name: Some(".edgepkg.LabelsEntry".to_string()),
+                                ..Default::default()
+                            },
+                            FieldDescriptorProto {
+                                name: Some("choice_text".to_string()),
+                                number: Some(6),
+                                label: Some(Label::Optional as i32),
+                                r#type: Some(Type::String as i32),
+                                oneof_index: Some(0),
+                                ..Default::default()
+                            },
+                            FieldDescriptorProto {
+                                name: Some("choice_count".to_string()),
+                                number: Some(7),
+                                label: Some(Label::Optional as i32),
+                                r#type: Some(Type::Int64 as i32),
+                                oneof_index: Some(0),
+                                ..Default::default()
+                            },
+                            FieldDescriptorProto {
+                                name: Some("maybe".to_string()),
+                                number: Some(8),
+                                label: Some(Label::Optional as i32),
+                                r#type: Some(Type::String as i32),
+                                proto3_optional: Some(true),
+                                oneof_index: Some(1),
+                                ..Default::default()
+                            },
+                        ],
+                        oneof_decl: vec![
+                            OneofDescriptorProto {
+                                name: Some("choice".to_string()),
+                                ..Default::default()
+                            },
+                            OneofDescriptorProto {
+                                name: Some("_maybe".to_string()),
+                                ..Default::default()
+                            },
+                        ],
+                        ..Default::default()
+                    },
+                ],
+                service: vec![ServiceDescriptorProto {
+                    name: Some("EdgeService".to_string()),
+                    method: vec![
+                        MethodDescriptorProto {
+                            name: Some("ServerStream".to_string()),
+                            input_type: Some(".edgepkg.EdgeMessage".to_string()),
+                            output_type: Some(".edgepkg.EdgeMessage".to_string()),
+                            server_streaming: Some(true),
+                            ..Default::default()
+                        },
+                        MethodDescriptorProto {
+                            name: Some("Bidi".to_string()),
+                            input_type: Some(".edgepkg.EdgeMessage".to_string()),
+                            output_type: Some(".edgepkg.EdgeMessage".to_string()),
+                            client_streaming: Some(true),
+                            server_streaming: Some(true),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                }],
                 ..Default::default()
             }],
         };
@@ -1303,6 +1457,70 @@ mod tests {
             result.get("count").and_then(|value| value.as_i64()),
             Some(5)
         );
+    }
+
+    #[test]
+    fn json_to_protobuf_handles_repeated_maps_oneofs_bytes_and_enums() {
+        let schema = Schema::from_descriptor_set(&edge_descriptor_set()).unwrap();
+        let desc = schema.find_message("edgepkg.EdgeMessage").unwrap();
+
+        let proto_data = json_to_protobuf(
+            br#"{
+                "flag": true,
+                "blob": "aGVsbG8=",
+                "state": "STATE_READY",
+                "scores": [-1, 0, 7],
+                "labels": {"low": 1, "high": 9},
+                "choice_text": "selected",
+                "maybe": "present"
+            }"#,
+            &desc,
+        )
+        .unwrap();
+        let json = protobuf_to_json(&proto_data, &desc).unwrap();
+        let result = serde_json::from_slice::<serde_json::Value>(&json).unwrap();
+
+        assert_eq!(result["flag"], true);
+        assert_eq!(result["blob"], "aGVsbG8=");
+        assert_eq!(result["state"], "STATE_READY");
+        assert_eq!(result["scores"], serde_json::json!([-1, 0, 7]));
+        assert_eq!(result["labels"]["low"], 1);
+        assert_eq!(result["labels"]["high"], 9);
+        assert_eq!(result["choice_text"], "selected");
+        assert_eq!(result["maybe"], "present");
+        assert!(result.get("choiceText").is_none());
+    }
+
+    #[test]
+    fn json_to_protobuf_rejects_invalid_edge_shapes() {
+        let schema = Schema::from_descriptor_set(&edge_descriptor_set()).unwrap();
+        let desc = schema.find_message("edgepkg.EdgeMessage").unwrap();
+
+        let cases: &[(&str, &[u8])] = &[
+            ("invalid base64 bytes", br#"{"blob":"not base64!"}"#),
+            ("wrong repeated shape", br#"{"scores": 1}"#),
+            ("wrong map shape", br#"{"labels": [{"key":"a","value":1}]}"#),
+            (
+                "oneof conflict",
+                br#"{"choice_text":"text","choice_count":"2"}"#,
+            ),
+            ("trailing JSON", br#"{"flag":true} garbage"#),
+        ];
+
+        for (name, json) in cases {
+            assert!(json_to_protobuf(json, &desc).is_err(), "{name}");
+        }
+    }
+
+    #[test]
+    fn describe_symbol_reports_streaming_method_shapes() {
+        let schema = Schema::from_descriptor_set(&edge_descriptor_set()).unwrap();
+
+        let server_stream = describe_symbol(&schema, "edgepkg.EdgeService/ServerStream").unwrap();
+        assert!(server_stream.contains("rpc: server-stream"));
+
+        let bidi = describe_symbol(&schema, "edgepkg.EdgeService/Bidi").unwrap();
+        assert!(bidi.contains("rpc: bidi-stream"));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1843,13 +1843,30 @@ fn write_stream_descriptor_set(dir: &Path) -> PathBuf {
             ],
             service: vec![ServiceDescriptorProto {
                 name: Some("StreamService".to_string()),
-                method: vec![MethodDescriptorProto {
-                    name: Some("ClientStream".to_string()),
-                    input_type: Some(".streampkg.StreamRequest".to_string()),
-                    output_type: Some(".streampkg.StreamResponse".to_string()),
-                    client_streaming: Some(true),
-                    ..Default::default()
-                }],
+                method: vec![
+                    MethodDescriptorProto {
+                        name: Some("ClientStream".to_string()),
+                        input_type: Some(".streampkg.StreamRequest".to_string()),
+                        output_type: Some(".streampkg.StreamResponse".to_string()),
+                        client_streaming: Some(true),
+                        ..Default::default()
+                    },
+                    MethodDescriptorProto {
+                        name: Some("ServerStream".to_string()),
+                        input_type: Some(".streampkg.StreamRequest".to_string()),
+                        output_type: Some(".streampkg.StreamResponse".to_string()),
+                        server_streaming: Some(true),
+                        ..Default::default()
+                    },
+                    MethodDescriptorProto {
+                        name: Some("Bidi".to_string()),
+                        input_type: Some(".streampkg.StreamRequest".to_string()),
+                        output_type: Some(".streampkg.StreamResponse".to_string()),
+                        client_streaming: Some(true),
+                        server_streaming: Some(true),
+                        ..Default::default()
+                    },
+                ],
                 ..Default::default()
             }],
             ..Default::default()
@@ -6010,6 +6027,11 @@ fn grpc_schema_descriptor_and_client_streaming_cases() {
     assert!(res.stdout.contains("SERVING"));
 
     let stream_server = TestServer::start(|req| {
+        if req.path == "/streampkg.StreamService/ServerStream" {
+            let mut body = grpc_frame(&proto_field_varint(1, 1));
+            body.extend(grpc_frame(&proto_field_varint(1, 2)));
+            return TestResponse::ok(body).header("Content-Type", "application/grpc+proto");
+        }
         let mut body = &req.body[..];
         let mut count = 0_u64;
         while body.len() >= 5 {
@@ -6054,6 +6076,22 @@ fn grpc_schema_descriptor_and_client_streaming_cases() {
     assert!(res.stdout.contains("1"));
 
     let res = run_fetch(&[
+        &format!("{}/streampkg.StreamService/ServerStream", stream_server.url),
+        "--grpc",
+        "--proto-desc",
+        stream_desc.to_str().unwrap(),
+        "-d",
+        r#"{"value":"seed"}"#,
+        "--http",
+        "1",
+        "--format",
+        "on",
+    ]);
+    assert_exit(&res, 0);
+    assert!(res.stdout.contains("\"count\": \"1\""));
+    assert!(res.stdout.contains("\"count\": \"2\""));
+
+    let res = run_fetch(&[
         &format!("{}/streampkg.StreamService/ClientStream", stream_server.url),
         "--grpc",
         "--proto-desc",
@@ -6064,6 +6102,19 @@ fn grpc_schema_descriptor_and_client_streaming_cases() {
         "on",
     ]);
     assert_exit(&res, 0);
+
+    let res = run_fetch(&[
+        &format!("{}/streampkg.StreamService/ClientStream", stream_server.url),
+        "--grpc",
+        "--proto-desc",
+        stream_desc.to_str().unwrap(),
+        "-d",
+        r#"{"value":"one"}{"value":"#,
+        "--http",
+        "1",
+    ]);
+    assert_exit(&res, 1);
+    assert!(res.stderr.contains("failed to decode JSON message"));
 
     if Command::new("protoc").arg("--version").output().is_ok() {
         let proto_file = temp_file(
@@ -6106,6 +6157,65 @@ service StreamService {
         assert_exit(&res, 0);
         assert!(res.stdout.contains("2"));
     }
+
+    let header_server = TestServer::start(|_| {
+        TestResponse::ok(proto_field_varint(1, 1)).header("Content-Type", "application/protobuf")
+    });
+    let res = run_fetch(&[
+        &format!("{}/grpc.health.v1.Health/Check", header_server.url),
+        "--grpc",
+        "--proto-desc",
+        health_desc.to_str().unwrap(),
+        "-j",
+        r#"{"service":"svc"}"#,
+        "--http",
+        "1",
+        "--basic",
+        "user:pass",
+        "-H",
+        "X-Test: yes",
+        "--format",
+        "on",
+    ]);
+    assert_exit(&res, 0);
+    let requests = header_server.requests.lock().unwrap();
+    let request = requests.last().expect("gRPC request captured");
+    assert_eq!(request.method, "POST");
+    assert_eq!(request.header("content-type"), "application/grpc+proto");
+    assert_eq!(request.header("te"), "trailers");
+    assert_eq!(request.header("x-test"), "yes");
+    assert!(request.header("authorization").starts_with("Basic "));
+    assert_eq!(request.body, grpc_frame(&proto_field_string(1, "svc")));
+    drop(requests);
+
+    let res = run_fetch(&[
+        &format!("{}/grpc.health.v1.Health/Missing", header_server.url),
+        "--grpc",
+        "--proto-desc",
+        health_desc.to_str().unwrap(),
+        "--http",
+        "1",
+    ]);
+    assert_exit(&res, 1);
+    assert!(res.stderr.contains("method Missing not found"));
+
+    let header_status_server = TestServer::start(|_| {
+        TestResponse::ok("")
+            .header("Content-Type", "application/grpc+proto")
+            .header("grpc-status", "16")
+            .header("grpc-message", "bad%20token")
+    });
+    let res = run_fetch(&[
+        &format!("{}/test.Auth/Check", header_status_server.url),
+        "--grpc",
+        "--http",
+        "1",
+        "--format",
+        "off",
+    ]);
+    assert_exit(&res, 1);
+    assert!(res.stderr.contains("UNAUTHENTICATED"));
+    assert!(res.stderr.contains("bad token"));
 
     let res = run_fetch(&[
         "http://example.com/svc/Method",


### PR DESCRIPTION
## Summary
- Added unit coverage for richer protobuf shapes: maps, repeated fields, bytes, enums, oneofs, proto3 optional fields, and streaming method descriptions.
- Extended reflection tests to cover error payload parsing and missing/empty descriptor responses.
- Expanded integration coverage for schema-aware server streaming, malformed client-stream JSON, gRPC request headers/body framing, missing-method CLI errors, and `grpc-status` surfaced from response headers.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`