### PR TITLE
Stream gRPC responses and request bodies incrementally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - `--grpc-list` and `--grpc-describe` provide grpcurl-style discovery using reflection or local descriptor files.
 - `--grpc` now automatically tries gRPC reflection when no local schema is supplied.
 - Plaintext loopback gRPC servers are supported via `h2c` for both calls and discovery.
+- Formatted gRPC responses with `Content-Type: application/grpc+proto` stream through `FrameDecoder`, writing each complete message immediately while preserving trailers.
+- Client-streaming and bidi gRPC calls stream JSON input into framed protobuf request bodies instead of materializing the whole stream up front.
 - `--inspect-dns` resolves the URL hostname without making an HTTP request, showing common DNS record types, resolver backend, duration, and per-record TTLs from direct UDP or DoH responses.
 - `--inspect-tls --http 3` performs QUIC/TLS inspection with `h3` ALPN instead of the TCP TLS path.
 - Rust `--inspect-tls` renders a verified certificate chain when verification succeeds, appending omitted trusted roots or replacing server-sent cross-signed roots with the matching platform/custom trusted root for expiry display; `--insecure` keeps the raw peer chain.

--- a/src/format/grpc.rs
+++ b/src/format/grpc.rs
@@ -18,21 +18,23 @@ pub fn format_grpc_stream(buf: &[u8]) -> Result<String, GrpcFormatError> {
     let mut out = String::new();
 
     for (idx, frame) in frames.iter().enumerate() {
-        if frame.compressed {
-            return Err(GrpcFormatError(
-                "compressed gRPC messages are not supported".to_string(),
-            ));
-        }
         if idx > 0 {
             out.push('\n');
         }
-        out.push_str(
-            &crate::format::protobuf::format_protobuf(&frame.data)
-                .map_err(|err| GrpcFormatError(err.to_string()))?,
-        );
+        out.push_str(&format_grpc_frame(frame)?);
     }
 
     Ok(out)
+}
+
+pub fn format_grpc_frame(frame: &framing::Frame) -> Result<String, GrpcFormatError> {
+    if frame.compressed {
+        return Err(GrpcFormatError(
+            "compressed gRPC messages are not supported".to_string(),
+        ));
+    }
+    crate::format::protobuf::format_protobuf(&frame.data)
+        .map_err(|err| GrpcFormatError(err.to_string()))
 }
 
 #[cfg(test)]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::error::Error as StdError;
 use std::fmt;
-use std::io::{ErrorKind, IsTerminal, Read, Write};
+use std::io::{Cursor, ErrorKind, IsTerminal, Read, Write};
 use std::path::Path;
 use std::pin::Pin;
 use std::process::Stdio;
@@ -17,7 +17,7 @@ use base64::Engine;
 use bytes::Bytes;
 #[cfg(test)]
 use flate2::read::GzDecoder;
-use futures_util::stream;
+use futures_util::{TryStreamExt, stream};
 use http_body_util::BodyExt;
 use reqwest::header::{
     ACCEPT, ACCEPT_ENCODING, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, HeaderMap,
@@ -71,15 +71,36 @@ pub(crate) struct RequestBodyPayload {
 #[derive(Debug, Clone)]
 enum RequestBodySource {
     Bytes(Bytes),
-    File { path: String, len: u64 },
+    File {
+        path: String,
+        len: u64,
+    },
     Stdin,
     Multipart(multipart::Multipart),
+    GrpcJsonStream {
+        source: Box<RequestBodySource>,
+        desc: prost_reflect::MessageDescriptor,
+    },
 }
 
 impl RequestBodyPayload {
     pub(crate) fn from_bytes(bytes: Vec<u8>, content_type: Option<String>) -> Self {
         Self {
             source: RequestBodySource::Bytes(Bytes::from(bytes)),
+            content_type,
+        }
+    }
+
+    pub(crate) fn from_grpc_json_stream(
+        body: RequestBodyPayload,
+        desc: prost_reflect::MessageDescriptor,
+        content_type: Option<String>,
+    ) -> Self {
+        Self {
+            source: RequestBodySource::GrpcJsonStream {
+                source: Box::new(body.source),
+                desc,
+            },
             content_type,
         }
     }
@@ -807,6 +828,28 @@ async fn finish_response(
                 code,
             ));
         }
+        if should_stream_formatted_grpc_stdout(cli, &response_headers, stdout_is_terminal) {
+            let streamed = stream_response_to_formatted_grpc_stdout(
+                response,
+                response_headers.clone(),
+                compression,
+                cli.copy,
+                grpc_method.map(|method| method.output()),
+            )
+            .await?;
+            handle_optional_clipboard_outcome(cli, streamed.clipboard);
+            let body_duration =
+                body_duration_from_len(method_is_head, streamed.bytes_written, body_start);
+            print_timing(cli, response_timing, body_duration);
+
+            let code = exit_code(status.as_u16(), cli.ignore_status);
+            return Ok(check_grpc_status(
+                cli,
+                &response_headers,
+                &streamed.trailers,
+                code,
+            ));
+        }
         if let Some(target) = stdout_stream_target(cli, &response_headers, stdout_is_terminal) {
             let streamed = stream_response_to_stdout(
                 cli,
@@ -975,6 +1018,15 @@ fn should_stream_formatted_sse_stdout(
         && format_enabled(cli.format.as_deref(), stdout_is_terminal)
 }
 
+fn should_stream_formatted_grpc_stdout(
+    cli: &Cli,
+    headers: &HeaderMap,
+    stdout_is_terminal: bool,
+) -> bool {
+    response_header_content_type(headers) == ContentType::Grpc
+        && format_enabled(cli.format.as_deref(), stdout_is_terminal)
+}
+
 fn should_retry_sse_without_compression(response: &Response, compression: CompressionMode) -> bool {
     compression == CompressionMode::Auto
         && response_header_content_type(response.headers()) == ContentType::Sse
@@ -1134,6 +1186,78 @@ async fn stream_response_to_formatted_sse_stdout(
         if !formatted.is_empty() {
             stdout.write_all(formatted.as_bytes()).await?;
             stdout.flush().await?;
+        }
+    }
+}
+
+async fn stream_response_to_formatted_grpc_stdout(
+    response: Response,
+    response_headers: HeaderMap,
+    compression: CompressionMode,
+    copy: bool,
+    grpc_response_desc: Option<prost_reflect::MessageDescriptor>,
+) -> Result<StreamedOutput, FetchError> {
+    let (reader, trailers) = async_response_reader(response);
+    let mut reader = decoded_async_response_reader(reader, compression, &response_headers)?;
+    let mut stdout = tokio::io::stdout();
+    let mut capture = copy.then(clipboard::Capture::default);
+    let mut decoder = crate::grpc::framing::FrameDecoder::new();
+    let mut buf = vec![0; 16 * 1024];
+    let mut bytes_read = 0i64;
+    let mut frame_index = 0usize;
+    let mut descriptor_messages_written = 0usize;
+    let mut descriptor_output_ends_with_newline = true;
+
+    loop {
+        let n = reader.read(&mut buf).await?;
+        if n == 0 {
+            decoder
+                .finish()
+                .map_err(|err| FetchError::Message(format!("failed to read gRPC stream: {err}")))?;
+            stdout.flush().await?;
+            let clipboard = capture.map(clipboard::Capture::copy);
+            let trailers = trailers
+                .lock()
+                .map(|trailers| trailers.clone())
+                .unwrap_or_default();
+            return Ok(StreamedOutput {
+                trailers,
+                bytes_written: bytes_read,
+                clipboard,
+            });
+        }
+
+        if let Some(capture) = capture.as_mut() {
+            capture.push(&buf[..n]);
+        }
+        bytes_read = bytes_read.saturating_add(i64::try_from(n).unwrap_or(i64::MAX));
+        let frames = decoder
+            .push(&buf[..n])
+            .map_err(|err| FetchError::Message(format!("failed to read gRPC stream: {err}")))?;
+        for frame in frames {
+            if let Some(desc) = grpc_response_desc.as_ref() {
+                let Some(formatted) = proto::format_grpc_frame_with_descriptor(&frame, desc)
+                    .map_err(|err| FetchError::Message(err.to_string()))?
+                else {
+                    continue;
+                };
+                if descriptor_messages_written > 0 && !descriptor_output_ends_with_newline {
+                    stdout.write_all(b"\n").await?;
+                }
+                stdout.write_all(formatted.as_bytes()).await?;
+                stdout.flush().await?;
+                descriptor_output_ends_with_newline = formatted.ends_with('\n');
+                descriptor_messages_written += 1;
+            } else {
+                if frame_index > 0 {
+                    stdout.write_all(b"\n").await?;
+                }
+                let formatted = grpc_format::format_grpc_frame(&frame)
+                    .map_err(|err| FetchError::Message(err.to_string()))?;
+                stdout.write_all(formatted.as_bytes()).await?;
+                stdout.flush().await?;
+                frame_index += 1;
+            }
         }
     }
 }
@@ -1737,6 +1861,17 @@ fn request_body_sha256_hex(body: &RequestBody) -> Result<String, FetchError> {
                 .write_to(&mut writer)
                 .map_err(|err| FetchError::Message(err.to_string()))?;
         }
+        RequestBodySource::GrpcJsonStream { source, desc } => {
+            if request_body_source_uses_stdin(source) {
+                return Err(FetchError::Message(
+                    "AWS SigV4 cannot sign a streaming stdin request body unless x-amz-content-sha256 is set or S3 unsigned payload is used".to_string(),
+                ));
+            }
+            let bytes = request_body_source_to_bytes((**source).clone())?;
+            let framed = proto::stream_json_to_grpc_frames(&bytes, desc)
+                .map_err(|err| FetchError::Message(err.to_string()))?;
+            hasher.update(framed);
+        }
         RequestBodySource::Stdin => {
             return Err(FetchError::Message(
                 "AWS SigV4 cannot sign a streaming stdin request body unless x-amz-content-sha256 is set or S3 unsigned payload is used".to_string(),
@@ -1811,6 +1946,10 @@ fn request_body_content_len(body: &RequestBody) -> Option<u64> {
             source: RequestBodySource::Stdin,
             ..
         } => None,
+        RequestBodyPayload {
+            source: RequestBodySource::GrpcJsonStream { .. },
+            ..
+        } => None,
     }
 }
 
@@ -1823,6 +1962,36 @@ fn request_body_to_reqwest_body(body: RequestBodyPayload) -> Result<Body, FetchE
         }
         RequestBodySource::Stdin => Ok(Body::wrap_stream(ReaderStream::new(tokio::io::stdin()))),
         RequestBodySource::Multipart(multipart) => Ok(Body::wrap_stream(multipart.stream())),
+        RequestBodySource::GrpcJsonStream { source, desc } => {
+            let reader = request_body_source_to_async_reader(*source)?;
+            Ok(Body::wrap_stream(proto::json_reader_to_grpc_frame_stream(
+                reader, desc,
+            )))
+        }
+    }
+}
+
+fn request_body_source_to_async_reader(
+    source: RequestBodySource,
+) -> Result<AsyncReadBox, FetchError> {
+    match source {
+        RequestBodySource::Bytes(bytes) => Ok(Box::pin(Cursor::new(bytes))),
+        RequestBodySource::File { path, .. } => {
+            let file = std::fs::File::open(&path)?;
+            Ok(Box::pin(tokio::fs::File::from_std(file)))
+        }
+        RequestBodySource::Stdin => Ok(Box::pin(tokio::io::stdin())),
+        RequestBodySource::Multipart(multipart) => Ok(Box::pin(StreamReader::new(
+            multipart
+                .stream()
+                .map_err(|err| std::io::Error::other(err.to_string())),
+        ))),
+        RequestBodySource::GrpcJsonStream { source, desc } => {
+            let reader = request_body_source_to_async_reader(*source)?;
+            Ok(Box::pin(StreamReader::new(
+                proto::json_reader_to_grpc_frame_stream(reader, desc),
+            )))
+        }
     }
 }
 
@@ -1833,19 +2002,28 @@ pub(crate) fn request_body_into_bytes(
         return Ok(None);
     };
     let content_type = body.content_type.clone();
-    let bytes = match body.source {
-        RequestBodySource::Bytes(bytes) => bytes.to_vec(),
-        RequestBodySource::File { path, .. } => std::fs::read(path)?,
+    let bytes = request_body_source_to_bytes(body.source)?;
+    Ok(Some((bytes, content_type)))
+}
+
+fn request_body_source_to_bytes(source: RequestBodySource) -> Result<Vec<u8>, FetchError> {
+    match source {
+        RequestBodySource::Bytes(bytes) => Ok(bytes.to_vec()),
+        RequestBodySource::File { path, .. } => Ok(std::fs::read(path)?),
         RequestBodySource::Stdin => {
             let mut buf = Vec::new();
             std::io::stdin().read_to_end(&mut buf)?;
-            buf
+            Ok(buf)
         }
         RequestBodySource::Multipart(multipart) => multipart
             .open()
-            .map_err(|err| FetchError::Message(err.to_string()))?,
-    };
-    Ok(Some((bytes, content_type)))
+            .map_err(|err| FetchError::Message(err.to_string())),
+        RequestBodySource::GrpcJsonStream { source, desc } => {
+            let bytes = request_body_source_to_bytes(*source)?;
+            proto::stream_json_to_grpc_frames(&bytes, &desc)
+                .map_err(|err| FetchError::Message(err.to_string()))
+        }
+    }
 }
 
 fn request_body_preview(body: &RequestBodyPayload) -> Result<Vec<u8>, FetchError> {
@@ -1864,6 +2042,10 @@ fn request_body_preview(body: &RequestBodyPayload) -> Result<Vec<u8>, FetchError
                 .map_err(|err| FetchError::Message(err.to_string()))?;
             Ok(out)
         }
+        RequestBodySource::GrpcJsonStream { .. } => {
+            request_body_source_to_bytes(body.source.clone())
+                .map(|bytes| bytes.into_iter().take(1024).collect())
+        }
     }
 }
 
@@ -1879,6 +2061,9 @@ fn write_request_body_to_stderr(body: &RequestBodyPayload) -> Result<(), FetchEr
         RequestBodySource::Multipart(multipart) => multipart
             .write_to(&mut stderr)
             .map_err(|err| FetchError::Message(err.to_string()))?,
+        RequestBodySource::GrpcJsonStream { .. } => {
+            stderr.write_all(&request_body_source_to_bytes(body.source.clone())?)?
+        }
     }
     Ok(())
 }
@@ -2324,10 +2509,18 @@ fn redirected_request(
 }
 
 fn request_body_replayable(body: &RequestBody) -> bool {
-    !matches!(
-        body.as_ref().map(|body| &body.source),
-        Some(RequestBodySource::Stdin)
-    )
+    body.as_ref()
+        .is_none_or(|body| !request_body_source_uses_stdin(&body.source))
+}
+
+fn request_body_source_uses_stdin(source: &RequestBodySource) -> bool {
+    match source {
+        RequestBodySource::Stdin => true,
+        RequestBodySource::GrpcJsonStream { source, .. } => request_body_source_uses_stdin(source),
+        RequestBodySource::Bytes(_)
+        | RequestBodySource::File { .. }
+        | RequestBodySource::Multipart(_) => false,
+    }
 }
 
 fn ensure_request_body_replayable(body: &RequestBody, action: &str) -> Result<(), FetchError> {

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use prost::Message;
 use prost_reflect::{
     Cardinality, DescriptorPool, DynamicMessage, FieldDescriptor, Kind, MessageDescriptor,
@@ -6,6 +7,7 @@ use prost_reflect::{
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::error::FetchError;
 use crate::grpc::framing;
@@ -197,17 +199,16 @@ pub(crate) fn grpc_request_body(
     };
 
     if method.is_client_streaming() {
-        let Some((bytes, _)) = crate::http::request_body_into_bytes(body)? else {
+        let Some(body) = body else {
             return Ok(None);
         };
-        return stream_json_to_grpc_frames(&bytes, &method.input())
-            .map(|bytes| {
-                Some(crate::http::RequestBodyPayload::from_bytes(
-                    bytes,
-                    Some(grpc_content_type()),
-                ))
-            })
-            .map_err(|err| FetchError::Message(err.to_string()));
+        return Ok(Some(
+            crate::http::RequestBodyPayload::from_grpc_json_stream(
+                body,
+                method.input(),
+                Some(grpc_content_type()),
+            ),
+        ));
     }
 
     let raw = if let Some((bytes, _)) = crate::http::request_body_into_bytes(body)? {
@@ -229,25 +230,36 @@ pub fn format_grpc_stream_with_descriptor(
     let frames = framing::read_frames(bytes)
         .map_err(|err| ProtoError::Message(format!("failed to read gRPC stream: {err}")))?;
     let mut out = String::new();
-    for (index, frame) in frames.iter().enumerate() {
-        if frame.compressed {
-            return Err(ProtoError::Message(
-                "compressed gRPC messages are not supported".to_string(),
-            ));
+    let mut messages_written = 0usize;
+    for frame in &frames {
+        if let Some(formatted) = format_grpc_frame_with_descriptor(frame, desc)? {
+            if messages_written > 0 && !out.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push_str(&formatted);
+            messages_written += 1;
         }
-        if frame.data.is_empty() {
-            continue;
-        }
-        if index > 0 && !out.ends_with('\n') {
-            out.push('\n');
-        }
-        let msg = decode_dynamic_message(frame.data.as_slice(), desc)?;
-        let mut formatted = String::from_utf8(serialize_dynamic_message_json(&msg, true)?)
-            .map_err(|err| ProtoError::Message(format!("failed to format protobuf JSON: {err}")))?;
-        formatted.push('\n');
-        out.push_str(&formatted);
     }
     Ok(out)
+}
+
+pub fn format_grpc_frame_with_descriptor(
+    frame: &framing::Frame,
+    desc: &MessageDescriptor,
+) -> Result<Option<String>, ProtoError> {
+    if frame.compressed {
+        return Err(ProtoError::Message(
+            "compressed gRPC messages are not supported".to_string(),
+        ));
+    }
+    if frame.data.is_empty() {
+        return Ok(None);
+    }
+    let msg = decode_dynamic_message(frame.data.as_slice(), desc)?;
+    let mut formatted = String::from_utf8(serialize_dynamic_message_json(&msg, true)?)
+        .map_err(|err| ProtoError::Message(format!("failed to format protobuf JSON: {err}")))?;
+    formatted.push('\n');
+    Ok(Some(formatted))
 }
 
 pub fn describe_symbol(schema: &Schema, symbol: &str) -> Result<String, FetchError> {
@@ -430,25 +442,128 @@ pub fn stream_json_to_grpc_frames(
 ) -> Result<Vec<u8>, ProtoError> {
     let mut out = Vec::new();
     let stream = serde_json::Deserializer::from_slice(json_stream).into_iter::<serde_json::Value>();
-    let options = prost_reflect::DeserializeOptions::new().deny_unknown_fields(false);
     for value in stream {
         let value = value
             .map_err(|err| ProtoError::Message(format!("failed to decode JSON message: {err}")))?;
-        let value_text = value.to_string();
-        let mut deserializer = serde_json::Deserializer::from_str(&value_text);
-        let msg =
-            DynamicMessage::deserialize_with_options(desc.clone(), &mut deserializer, &options)
-                .map_err(|err| {
-                    ProtoError::Message(format!("failed to convert JSON to protobuf: {err}"))
-                })?;
-        deserializer
-            .end()
-            .map_err(|err| ProtoError::Message(format!("failed to decode JSON message: {err}")))?;
-        let frame = framing::frame(&msg.encode_to_vec(), false)
-            .map_err(|err| ProtoError::Message(err.to_string()))?;
-        out.extend_from_slice(&frame);
+        out.extend_from_slice(&json_value_to_grpc_frame(value, desc)?);
     }
     Ok(out)
+}
+
+pub(crate) fn json_reader_to_grpc_frame_stream<R>(
+    reader: R,
+    desc: MessageDescriptor,
+) -> impl futures_util::Stream<Item = Result<Bytes, std::io::Error>>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    struct State<R> {
+        reader: R,
+        desc: MessageDescriptor,
+        pending: Vec<u8>,
+        eof: bool,
+    }
+
+    futures_util::stream::try_unfold(
+        State {
+            reader,
+            desc,
+            pending: Vec::new(),
+            eof: false,
+        },
+        |mut state| async move {
+            loop {
+                match parse_next_json_value(&state.pending, state.eof) {
+                    Ok(JsonParse::Message { value, consumed }) => {
+                        state.pending.drain(..consumed);
+                        let frame = json_value_to_grpc_frame(value, &state.desc)
+                            .map_err(std::io::Error::other)?;
+                        return Ok(Some((Bytes::from(frame), state)));
+                    }
+                    Ok(JsonParse::NeedMore) => {}
+                    Ok(JsonParse::Done) => return Ok(None),
+                    Err(err) => return Err(std::io::Error::other(err)),
+                }
+
+                if state.eof {
+                    return Ok(None);
+                }
+
+                let mut buf = [0_u8; 16 * 1024];
+                let n = state.reader.read(&mut buf).await?;
+                if n == 0 {
+                    state.eof = true;
+                } else {
+                    state.pending.extend_from_slice(&buf[..n]);
+                }
+            }
+        },
+    )
+}
+
+enum JsonParse {
+    Message {
+        value: serde_json::Value,
+        consumed: usize,
+    },
+    NeedMore,
+    Done,
+}
+
+fn parse_next_json_value(buf: &[u8], eof: bool) -> Result<JsonParse, ProtoError> {
+    if buf.is_empty() {
+        return Ok(if eof {
+            JsonParse::Done
+        } else {
+            JsonParse::NeedMore
+        });
+    }
+    if buf.iter().all(u8::is_ascii_whitespace) {
+        return Ok(if eof {
+            JsonParse::Done
+        } else {
+            JsonParse::NeedMore
+        });
+    }
+
+    let mut stream = serde_json::Deserializer::from_slice(buf).into_iter::<serde_json::Value>();
+    match stream.next() {
+        Some(Ok(value)) => Ok(JsonParse::Message {
+            value,
+            consumed: stream.byte_offset(),
+        }),
+        Some(Err(err)) if err.is_eof() && !eof => Ok(JsonParse::NeedMore),
+        Some(Err(err)) => Err(ProtoError::Message(format!(
+            "failed to decode JSON message: {err}"
+        ))),
+        None => Ok(if eof {
+            JsonParse::Done
+        } else {
+            JsonParse::NeedMore
+        }),
+    }
+}
+
+fn json_value_to_grpc_frame(
+    value: serde_json::Value,
+    desc: &MessageDescriptor,
+) -> Result<Vec<u8>, ProtoError> {
+    let value_text = value.to_string();
+    let mut deserializer = serde_json::Deserializer::from_str(&value_text);
+    let options = prost_reflect::DeserializeOptions::new().deny_unknown_fields(false);
+    let msg =
+        match DynamicMessage::deserialize_with_options(desc.clone(), &mut deserializer, &options) {
+            Ok(msg) => msg,
+            Err(err) => {
+                return Err(ProtoError::Message(format!(
+                    "failed to convert JSON to protobuf: {err}"
+                )));
+            }
+        };
+    deserializer
+        .end()
+        .map_err(|err| ProtoError::Message(format!("failed to decode JSON message: {err}")))?;
+    framing::frame(&msg.encode_to_vec(), false).map_err(|err| ProtoError::Message(err.to_string()))
 }
 
 fn split_method_name(full_name: &str) -> Result<(&str, &str), ProtoError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -200,6 +200,11 @@ struct ReflectionGrpcServer {
     ca_cert_path: Option<PathBuf>,
 }
 
+struct ReadCapture {
+    buffer: Arc<Mutex<Vec<u8>>>,
+    done: mpsc::Receiver<()>,
+}
+
 #[cfg(unix)]
 struct PtyPair {
     master: fs::File,
@@ -750,6 +755,55 @@ fn wait_for_h3_requests(server: &H3TestServer, count: usize) -> Vec<H3Request> {
     }
 }
 
+fn start_read_capture<R>(mut reader: R) -> ReadCapture
+where
+    R: Read + Send + 'static,
+{
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let buffer_for_thread = Arc::clone(&buffer);
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut chunk = [0_u8; 1024];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => buffer_for_thread
+                    .lock()
+                    .unwrap()
+                    .extend_from_slice(&chunk[..n]),
+                Err(_) => break,
+            }
+        }
+        let _ = tx.send(());
+    });
+    ReadCapture { buffer, done: rx }
+}
+
+impl ReadCapture {
+    fn output(&self) -> String {
+        String::from_utf8_lossy(&self.buffer.lock().unwrap()).into_owned()
+    }
+
+    fn wait_for(&self, want: &str, timeout: Duration) {
+        let start = Instant::now();
+        loop {
+            if self.output().contains(want) {
+                return;
+            }
+            assert!(
+                start.elapsed() < timeout,
+                "timed out waiting for captured output {want:?}; output:\n{}",
+                self.output()
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn close(self) {
+        let _ = self.done.recv_timeout(Duration::from_secs(1));
+    }
+}
+
 #[cfg(unix)]
 fn open_pty(rows: u16, cols: u16, xpixel: u16, ypixel: u16) -> PtyPair {
     let mut master: libc::c_int = -1;
@@ -852,7 +906,6 @@ impl PtyCapture {
     }
 }
 
-#[cfg(unix)]
 fn wait_child(
     child: &mut std::process::Child,
     timeout: Duration,
@@ -1432,6 +1485,47 @@ fn start_status_grpc_h2c_server() -> String {
     url
 }
 
+#[cfg(unix)]
+fn start_delayed_response_grpc_h2c_server(close_rx: mpsc::Receiver<()>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind delayed grpc server");
+    listener.set_nonblocking(true).unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            serve_delayed_response_grpc_h2_connection(stream, close_rx).await;
+        });
+    });
+    url
+}
+
+fn start_delayed_bidi_grpc_h2c_server(finish_rx: mpsc::Receiver<()>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind delayed bidi grpc server");
+    listener.set_nonblocking(true).unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            serve_delayed_bidi_grpc_h2_connection(stream, finish_rx).await;
+        });
+    });
+    url
+}
+
 async fn serve_status_grpc_h2_connection<T>(stream: T)
 where
     T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
@@ -1446,6 +1540,45 @@ where
         tokio::spawn(async move {
             handle_status_grpc_h2_request(request, respond).await;
         });
+    }
+}
+
+#[cfg(unix)]
+async fn serve_delayed_response_grpc_h2_connection<T>(stream: T, close_rx: mpsc::Receiver<()>)
+where
+    T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let Ok(mut connection) = h2::server::handshake(stream).await else {
+        return;
+    };
+    if let Some(Ok((request, respond))) = connection.accept().await {
+        tokio::spawn(async move {
+            handle_delayed_response_grpc_h2_request(request, respond, close_rx).await;
+        });
+    }
+    while let Some(result) = connection.accept().await {
+        if result.is_err() {
+            break;
+        }
+    }
+}
+
+async fn serve_delayed_bidi_grpc_h2_connection<T>(stream: T, finish_rx: mpsc::Receiver<()>)
+where
+    T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let Ok(mut connection) = h2::server::handshake(stream).await else {
+        return;
+    };
+    if let Some(Ok((request, respond))) = connection.accept().await {
+        tokio::spawn(async move {
+            handle_delayed_bidi_grpc_h2_request(request, respond, finish_rx).await;
+        });
+    }
+    while let Some(result) = connection.accept().await {
+        if result.is_err() {
+            break;
+        }
     }
 }
 
@@ -1490,6 +1623,111 @@ async fn handle_status_grpc_h2_request(
         trailers.insert("grpc-message", http::HeaderValue::from_static(message));
     }
     let _ = send.send_trailers(trailers);
+}
+
+#[cfg(unix)]
+async fn handle_delayed_response_grpc_h2_request(
+    request: http::Request<h2::RecvStream>,
+    mut respond: h2::server::SendResponse<bytes::Bytes>,
+    close_rx: mpsc::Receiver<()>,
+) {
+    let mut body = request.into_body();
+    while let Some(chunk) = body.data().await {
+        if chunk.is_err() {
+            return;
+        }
+    }
+
+    let Ok(response) = http::Response::builder()
+        .status(200)
+        .header("content-type", "application/grpc+proto")
+        .body(())
+    else {
+        return;
+    };
+    let Ok(mut send) = respond.send_response(response, false) else {
+        return;
+    };
+    if send
+        .send_data(
+            bytes::Bytes::from(grpc_frame(&proto_field_varint(1, 1))),
+            false,
+        )
+        .is_err()
+    {
+        return;
+    }
+    wait_for_test_signal(close_rx, Duration::from_secs(5)).await;
+    if send
+        .send_data(
+            bytes::Bytes::from(grpc_frame(&proto_field_varint(1, 2))),
+            false,
+        )
+        .is_err()
+    {
+        return;
+    }
+    send_ok_grpc_trailers(send);
+}
+
+async fn handle_delayed_bidi_grpc_h2_request(
+    request: http::Request<h2::RecvStream>,
+    mut respond: h2::server::SendResponse<bytes::Bytes>,
+    finish_rx: mpsc::Receiver<()>,
+) {
+    let mut body = request.into_body();
+    let mut pending = Vec::new();
+    while !has_complete_grpc_frame(&pending) {
+        match body.data().await {
+            Some(Ok(chunk)) => pending.extend_from_slice(&chunk),
+            Some(Err(_)) | None => return,
+        }
+    }
+
+    let Ok(response) = http::Response::builder()
+        .status(200)
+        .header("content-type", "application/grpc+proto")
+        .body(())
+    else {
+        return;
+    };
+    let Ok(mut send) = respond.send_response(response, false) else {
+        return;
+    };
+    if send
+        .send_data(
+            bytes::Bytes::from(grpc_frame(&proto_field_varint(1, 1))),
+            false,
+        )
+        .is_err()
+    {
+        return;
+    }
+    wait_for_test_signal(finish_rx, Duration::from_secs(5)).await;
+    while let Some(chunk) = body.data().await {
+        if chunk.is_err() {
+            return;
+        }
+    }
+    send_ok_grpc_trailers(send);
+}
+
+fn has_complete_grpc_frame(bytes: &[u8]) -> bool {
+    if bytes.len() < 5 {
+        return false;
+    }
+    let len = u32::from_be_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]) as usize;
+    bytes.len() >= 5 + len
+}
+
+fn send_ok_grpc_trailers(mut send: h2::SendStream<bytes::Bytes>) {
+    let mut trailers = http::HeaderMap::new();
+    trailers.insert("grpc-status", http::HeaderValue::from_static("0"));
+    let _ = send.send_trailers(trailers);
+}
+
+async fn wait_for_test_signal(rx: mpsc::Receiver<()>, timeout: Duration) {
+    let _ = tokio::task::spawn_blocking(move || rx.recv_timeout(timeout)).await;
 }
 
 async fn handle_reflection_h2_request(
@@ -6444,6 +6682,132 @@ fn grpc_h2c_stream_frames_and_status_trailers_are_handled() {
     assert!(res.stdout.is_empty(), "stdout:\n{}", res.stdout);
     assert!(res.stderr.contains("PERMISSION_DENIED"), "{}", res.stderr);
     assert!(res.stderr.contains("permission denied"), "{}", res.stderr);
+}
+
+#[cfg(unix)]
+#[test]
+fn formatted_grpc_outputs_frames_before_stream_ends() {
+    let dir = TempDir::new().unwrap();
+    let stream_desc = write_stream_descriptor_set(dir.path());
+    let (close_tx, close_rx) = mpsc::channel();
+    let server_url = start_delayed_response_grpc_h2c_server(close_rx);
+    let url = format!("{server_url}/streampkg.StreamService/ServerStream");
+
+    let pty = open_pty(24, 80, 800, 480);
+    let mut cmd = Command::new(fetch_bin());
+    cmd.args([
+        url.as_str(),
+        "--grpc",
+        "--proto-desc",
+        stream_desc.to_str().unwrap(),
+        "-d",
+        r#"{"value":"seed"}"#,
+        "--format",
+        "on",
+        "--pager",
+        "off",
+    ]);
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("HTTP_PROXY", "");
+    cmd.env("HTTPS_PROXY", "");
+    cmd.env("ALL_PROXY", "");
+    cmd.env("NO_PROXY", "*");
+    configure_pty_child(&mut cmd, &pty.slave);
+    let mut child = cmd.spawn().expect("spawn delayed grpc fetch under PTY");
+    drop(pty.slave);
+    let capture = start_pty_capture(&pty.master);
+
+    capture.wait_for(r#""count": "1""#, Duration::from_secs(5));
+    assert!(
+        wait_child(&mut child, Duration::from_millis(100)).is_none(),
+        "fetch exited before the gRPC stream closed; PTY output:\n{}",
+        capture.output()
+    );
+    close_tx.send(()).unwrap();
+
+    let status = wait_child(&mut child, Duration::from_secs(5))
+        .unwrap_or_else(|| {
+            let _ = child.kill();
+            panic!(
+                "fetch did not exit after gRPC stream closed; PTY output:\n{}",
+                capture.output()
+            )
+        })
+        .expect("wait delayed grpc fetch");
+    assert!(
+        status.success(),
+        "fetch exited with {status}; PTY output:\n{}",
+        capture.output()
+    );
+    assert!(capture.output().contains(r#""count": "2""#));
+    drop(pty.master);
+    capture.close();
+}
+
+#[test]
+fn bidi_grpc_streams_request_and_response_before_stdin_eof() {
+    let dir = TempDir::new().unwrap();
+    let stream_desc = write_stream_descriptor_set(dir.path());
+    let (finish_tx, finish_rx) = mpsc::channel();
+    let server_url = start_delayed_bidi_grpc_h2c_server(finish_rx);
+
+    let mut cmd = Command::new(fetch_bin());
+    cmd.args([
+        &format!("{server_url}/streampkg.StreamService/Bidi"),
+        "--grpc",
+        "--proto-desc",
+        stream_desc.to_str().unwrap(),
+        "-d",
+        "@-",
+        "--format",
+        "on",
+        "--pager",
+        "off",
+    ]);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.env("NO_COLOR", "");
+    cmd.env("HTTP_PROXY", "");
+    cmd.env("HTTPS_PROXY", "");
+    cmd.env("ALL_PROXY", "");
+    cmd.env("NO_PROXY", "*");
+
+    let mut child = cmd.spawn().expect("spawn delayed bidi grpc fetch");
+    let mut stdin = child.stdin.take().expect("child stdin");
+    let stdout = start_read_capture(child.stdout.take().expect("child stdout"));
+    let stderr = start_read_capture(child.stderr.take().expect("child stderr"));
+
+    stdin.write_all(br#"{"value":"one"}"#).unwrap();
+    stdin.flush().unwrap();
+    stdout.wait_for(r#""count": "1""#, Duration::from_secs(5));
+    assert!(
+        wait_child(&mut child, Duration::from_millis(100)).is_none(),
+        "fetch exited before stdin EOF; stdout:\n{}\nstderr:\n{}",
+        stdout.output(),
+        stderr.output()
+    );
+
+    drop(stdin);
+    finish_tx.send(()).unwrap();
+    let status = wait_child(&mut child, Duration::from_secs(5))
+        .unwrap_or_else(|| {
+            let _ = child.kill();
+            panic!(
+                "fetch did not exit after stdin closed; stdout:\n{}\nstderr:\n{}",
+                stdout.output(),
+                stderr.output()
+            )
+        })
+        .expect("wait delayed bidi grpc fetch");
+    assert!(
+        status.success(),
+        "fetch exited with {status}; stdout:\n{}\nstderr:\n{}",
+        stdout.output(),
+        stderr.output()
+    );
+    stdout.close();
+    stderr.close();
 }
 
 #[test]


### PR DESCRIPTION
**Summary**
- Added a dedicated streaming path for `application/grpc+proto` responses so complete frames are decoded, formatted, written, and flushed as they arrive while trailers are still preserved.
- Switched client-streaming and bidi gRPC request bodies to stream framed protobuf messages from JSON input instead of buffering the whole payload first.
- Kept the existing buffered path for non-streaming protobuf responses and updated the repo guidance in `AGENTS.md`.
- Added delayed-frame integration coverage for both server streaming and bidi streaming to prove output appears before EOF.

**Testing**
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`