### PR TITLE
Preserve whitespace in query, form, and multipart values

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -294,7 +294,7 @@ fn parse_file(path: &Path, contents: &str) -> Result<ConfigFile, String> {
             continue;
         }
 
-        let Some((key, value)) = line.split_once('=') else {
+        let Some((key, value)) = raw_line.trim_start().split_once('=') else {
             return Err(file_error(
                 path,
                 line_num,
@@ -302,7 +302,11 @@ fn parse_file(path: &Path, contents: &str) -> Result<ConfigFile, String> {
             ));
         };
         let key = key.trim();
-        let value = value.trim();
+        let value = if key == "query" {
+            value.trim_start()
+        } else {
+            value.trim()
+        };
         let target = match current_host.as_deref() {
             Some(host) => file
                 .hosts
@@ -734,7 +738,7 @@ fn header_value_error(path: &Path, line_num: usize, value: &str) -> String {
 
 fn parse_query(value: &str) -> String {
     let (key, val) = value.split_once('=').unwrap_or((value, ""));
-    format!("{}={}", key.trim(), val.trim())
+    format!("{}={}", key.trim(), val)
 }
 
 fn validate_dns_server(path: &Path, line_num: usize, value: &str) -> Result<(), String> {
@@ -1097,6 +1101,19 @@ mod tests {
         assert_eq!(file.global.session.as_deref(), Some("abc_123"));
         assert_eq!(file.global.sort_headers, Some(true));
         assert_eq!(file.global.verbosity, Some(3));
+    }
+
+    #[test]
+    fn parse_query_preserves_value_spaces_after_equals() {
+        assert_eq!(parse_query(" q = hello "), "q= hello ");
+    }
+
+    #[test]
+    fn parse_file_preserves_query_value_trailing_space_after_equals() {
+        let path = PathBuf::from("test/config");
+        let file = parse_file(&path, "query = q= hello \n").unwrap();
+
+        assert_eq!(file.global.query, vec!["q= hello "]);
     }
 
     #[test]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -2974,7 +2974,7 @@ pub(crate) fn apply_query(url: &mut Url, query: &[String]) {
         values
             .entry(key.trim().to_string())
             .or_default()
-            .push(val.trim().to_string());
+            .push(val.to_string());
     }
 
     let mut serializer = url::form_urlencoded::Serializer::new(String::new());
@@ -3233,7 +3233,7 @@ pub(crate) fn request_body(cli: &Cli) -> Result<RequestBody, FetchError> {
         let mut serializer = url::form_urlencoded::Serializer::new(String::new());
         for raw in &cli.form {
             let (key, val) = raw.split_once('=').unwrap_or((raw, ""));
-            serializer.append_pair(key.trim(), val.trim());
+            serializer.append_pair(key.trim(), val);
         }
         return Ok(Some(RequestBodyPayload {
             source: RequestBodySource::Bytes(Bytes::from(serializer.finish().into_bytes())),
@@ -3629,12 +3629,13 @@ mod tests {
                 "z=two".to_string(),
                 "blank".to_string(),
                 "space=second value".to_string(),
+                "spaced= hello ".to_string(),
             ],
         );
 
         assert_eq!(
             url.as_str(),
-            "https://example.com/path?a=one&blank=&space=hello+world&space=second+value&z=old&z=two"
+            "https://example.com/path?a=one&blank=&space=hello+world&space=second+value&spaced=+hello+&z=old&z=two"
         );
     }
 
@@ -3764,6 +3765,19 @@ mod tests {
             .unwrap();
         assert_eq!(body.0, br#"{"ok":true}"#);
         assert_eq!(body.1.as_deref(), Some("application/json"));
+    }
+
+    #[test]
+    fn request_body_form_preserves_value_spaces_after_equals() {
+        let cli =
+            Cli::try_parse_from(["fetch", "--form", "message= hello ", "https://example.com"])
+                .unwrap();
+        let body = request_body_into_bytes(request_body(&cli).unwrap())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(body.0, b"message=+hello+");
+        assert_eq!(body.1.as_deref(), Some("application/x-www-form-urlencoded"));
     }
 
     #[test]

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -49,7 +49,6 @@ impl Multipart {
             let (name, value) = raw.split_once('=').unwrap_or((raw, ""));
             let name = name.trim().to_string();
             validate_multipart_disposition_value("field name", &name)?;
-            let value = value.trim();
             let value = if let Some(path) = value.strip_prefix('@') {
                 let path = expand_home(path);
                 validate_file(&path)?;
@@ -404,6 +403,18 @@ mod tests {
         assert!(body.contains("name=\"field\""));
         assert!(body.contains("value"));
         assert!(multipart.content_type().contains(&multipart.boundary));
+    }
+
+    #[test]
+    fn multipart_text_field_preserves_value_spaces_after_equals() {
+        let multipart = Multipart::from_cli_fields(&[" note = hello ".to_string()])
+            .unwrap()
+            .unwrap();
+
+        let body = String::from_utf8(multipart.open().unwrap()).unwrap();
+
+        assert!(body.contains("name=\"note\""));
+        assert!(body.contains("\r\n\r\n hello \r\n"));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4348,6 +4348,35 @@ fn request_construction_host_header_form_and_http_version() {
 }
 
 #[test]
+fn request_query_form_and_multipart_values_preserve_spaces_after_equals() {
+    let server = TestServer::start(|_| TestResponse::ok(""));
+
+    let res = run_fetch(&[&server.url, "--query", "q= hello "]);
+    assert_exit(&res, 0);
+    let req = wait_for_requests(&server, 1).remove(0);
+    assert_eq!(req.path, "/?q=+hello+");
+
+    let res = run_fetch(&[&server.url, "--form", "message= hello "]);
+    assert_exit(&res, 0);
+    let req = wait_for_requests(&server, 2).remove(1);
+    assert_eq!(
+        req.header("content-type"),
+        "application/x-www-form-urlencoded"
+    );
+    assert_eq!(req.body_string(), "message=+hello+");
+
+    let res = run_fetch(&[&server.url, "--multipart", "note= hello "]);
+    assert_exit(&res, 0);
+    let req = wait_for_requests(&server, 3).remove(2);
+    assert!(
+        req.header("content-type")
+            .starts_with("multipart/form-data; boundary=")
+    );
+    let body = req.body_string();
+    assert!(body.contains("name=\"note\"\r\n\r\n hello \r\n"), "{body}");
+}
+
+#[test]
 fn proxy_config_environment_and_curl_http1_cases() {
     let proxy = TestServer::start(|req| {
         if req.path.starts_with("http://target.example/via-proxy")


### PR DESCRIPTION
## Summary
- Stop trimming values after the first `=` for `--query`, `--form`, `--multipart`, and config query entries.
- Keep trimming only syntactic names where needed, so user-supplied leading/trailing spaces in values are preserved end to end.
- Add coverage for CLI and config parsing paths to verify the preserved whitespace behavior.

## Testing
- Added focused unit tests for config query parsing, urlencoded form bodies, and multipart text fields.
- Added an integration test covering `--query 'q= hello '`, `--form 'message= hello '`, and `--multipart 'note= hello '`, plus `cargo fmt` and `cargo clippy --locked --all-targets --all-features -- -D warnings` passed.