### PR TITLE
Honor --dns-server during TLS inspection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - Client-streaming and bidi gRPC calls stream JSON input into framed protobuf request bodies instead of materializing the whole stream up front.
 - `--inspect-dns` resolves the URL hostname without making an HTTP request, showing common DNS record types, resolver backend, duration, and per-record TTLs from direct UDP or DoH responses.
 - `--inspect-tls --http 3` performs QUIC/TLS inspection with `h3` ALPN instead of the TCP TLS path.
+- `--inspect-tls` honors `--dns-server` for both TCP and QUIC inspection, resolving domain targets through the configured UDP or DoH resolver before the TLS handshake.
 - Rust `--inspect-tls` renders a verified certificate chain when verification succeeds, appending omitted trusted roots or replacing server-sent cross-signed roots with the matching platform/custom trusted root for expiry display; `--insecure` keeps the raw peer chain.
 - `--tls` remains a compatibility alias for setting the minimum TLS version; prefer `--min-tls` in new docs/examples, and use `--max-tls` to cap negotiation or combine min/max for an exact TLS version.
 - Rust TLS version options accept only TLS 1.2 and TLS 1.3; legacy TLS 1.0/1.1 values are rejected consistently for CLI flags, config, WebSocket, and inspection paths.

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -251,7 +251,10 @@ Expiry is color-coded: red if expired or less than 7 days remaining, yellow if l
 
 HTTP-only flags (e.g. `--data`, `--timing`, `--grpc`) are ignored with a warning when used with `--inspect-tls`.
 
-When combined with `--http 3`, TLS inspection uses a QUIC handshake and offers `h3` ALPN instead of dialing TCP.
+`--dns-server` applies to TLS inspection too, so certificate diagnostics can use
+the same UDP or DNS-over-HTTPS resolver override as normal requests. When
+combined with `--http 3`, TLS inspection uses a QUIC handshake and offers `h3`
+ALPN instead of dialing TCP.
 
 ```sh
 # Check certificate chain
@@ -262,6 +265,9 @@ fetch --inspect-tls --insecure expired.badssl.com
 
 # Inspect the HTTP/3 QUIC/TLS path
 fetch --inspect-tls --http 3 example.com
+
+# Inspect with a custom DNS resolver
+fetch --inspect-tls --dns-server 1.1.1.1 example.com
 ```
 
 ### Configuration File

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -351,7 +351,8 @@ fetch --retry 3 --retry-delay 0.5 example.com
 
 ### `--dns-server IP[:PORT]|URL`
 
-Use custom DNS server. Supports UDP DNS and DNS-over-HTTPS.
+Use custom DNS server. Supports UDP DNS and DNS-over-HTTPS for requests and
+DNS/TLS inspection.
 
 ```sh
 fetch --dns-server 8.8.8.8 example.com
@@ -418,6 +419,7 @@ Inspect the TLS certificate chain by performing a TLS handshake only (no HTTP re
 ```sh
 fetch --inspect-tls example.com
 fetch --inspect-tls --http 3 example.com
+fetch --inspect-tls --dns-server 1.1.1.1 example.com
 fetch --inspect-tls --insecure expired.badssl.com
 ```
 

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -39,7 +39,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
         .map(|seconds| crate::http::duration_from_seconds("timeout", seconds))
         .transpose()?;
     let inspection = if let Some(timeout) = timeout {
-        tokio::time::timeout(timeout, inspect(cli, &url, http_version))
+        tokio::time::timeout(timeout, inspect(cli, &url, http_version, Some(timeout)))
             .await
             .map_err(|_| {
                 FetchError::Message(format!(
@@ -48,7 +48,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                 ))
             })??
     } else {
-        inspect(cli, &url, http_version).await?
+        inspect(cli, &url, http_version, None).await?
     };
 
     if !cli.silent {
@@ -91,11 +91,12 @@ async fn inspect(
     cli: &Cli,
     url: &Url,
     http_version: Option<HttpVersion>,
+    timeout: Option<Duration>,
 ) -> Result<Inspection, FetchError> {
     if http_version == Some(HttpVersion::Http3) {
-        inspect_quic(cli, url).await
+        inspect_quic(cli, url, timeout).await
     } else {
-        inspect_tcp(cli, url, http_version).await
+        inspect_tcp(cli, url, http_version, timeout).await
     }
 }
 
@@ -103,6 +104,7 @@ async fn inspect_tcp(
     cli: &Cli,
     url: &Url,
     http_version: Option<HttpVersion>,
+    timeout: Option<Duration>,
 ) -> Result<Inspection, FetchError> {
     let host = tls_host(url)?;
     let port = url.port_or_known_default().unwrap_or(443);
@@ -119,7 +121,7 @@ async fn inspect_tcp(
 
     let server_name = ServerName::try_from(host.clone())
         .map_err(|_| FetchError::Message(format!("invalid server name '{host}'")))?;
-    let stream = connect_tcp_host(&host, port).await?;
+    let stream = connect_tcp_host(&host, port, cli.dns_server.as_deref(), timeout).await?;
     let connector = TlsConnector::from(Arc::new(config));
     let stream = connector
         .connect(server_name, stream)
@@ -148,8 +150,13 @@ async fn inspect_tcp(
     })
 }
 
-async fn connect_tcp_host(host: &str, port: u16) -> Result<TcpStream, FetchError> {
-    let addrs = tokio::net::lookup_host((host, port)).await?;
+async fn connect_tcp_host(
+    host: &str,
+    port: u16,
+    dns_server: Option<&str>,
+    timeout: Option<Duration>,
+) -> Result<TcpStream, FetchError> {
+    let addrs = resolve_tls_host(host, port, dns_server, timeout).await?;
     let mut last_err = None;
 
     for addr in addrs {
@@ -164,11 +171,62 @@ async fn connect_tcp_host(host: &str, port: u16) -> Result<TcpStream, FetchError
         .unwrap_or_else(|| FetchError::Message("no addresses found".to_string())))
 }
 
-async fn inspect_quic(cli: &Cli, url: &Url) -> Result<Inspection, FetchError> {
+async fn resolve_tls_host(
+    host: &str,
+    port: u16,
+    dns_server: Option<&str>,
+    timeout: Option<Duration>,
+) -> Result<Vec<SocketAddr>, FetchError> {
+    let Some(dns_server) = dns_server else {
+        return tokio::net::lookup_host((host, port))
+            .await
+            .map(|addrs| addrs.collect())
+            .map_err(FetchError::from);
+    };
+    if host.parse::<IpAddr>().is_ok() {
+        return tokio::net::lookup_host((host, port))
+            .await
+            .map(|addrs| addrs.collect())
+            .map_err(FetchError::from);
+    }
+
+    let addrs = if dns_server.starts_with("http://") || dns_server.starts_with("https://") {
+        let server_url = Url::parse(dns_server).map_err(|err| {
+            FetchError::Message(format!("invalid dns-server '{dns_server}': {err}"))
+        })?;
+        crate::dns::doh::lookup_doh(&server_url, host, timeout)
+            .await
+            .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?
+    } else {
+        let server_addr = crate::dns::resolver::normalize_udp_dns_server(dns_server)
+            .map_err(|err| FetchError::Message(err.to_string()))?;
+        crate::dns::resolver::lookup_udp(&server_addr, host, timeout)
+            .await
+            .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?
+    };
+
+    let mut addrs = addrs
+        .into_iter()
+        .map(|addr| SocketAddr::new(addr, port))
+        .collect::<Vec<_>>();
+    addrs.sort_by(|left, right| {
+        left.ip()
+            .cmp(&right.ip())
+            .then(left.port().cmp(&right.port()))
+    });
+    addrs.dedup();
+    Ok(addrs)
+}
+
+async fn inspect_quic(
+    cli: &Cli,
+    url: &Url,
+    timeout: Option<Duration>,
+) -> Result<Inspection, FetchError> {
     let host = tls_host(url)?;
     ensure_quic_protocol_versions(cli)?;
     let port = url.port_or_known_default().unwrap_or(443);
-    let addrs = tokio::net::lookup_host((host.as_str(), port)).await?;
+    let addrs = resolve_tls_host(&host, port, cli.dns_server.as_deref(), timeout).await?;
 
     let ca_certs = load_ca_certs(&cli.ca_cert)?;
     let native_roots = load_native_root_certs();
@@ -1884,7 +1942,7 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
 
         let inspection = tokio::time::timeout(
             Duration::from_secs(5),
-            inspect_tcp(&cli, &url, Some(HttpVersion::Http2)),
+            inspect_tcp(&cli, &url, Some(HttpVersion::Http2), None),
         )
         .await
         .expect("IPv6 TLS inspection timed out")
@@ -1927,7 +1985,9 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
         .unwrap();
         let url = tls_url(&raw_url).unwrap();
 
-        let inspection = inspect(&cli, &url, Some(HttpVersion::Http3)).await.unwrap();
+        let inspection = inspect(&cli, &url, Some(HttpVersion::Http3), None)
+            .await
+            .unwrap();
 
         assert_eq!(inspection.alpn.as_deref(), Some("h3"));
         assert_eq!(inspection.version, Some(ProtocolVersion::TLSv1_3));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5988,6 +5988,20 @@ fn tls_certificate_validation_inspection_and_bounds_cases() {
     assert!(res.stderr.contains("TLS"));
     assert!(res.stderr.contains("Certificate") || res.stderr.contains("certificate"));
 
+    let dns_addr = start_udp_dns_server("fetch-tls.test.", Ipv4Addr::new(127, 0, 0, 1));
+    let tls_url = Url::parse(&tls.url).unwrap();
+    let dns_tls_url = format!("https://fetch-tls.test:{}", tls_url.port().unwrap());
+    let res = run_fetch(&[
+        "--inspect-tls",
+        "--dns-server",
+        &dns_addr,
+        "--insecure",
+        &dns_tls_url,
+    ]);
+    assert_exit(&res, 0);
+    assert!(res.stderr.contains("TLS"));
+    assert!(!res.stderr.contains("--dns-server"));
+
     let res = run_fetch(&["--inspect-tls", "http://example.com"]);
     assert_exit(&res, 1);
     assert!(!res.stderr.is_empty());


### PR DESCRIPTION
## Summary
- Route `--inspect-tls` hostname resolution through the configured UDP or DoH resolver for both TCP and QUIC inspection.
- Preserve direct connect behavior for IP literals while keeping the existing timeout budget aligned with DNS resolution.
- Add regression coverage for TLS inspection with `--dns-server`, and update the CLI docs plus repo notes.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`