### PR TITLE
Preserve empty descriptor-aware gRPC messages

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1205,7 +1205,7 @@ async fn stream_response_to_formatted_grpc_stdout(
     let mut buf = vec![0; 16 * 1024];
     let mut bytes_read = 0i64;
     let mut frame_index = 0usize;
-    let mut descriptor_messages_written = 0usize;
+    let mut descriptor_wrote_any = false;
     let mut descriptor_output_ends_with_newline = true;
 
     loop {
@@ -1236,18 +1236,15 @@ async fn stream_response_to_formatted_grpc_stdout(
             .map_err(|err| FetchError::Message(format!("failed to read gRPC stream: {err}")))?;
         for frame in frames {
             if let Some(desc) = grpc_response_desc.as_ref() {
-                let Some(formatted) = proto::format_grpc_frame_with_descriptor(&frame, desc)
-                    .map_err(|err| FetchError::Message(err.to_string()))?
-                else {
-                    continue;
-                };
-                if descriptor_messages_written > 0 && !descriptor_output_ends_with_newline {
+                let formatted = proto::format_grpc_frame_with_descriptor(&frame, desc)
+                    .map_err(|err| FetchError::Message(err.to_string()))?;
+                if descriptor_wrote_any && !descriptor_output_ends_with_newline {
                     stdout.write_all(b"\n").await?;
                 }
                 stdout.write_all(formatted.as_bytes()).await?;
                 stdout.flush().await?;
                 descriptor_output_ends_with_newline = formatted.ends_with('\n');
-                descriptor_messages_written += 1;
+                descriptor_wrote_any = true;
             } else {
                 if frame_index > 0 {
                     stdout.write_all(b"\n").await?;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -230,15 +230,14 @@ pub fn format_grpc_stream_with_descriptor(
     let frames = framing::read_frames(bytes)
         .map_err(|err| ProtoError::Message(format!("failed to read gRPC stream: {err}")))?;
     let mut out = String::new();
-    let mut messages_written = 0usize;
+    let mut wrote_any = false;
     for frame in &frames {
-        if let Some(formatted) = format_grpc_frame_with_descriptor(frame, desc)? {
-            if messages_written > 0 && !out.ends_with('\n') {
-                out.push('\n');
-            }
-            out.push_str(&formatted);
-            messages_written += 1;
+        let formatted = format_grpc_frame_with_descriptor(frame, desc)?;
+        if wrote_any && !out.ends_with('\n') {
+            out.push('\n');
         }
+        out.push_str(&formatted);
+        wrote_any = true;
     }
     Ok(out)
 }
@@ -246,20 +245,17 @@ pub fn format_grpc_stream_with_descriptor(
 pub fn format_grpc_frame_with_descriptor(
     frame: &framing::Frame,
     desc: &MessageDescriptor,
-) -> Result<Option<String>, ProtoError> {
+) -> Result<String, ProtoError> {
     if frame.compressed {
         return Err(ProtoError::Message(
             "compressed gRPC messages are not supported".to_string(),
         ));
     }
-    if frame.data.is_empty() {
-        return Ok(None);
-    }
     let msg = decode_dynamic_message(frame.data.as_slice(), desc)?;
     let mut formatted = String::from_utf8(serialize_dynamic_message_json(&msg, true)?)
         .map_err(|err| ProtoError::Message(format!("failed to format protobuf JSON: {err}")))?;
     formatted.push('\n');
-    Ok(Some(formatted))
+    Ok(formatted)
 }
 
 pub fn describe_symbol(schema: &Schema, symbol: &str) -> Result<String, FetchError> {
@@ -1235,6 +1231,20 @@ mod tests {
         let out = format_grpc_stream_with_descriptor(&body, &method.output()).unwrap();
 
         assert!(out.contains("\"count\": \"3\""));
+    }
+
+    #[test]
+    fn format_grpc_stream_with_descriptor_preserves_empty_messages() {
+        let schema = Schema::from_descriptor_set(&stream_descriptor_set()).unwrap();
+        let method = schema
+            .find_method("streampkg.StreamService/ClientStream")
+            .unwrap();
+        let mut body = framing::frame(&[], false).unwrap();
+        body.extend_from_slice(&framing::frame(b"\x08\x03", false).unwrap());
+
+        let out = format_grpc_stream_with_descriptor(&body, &method.output()).unwrap();
+
+        assert_eq!(out, "{}\n{\n  \"count\": \"3\"\n}\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Stop dropping zero-length gRPC frames in descriptor-aware protobuf formatting
- Decode empty payloads through the message descriptor so valid empty messages render as `{}`
- Track whether anything has been written before inserting separators to avoid leading blank lines
- Add a regression test covering an empty frame followed by a populated frame

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`