### PR TITLE
Enable gRPC reflection for schema-less response decoding

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -132,10 +132,17 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
         connect_timing: Some(&connect_timing),
     };
     let mut initial_client = client::build_client_for_url(cli, &url, &client_build).await?;
-    if cli.grpc && grpc_method.is_none() && grpc_request_requires_schema(cli) {
-        let schema =
-            crate::grpc::reflection::schema_for_call(cli, &url, &initial_client.client).await?;
-        grpc_method = Some(proto::method_for_url(&schema, &url)?);
+    if cli.grpc && grpc_method.is_none() {
+        let request_requires_schema = grpc_request_requires_schema(cli);
+        match crate::grpc::reflection::schema_for_call(cli, &url, &initial_client.client).await {
+            Ok(schema) => match proto::method_for_url(&schema, &url) {
+                Ok(method) => grpc_method = Some(method),
+                Err(err) if request_requires_schema => return Err(err),
+                Err(_) => {}
+            },
+            Err(err) if request_requires_schema => return Err(err),
+            Err(_) => {}
+        }
     }
     let method_name = effective_method(cli);
     let method = Method::from_bytes(method_name.as_bytes())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6303,6 +6303,15 @@ fn grpc_reflection_h2c_go_cases() {
     assert_exit(&res, 0);
     assert!(res.stdout.contains("\"status\": \"SERVING\""));
 
+    let res = run_fetch(&[
+        &format!("{}/grpc.health.v1.Health/Check", server.url),
+        "--grpc",
+        "--format",
+        "on",
+    ]);
+    assert_exit(&res, 0);
+    assert!(res.stdout.contains("\"status\": \"SERVING\""));
+
     let tls = start_reflection_grpc_tls_server(true);
     let ca_cert = tls.ca_cert_path.as_ref().unwrap().to_str().unwrap();
     let res = run_fetch(&["--grpc-list", "--ca-cert", ca_cert, &tls.url]);


### PR DESCRIPTION
## Summary
- Attempt gRPC reflection whenever `--grpc` is used without a local method descriptor, instead of only when the request body needs a schema.
- Keep raw-call compatibility by ignoring reflection failures unless the request body actually requires schema-driven JSON-to-protobuf conversion.
- Add an integration test covering a schema-less gRPC call that now decodes reflected response output.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features --test integration grpc_reflection_h2c_go_cases -- --test-threads=1`
- `cargo test --all-features`