### PR TITLE
Support gzip-compressed gRPC response messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - `--grpc` now automatically tries gRPC reflection when no local schema is supplied.
 - Plaintext loopback gRPC servers are supported via `h2c` for both calls and discovery.
 - Formatted gRPC responses with `Content-Type: application/grpc+proto` stream through `FrameDecoder`, writing each complete message immediately while preserving trailers.
+- gRPC calls and reflection advertise `grpc-accept-encoding: gzip`; response frames with the compressed flag are decompressed with the response `grpc-encoding` before protobuf decoding, with unsupported encodings reported by name.
 - Client-streaming and bidi gRPC calls stream JSON input into framed protobuf request bodies instead of materializing the whole stream up front.
 - `--inspect-dns` resolves the URL hostname without making an HTTP request, showing common DNS record types, resolver backend, duration, and per-record TTLs from direct UDP or DoH responses.
 - `--inspect-tls --http 3` performs QUIC/TLS inspection with `h3` ALPN instead of the TCP TLS path.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -548,7 +548,7 @@ See [WebSocket documentation](websocket.md) for details.
 
 ### `--grpc`
 
-Enable gRPC mode. Automatically sets HTTP/2, POST method, and gRPC headers. When no local proto schema is provided, `fetch` automatically tries gRPC reflection before falling back to generic protobuf handling.
+Enable gRPC mode. Automatically sets HTTP/2, POST method, and gRPC headers, including `grpc-accept-encoding: gzip`. When no local proto schema is provided, `fetch` automatically tries gRPC reflection before falling back to generic protobuf handling. Gzip-compressed gRPC response messages are decompressed before protobuf formatting.
 
 ```sh
 fetch --grpc https://localhost:50051/package.Service/Method

--- a/docs/grpc.md
+++ b/docs/grpc.md
@@ -14,9 +14,9 @@ Enable gRPC mode. This flag:
 
 - Forces HTTP/2 protocol
 - Sets method to POST
-- Adds gRPC headers (`Content-Type: application/grpc+proto`, `TE: trailers`)
+- Adds gRPC headers (`Content-Type: application/grpc+proto`, `TE: trailers`, `grpc-accept-encoding: gzip`)
 - Applies gRPC message framing
-- Handles gRPC response framing
+- Handles gRPC response framing, including gzip-compressed response messages when the server sends `grpc-encoding: gzip`
 
 ```sh
 fetch --grpc https://localhost:50051/package.Service/Method
@@ -411,6 +411,8 @@ fetch --grpc --proto-file service.proto \
 ```
 
 For streaming responses, messages are separated by blank lines in the output. Formatting and flushing happen incrementally, so results appear in real time.
+
+If a server compresses individual response messages, `fetch` decompresses gzip-framed gRPC messages before protobuf decoding. Unsupported per-message encodings are reported with the encoding name.
 
 ### gRPC Status
 

--- a/src/format/grpc.rs
+++ b/src/format/grpc.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::grpc::encoding::{self, MessageEncoding};
 use crate::grpc::framing;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,7 +14,10 @@ impl fmt::Display for GrpcFormatError {
 
 impl std::error::Error for GrpcFormatError {}
 
-pub fn format_grpc_stream(buf: &[u8]) -> Result<String, GrpcFormatError> {
+pub fn format_grpc_stream(
+    buf: &[u8],
+    message_encoding: &MessageEncoding,
+) -> Result<String, GrpcFormatError> {
     let frames = framing::read_frames(buf).map_err(|err| GrpcFormatError(err.to_string()))?;
     let mut out = String::new();
 
@@ -21,31 +25,37 @@ pub fn format_grpc_stream(buf: &[u8]) -> Result<String, GrpcFormatError> {
         if idx > 0 {
             out.push('\n');
         }
-        out.push_str(&format_grpc_frame(frame)?);
+        out.push_str(&format_grpc_frame(frame, message_encoding)?);
     }
 
     Ok(out)
 }
 
-pub fn format_grpc_frame(frame: &framing::Frame) -> Result<String, GrpcFormatError> {
-    if frame.compressed {
-        return Err(GrpcFormatError(
-            "compressed gRPC messages are not supported".to_string(),
-        ));
-    }
-    crate::format::protobuf::format_protobuf(&frame.data)
-        .map_err(|err| GrpcFormatError(err.to_string()))
+pub fn format_grpc_frame(
+    frame: &framing::Frame,
+    message_encoding: &MessageEncoding,
+) -> Result<String, GrpcFormatError> {
+    let data = encoding::decompress_frame(frame, message_encoding)
+        .map_err(|err| GrpcFormatError(err.to_string()))?;
+    crate::format::protobuf::format_protobuf(&data).map_err(|err| GrpcFormatError(err.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::grpc::framing::frame;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::io::Write;
 
     #[test]
     fn test_format_grpc_stream_single_frame() {
         let proto_data = append_bytes(append_varint(Vec::new(), 1, 42), 2, b"hello");
-        let output = format_grpc_stream(&frame(&proto_data, false).unwrap()).unwrap();
+        let output = format_grpc_stream(
+            &frame(&proto_data, false).unwrap(),
+            &MessageEncoding::Identity,
+        )
+        .unwrap();
         assert!(output.contains("1:"));
         assert!(output.contains("42"));
         assert!(output.contains("2:"));
@@ -63,7 +73,7 @@ mod tests {
         stream.extend_from_slice(&frame2);
         stream.extend_from_slice(&frame3);
 
-        let output = format_grpc_stream(&stream).unwrap();
+        let output = format_grpc_stream(&stream, &MessageEncoding::Identity).unwrap();
         assert!(output.contains("100"));
         assert!(output.contains("200"));
         assert!(output.contains("300"));
@@ -71,16 +81,39 @@ mod tests {
 
     #[test]
     fn test_format_grpc_stream_empty_stream_and_message() {
-        assert_eq!(format_grpc_stream(&[]).unwrap(), "");
-        assert_eq!(format_grpc_stream(&frame(&[], false).unwrap()).unwrap(), "");
+        assert_eq!(
+            format_grpc_stream(&[], &MessageEncoding::Identity).unwrap(),
+            ""
+        );
+        assert_eq!(
+            format_grpc_stream(&frame(&[], false).unwrap(), &MessageEncoding::Identity).unwrap(),
+            ""
+        );
     }
 
     #[test]
-    fn test_format_grpc_stream_compressed_frame() {
-        let err = format_grpc_stream(&frame(b"compressed payload", true).unwrap()).unwrap_err();
+    fn test_format_grpc_stream_gzip_compressed_frame() {
+        let proto_data = append_bytes(Vec::new(), 1, b"compressed payload");
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&proto_data).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let out =
+            format_grpc_stream(&frame(&compressed, true).unwrap(), &MessageEncoding::Gzip).unwrap();
+
+        assert!(out.contains("\"compressed payload\""));
+    }
+
+    #[test]
+    fn test_format_grpc_stream_unsupported_compressed_frame() {
+        let err = format_grpc_stream(
+            &frame(b"compressed payload", true).unwrap(),
+            &MessageEncoding::Unsupported("br".to_string()),
+        )
+        .unwrap_err();
         assert!(
             err.to_string()
-                .contains("compressed gRPC messages are not supported")
+                .contains("unsupported gRPC compression encoding: br")
         );
     }
 
@@ -88,7 +121,7 @@ mod tests {
     fn test_format_grpc_stream_error_mid_stream() {
         let mut stream = frame(&append_varint(Vec::new(), 1, 42), false).unwrap();
         stream.extend_from_slice(&[0x00, 0x00]);
-        assert!(format_grpc_stream(&stream).is_err());
+        assert!(format_grpc_stream(&stream, &MessageEncoding::Identity).is_err());
     }
 
     #[test]
@@ -100,7 +133,7 @@ mod tests {
         stream.extend_from_slice(&frame(&msg1, false).unwrap());
         stream.extend_from_slice(&frame(&msg2, false).unwrap());
 
-        let output = format_grpc_stream(&stream).unwrap();
+        let output = format_grpc_stream(&stream, &MessageEncoding::Identity).unwrap();
         assert!(output.contains("10"));
         assert!(output.contains("\"first\""));
         assert!(output.contains("20"));

--- a/src/grpc/encoding.rs
+++ b/src/grpc/encoding.rs
@@ -1,0 +1,155 @@
+use std::fmt;
+use std::io::Read;
+
+use flate2::read::GzDecoder;
+use reqwest::header::HeaderMap;
+
+use crate::grpc::framing;
+
+pub const ACCEPT_ENCODING: &str = "gzip";
+const ENCODING_HEADER: &str = "grpc-encoding";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MessageEncoding {
+    Identity,
+    Gzip,
+    Unsupported(String),
+    Invalid(String),
+}
+
+impl MessageEncoding {
+    pub fn from_headers(headers: &HeaderMap) -> Self {
+        let Some(value) = headers.get(ENCODING_HEADER) else {
+            return Self::Identity;
+        };
+        match value.to_str() {
+            Ok(value) => Self::from_name(value),
+            Err(err) => Self::Invalid(err.to_string()),
+        }
+    }
+
+    pub fn from_name(value: &str) -> Self {
+        let value = value.trim();
+        if value.is_empty() || value.eq_ignore_ascii_case("identity") {
+            Self::Identity
+        } else if value.eq_ignore_ascii_case("gzip") {
+            Self::Gzip
+        } else {
+            Self::Unsupported(value.to_ascii_lowercase())
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncodingError(String);
+
+impl fmt::Display for EncodingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for EncodingError {}
+
+pub fn decompress_frame(
+    frame: &framing::Frame,
+    encoding: &MessageEncoding,
+) -> Result<Vec<u8>, EncodingError> {
+    if !frame.compressed {
+        return Ok(frame.data.clone());
+    }
+
+    match encoding {
+        MessageEncoding::Gzip => decompress_gzip(&frame.data),
+        MessageEncoding::Identity => Err(EncodingError(
+            "compressed gRPC message uses unsupported grpc-encoding: identity".to_string(),
+        )),
+        MessageEncoding::Unsupported(encoding) => Err(EncodingError(format!(
+            "unsupported gRPC compression encoding: {encoding}"
+        ))),
+        MessageEncoding::Invalid(err) => Err(EncodingError(format!(
+            "invalid grpc-encoding response header: {err}"
+        ))),
+    }
+}
+
+fn decompress_gzip(bytes: &[u8]) -> Result<Vec<u8>, EncodingError> {
+    let mut reader = GzDecoder::new(bytes).take(framing::MAX_MESSAGE_SIZE as u64 + 1);
+    let mut decoded = Vec::new();
+    reader
+        .read_to_end(&mut decoded)
+        .map_err(|err| EncodingError(format!("gzip gRPC message decompression failed: {err}")))?;
+    if decoded.len() > framing::MAX_MESSAGE_SIZE {
+        return Err(EncodingError(format!(
+            "decompressed gRPC message too large: {} bytes",
+            decoded.len()
+        )));
+    }
+    Ok(decoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use reqwest::header::HeaderValue;
+    use std::io::Write;
+
+    #[test]
+    fn parses_grpc_encoding_header() {
+        assert_eq!(MessageEncoding::from_name(""), MessageEncoding::Identity);
+        assert_eq!(
+            MessageEncoding::from_name("identity"),
+            MessageEncoding::Identity
+        );
+        assert_eq!(MessageEncoding::from_name("GZip"), MessageEncoding::Gzip);
+        assert_eq!(
+            MessageEncoding::from_name("br"),
+            MessageEncoding::Unsupported("br".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_grpc_encoding_from_headers() {
+        let mut headers = HeaderMap::new();
+        assert_eq!(
+            MessageEncoding::from_headers(&headers),
+            MessageEncoding::Identity
+        );
+
+        headers.insert("grpc-encoding", HeaderValue::from_static("gzip"));
+        assert_eq!(
+            MessageEncoding::from_headers(&headers),
+            MessageEncoding::Gzip
+        );
+    }
+
+    #[test]
+    fn decompresses_gzip_frame() {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(b"\x08\x2a").unwrap();
+        let compressed = encoder.finish().unwrap();
+        let frame = framing::Frame {
+            data: compressed,
+            compressed: true,
+        };
+
+        let decoded = decompress_frame(&frame, &MessageEncoding::Gzip).unwrap();
+
+        assert_eq!(decoded, b"\x08\x2a");
+    }
+
+    #[test]
+    fn names_unsupported_compressed_encoding() {
+        let frame = framing::Frame {
+            data: b"payload".to_vec(),
+            compressed: true,
+        };
+
+        let err =
+            decompress_frame(&frame, &MessageEncoding::Unsupported("br".to_string())).unwrap_err();
+
+        assert_eq!(err.to_string(), "unsupported gRPC compression encoding: br");
+    }
+}

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -1,3 +1,4 @@
+pub mod encoding;
 pub mod framing;
 pub mod reflection;
 pub mod status;

--- a/src/grpc/reflection.rs
+++ b/src/grpc/reflection.rs
@@ -8,6 +8,7 @@ use url::Url;
 use crate::cli::Cli;
 use crate::core;
 use crate::error::FetchError;
+use crate::grpc::encoding::{self, MessageEncoding};
 use crate::grpc::framing;
 use crate::grpc::status;
 use crate::proto::Schema;
@@ -170,8 +171,9 @@ async fn invoke(
     }
 
     let headers = response.headers().clone();
+    let message_encoding = MessageEncoding::from_headers(&headers);
     let response: http::Response<reqwest::Body> = response.into();
-    let (out, trailers) = read_reflection_frames(response.into_body()).await?;
+    let (out, trailers) = read_reflection_frames(response.into_body(), &message_encoding).await?;
     if let Some(grpc_status) =
         grpc_status_from_headers(&trailers).or_else(|| grpc_status_from_headers(&headers))
     {
@@ -183,6 +185,7 @@ async fn invoke(
 
 async fn read_reflection_frames(
     mut body: reqwest::Body,
+    message_encoding: &MessageEncoding,
 ) -> Result<(Vec<Vec<u8>>, HeaderMap), FetchError> {
     let mut decoder = framing::FrameDecoder::new();
     let mut out = Vec::new();
@@ -196,10 +199,9 @@ async fn read_reflection_frames(
                     .push(&data)
                     .map_err(|err| FetchError::Message(err.to_string()))?
                 {
-                    if frame.compressed {
-                        return Err("compressed gRPC messages are not supported".into());
-                    }
-                    out.push(frame.data);
+                    let data = encoding::decompress_frame(&frame, message_encoding)
+                        .map_err(|err| FetchError::Message(err.to_string()))?;
+                    out.push(data);
                 }
             }
             Err(frame) => {
@@ -230,6 +232,10 @@ fn reflection_headers(cli: &Cli) -> Result<HeaderMap, FetchError> {
     headers.insert(
         HeaderName::from_static("te"),
         HeaderValue::from_static("trailers"),
+    );
+    headers.insert(
+        HeaderName::from_static("grpc-accept-encoding"),
+        HeaderValue::from_static(encoding::ACCEPT_ENCODING),
     );
     for raw in &cli.headers {
         let Some((name, value)) = raw.split_once(':') else {
@@ -572,8 +578,41 @@ mod tests {
                 bytes::Bytes::from_static(&[0x00, 0x04, 0x00, 0x00, 0x01]),
             )]));
 
-        let err = read_reflection_frames(body).await.unwrap_err();
+        let err = read_reflection_frames(body, &MessageEncoding::Identity)
+            .await
+            .unwrap_err();
 
         assert!(err.to_string().contains("gRPC message too large"));
+    }
+
+    #[tokio::test]
+    async fn reflection_reader_decodes_gzip_messages() {
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        std::io::Write::write_all(&mut encoder, b"\x3a\x01*").unwrap();
+        let compressed = encoder.finish().unwrap();
+        let body =
+            reqwest::Body::wrap_stream(futures_util::stream::iter([Ok::<_, std::io::Error>(
+                bytes::Bytes::from(framing::frame(&compressed, true).unwrap()),
+            )]));
+
+        let (messages, _) = read_reflection_frames(body, &MessageEncoding::Gzip)
+            .await
+            .unwrap();
+
+        assert_eq!(messages, [b"\x3a\x01*".to_vec()]);
+    }
+
+    #[tokio::test]
+    async fn reflection_reader_names_unsupported_compression() {
+        let body =
+            reqwest::Body::wrap_stream(futures_util::stream::iter([Ok::<_, std::io::Error>(
+                bytes::Bytes::from(framing::frame(b"payload", true).unwrap()),
+            )]));
+
+        let err = read_reflection_frames(body, &MessageEncoding::Unsupported("br".to_string()))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "unsupported gRPC compression encoding: br");
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -47,6 +47,7 @@ use crate::format::protobuf;
 use crate::format::sse;
 use crate::format::xml;
 use crate::format::yaml;
+use crate::grpc::encoding as grpc_encoding;
 use crate::grpc::status as grpc_status;
 use crate::http::client::DnsResolution;
 use crate::output;
@@ -1202,6 +1203,7 @@ async fn stream_response_to_formatted_grpc_stdout(
     let mut stdout = tokio::io::stdout();
     let mut capture = copy.then(clipboard::Capture::default);
     let mut decoder = crate::grpc::framing::FrameDecoder::new();
+    let grpc_message_encoding = grpc_encoding::MessageEncoding::from_headers(&response_headers);
     let mut buf = vec![0; 16 * 1024];
     let mut bytes_read = 0i64;
     let mut frame_index = 0usize;
@@ -1236,8 +1238,9 @@ async fn stream_response_to_formatted_grpc_stdout(
             .map_err(|err| FetchError::Message(format!("failed to read gRPC stream: {err}")))?;
         for frame in frames {
             if let Some(desc) = grpc_response_desc.as_ref() {
-                let formatted = proto::format_grpc_frame_with_descriptor(&frame, desc)
-                    .map_err(|err| FetchError::Message(err.to_string()))?;
+                let formatted =
+                    proto::format_grpc_frame_with_descriptor(&frame, desc, &grpc_message_encoding)
+                        .map_err(|err| FetchError::Message(err.to_string()))?;
                 if descriptor_wrote_any && !descriptor_output_ends_with_newline {
                     stdout.write_all(b"\n").await?;
                 }
@@ -1249,7 +1252,7 @@ async fn stream_response_to_formatted_grpc_stdout(
                 if frame_index > 0 {
                     stdout.write_all(b"\n").await?;
                 }
-                let formatted = grpc_format::format_grpc_frame(&frame)
+                let formatted = grpc_format::format_grpc_frame(&frame, &grpc_message_encoding)
                     .map_err(|err| FetchError::Message(err.to_string()))?;
                 stdout.write_all(formatted.as_bytes()).await?;
                 stdout.flush().await?;
@@ -2107,6 +2110,10 @@ fn apply_grpc_headers(headers: &mut HeaderMap) {
         HeaderName::from_static("te"),
         HeaderValue::from_static("trailers"),
     );
+    headers.insert(
+        HeaderName::from_static("grpc-accept-encoding"),
+        HeaderValue::from_static(grpc_encoding::ACCEPT_ENCODING),
+    );
 }
 
 fn check_grpc_status(cli: &Cli, headers: &HeaderMap, trailers: &HeaderMap, exit_code: i32) -> i32 {
@@ -2290,12 +2297,13 @@ fn format_stdout_bytes_with_terminal(
             }
         }
         ContentType::Grpc => {
+            let grpc_message_encoding = grpc_encoding::MessageEncoding::from_headers(headers);
             if let Some(desc) = grpc_response_desc {
-                proto::format_grpc_stream_with_descriptor(&bytes, &desc)
+                proto::format_grpc_stream_with_descriptor(&bytes, &desc, &grpc_message_encoding)
                     .map(|formatted| formatted.into_bytes())
                     .map_err(|err| FetchError::Message(err.to_string()))
             } else {
-                grpc_format::format_grpc_stream(&bytes)
+                grpc_format::format_grpc_stream(&bytes, &grpc_message_encoding)
                     .map(|formatted| formatted.into_bytes())
                     .map_err(|err| FetchError::Message(err.to_string()))
             }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -10,6 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::error::FetchError;
+use crate::grpc::encoding::{self, MessageEncoding};
 use crate::grpc::framing;
 
 #[derive(Debug, Clone)]
@@ -226,13 +227,14 @@ pub(crate) fn grpc_request_body(
 pub fn format_grpc_stream_with_descriptor(
     bytes: &[u8],
     desc: &MessageDescriptor,
+    message_encoding: &MessageEncoding,
 ) -> Result<String, ProtoError> {
     let frames = framing::read_frames(bytes)
         .map_err(|err| ProtoError::Message(format!("failed to read gRPC stream: {err}")))?;
     let mut out = String::new();
     let mut wrote_any = false;
     for frame in &frames {
-        let formatted = format_grpc_frame_with_descriptor(frame, desc)?;
+        let formatted = format_grpc_frame_with_descriptor(frame, desc, message_encoding)?;
         if wrote_any && !out.ends_with('\n') {
             out.push('\n');
         }
@@ -245,13 +247,11 @@ pub fn format_grpc_stream_with_descriptor(
 pub fn format_grpc_frame_with_descriptor(
     frame: &framing::Frame,
     desc: &MessageDescriptor,
+    message_encoding: &MessageEncoding,
 ) -> Result<String, ProtoError> {
-    if frame.compressed {
-        return Err(ProtoError::Message(
-            "compressed gRPC messages are not supported".to_string(),
-        ));
-    }
-    let msg = decode_dynamic_message(frame.data.as_slice(), desc)?;
+    let data = encoding::decompress_frame(frame, message_encoding)
+        .map_err(|err| ProtoError::Message(err.to_string()))?;
+    let msg = decode_dynamic_message(data.as_slice(), desc)?;
     let mut formatted = String::from_utf8(serialize_dynamic_message_json(&msg, true)?)
         .map_err(|err| ProtoError::Message(format!("failed to format protobuf JSON: {err}")))?;
     formatted.push('\n');
@@ -756,12 +756,15 @@ pub enum ProtoError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
     use prost_types::{
         DescriptorProto, EnumDescriptorProto, EnumValueDescriptorProto, FieldDescriptorProto,
         FileDescriptorProto, FileDescriptorSet, MessageOptions, MethodDescriptorProto,
         OneofDescriptorProto, ServiceDescriptorProto,
         field_descriptor_proto::{Label, Type},
     };
+    use std::io::Write;
     use std::path::Path;
 
     fn stream_descriptor_set() -> Vec<u8> {
@@ -1228,7 +1231,26 @@ mod tests {
             .unwrap();
         let body = framing::frame(b"\x08\x03", false).unwrap();
 
-        let out = format_grpc_stream_with_descriptor(&body, &method.output()).unwrap();
+        let out =
+            format_grpc_stream_with_descriptor(&body, &method.output(), &MessageEncoding::Identity)
+                .unwrap();
+
+        assert!(out.contains("\"count\": \"3\""));
+    }
+
+    #[test]
+    fn format_grpc_stream_with_descriptor_decodes_gzip_messages() {
+        let schema = Schema::from_descriptor_set(&stream_descriptor_set()).unwrap();
+        let method = schema
+            .find_method("streampkg.StreamService/ClientStream")
+            .unwrap();
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(b"\x08\x03").unwrap();
+        let body = framing::frame(&encoder.finish().unwrap(), true).unwrap();
+
+        let out =
+            format_grpc_stream_with_descriptor(&body, &method.output(), &MessageEncoding::Gzip)
+                .unwrap();
 
         assert!(out.contains("\"count\": \"3\""));
     }
@@ -1242,7 +1264,9 @@ mod tests {
         let mut body = framing::frame(&[], false).unwrap();
         body.extend_from_slice(&framing::frame(b"\x08\x03", false).unwrap());
 
-        let out = format_grpc_stream_with_descriptor(&body, &method.output()).unwrap();
+        let out =
+            format_grpc_stream_with_descriptor(&body, &method.output(), &MessageEncoding::Identity)
+                .unwrap();
 
         assert_eq!(out, "{}\n{\n  \"count\": \"3\"\n}\n");
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2008,10 +2008,20 @@ fn assert_proxy_seen(seen: &mpsc::Receiver<String>, want: &str) {
 }
 
 fn grpc_frame(payload: &[u8]) -> Vec<u8> {
-    let mut out = vec![0; 5 + payload.len()];
+    grpc_frame_with_flag(payload, false)
+}
+
+fn grpc_frame_with_flag(payload: &[u8], compressed: bool) -> Vec<u8> {
+    let mut out = vec![u8::from(compressed); 5 + payload.len()];
     out[1..5].copy_from_slice(&(payload.len() as u32).to_be_bytes());
     out[5..].copy_from_slice(payload);
     out
+}
+
+fn gzip_bytes(payload: &[u8]) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(payload).unwrap();
+    encoder.finish().unwrap()
 }
 
 fn proto_field_string(field: u64, value: &str) -> Vec<u8> {
@@ -5767,6 +5777,7 @@ fn socks_proxy_unix_socket_timing_and_grpc_binary_cases() {
         out.extend(grpc_frame(&proto_field_string(1, "message three")));
         out
     };
+    let grpc_gzip = grpc_frame_with_flag(&gzip_bytes(&proto_field_string(1, "gzip grpc")), true);
     let binary = TestServer::start(move |req| match req.path.as_str() {
         "/proto" => {
             TestResponse::ok(proto_body.clone()).header("Content-Type", "application/protobuf")
@@ -5774,6 +5785,12 @@ fn socks_proxy_unix_socket_timing_and_grpc_binary_cases() {
         "/grpc" => {
             TestResponse::ok(grpc_body.clone()).header("Content-Type", "application/grpc+proto")
         }
+        "/grpc-gzip" => TestResponse::ok(grpc_gzip.clone())
+            .header("Content-Type", "application/grpc+proto")
+            .header("grpc-encoding", "gzip"),
+        "/grpc-br" => TestResponse::ok(grpc_frame_with_flag(b"not actually br", true))
+            .header("Content-Type", "application/grpc+proto")
+            .header("grpc-encoding", "br"),
         "/grpc-stream" => {
             TestResponse::ok(grpc_stream.clone()).header("Content-Type", "application/grpc+proto")
         }
@@ -5795,6 +5812,15 @@ fn socks_proxy_unix_socket_timing_and_grpc_binary_cases() {
     let res = run_fetch(&[&format!("{}/grpc", binary.url), "--format", "on"]);
     assert_exit(&res, 0);
     assert!(res.stdout.contains("grpc test"));
+    let res = run_fetch(&[&format!("{}/grpc-gzip", binary.url), "--format", "on"]);
+    assert_exit(&res, 0);
+    assert!(res.stdout.contains("gzip grpc"));
+    let res = run_fetch(&[&format!("{}/grpc-br", binary.url), "--format", "on"]);
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr
+            .contains("unsupported gRPC compression encoding: br")
+    );
     let res = run_fetch(&[&format!("{}/grpc-stream", binary.url), "--format", "on"]);
     assert_exit(&res, 0);
     assert!(res.stdout.contains("message one"));
@@ -6595,6 +6621,7 @@ service StreamService {
     assert_eq!(request.method, "POST");
     assert_eq!(request.header("content-type"), "application/grpc+proto");
     assert_eq!(request.header("te"), "trailers");
+    assert_eq!(request.header("grpc-accept-encoding"), "gzip");
     assert_eq!(request.header("x-test"), "yes");
     assert!(request.header("authorization").starts_with("Basic "));
     assert_eq!(request.body, grpc_frame(&proto_field_string(1, "svc")));


### PR DESCRIPTION
## Summary
- Added gRPC message encoding handling that reads `grpc-encoding`, decompresses gzip-framed messages before protobuf decoding, and reports unsupported encodings by name
- Advertises `grpc-accept-encoding: gzip` for gRPC calls and reflection so servers can safely return compressed messages
- Updated streaming, schema-aware, and reflection response paths to decode compressed frames consistently
- Documented the behavior and added integration coverage for gzip responses, unsupported encodings, and the new request header

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`