### PR TITLE
Centralize MIME policy for response formatting, request bodies, and edit temp files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Rust request uploads use a replayable body descriptor instead of a universal `Ve
 
 ### Content Type Detection
 
-`src/format/content_type.rs` maps MIME types to formatters. Supported types include JSON, XML, YAML, HTML, CSS, CSV, msgpack, protobuf, gRPC, SSE, NDJSON, Markdown, and images.
+`src/format/content_type.rs` centralizes MIME policy, mapping MIME types to response formatter kinds, preferred file extensions, and request-body default Content-Types for `@file` and multipart file parts. Supported formatter types include JSON, XML, YAML, HTML, CSS, CSV, msgpack, protobuf, gRPC, SSE, NDJSON, Markdown, and images.
 
 ## Testing
 

--- a/docs/request-bodies.md
+++ b/docs/request-bodies.md
@@ -41,16 +41,21 @@ cat data.json | fetch -d @- -m POST example.com/api
 ### Content-Type Detection
 
 When using `@filename`, the Content-Type is detected from the file extension.
-Some examples are:
+Multipart file parts use the same policy. Some examples are:
 
-| Extension | Content-Type               |
-| --------- | -------------------------- |
-| `.json`   | `application/json`         |
-| `.xml`    | `application/xml`          |
-| `.html`   | `text/html`                |
-| `.txt`    | `text/plain`               |
-| `.csv`    | `text/csv`                 |
-| Unknown   | `application/octet-stream` |
+| Extension        | Content-Type                |
+| ---------------- | --------------------------- |
+| `.json`          | `application/json`          |
+| `.xml`           | `application/xml`           |
+| `.html`, `.htm`  | `text/html`                 |
+| `.txt`, `.text`  | `text/plain`                |
+| `.csv`           | `text/csv`                  |
+| `.md`            | `text/markdown`             |
+| `.ndjson`        | `application/x-ndjson`      |
+| `.msgpack`       | `application/msgpack`       |
+| `.pb`            | `application/protobuf`      |
+| Image extensions | matching `image/*` type     |
+| Unknown          | `application/octet-stream`  |
 
 Override with a header:
 
@@ -206,6 +211,7 @@ fetch -F config=@~/config.json -m POST example.com/settings
 ## Editor Integration
 
 The `-e` or `--edit` flag opens an editor to compose or modify the request body before sending.
+When the request has a recognized Content-Type, the temporary edit file uses the matching extension from the shared MIME policy.
 
 ### Basic Usage
 

--- a/src/format/content_type.rs
+++ b/src/format/content_type.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+use std::path::Path;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContentType {
     Unknown,
@@ -16,16 +19,800 @@ pub enum ContentType {
     Yaml,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MimePolicy {
+    pub formatter: ContentType,
+    pub extension: Option<&'static str>,
+    pub request_content_type: Option<&'static str>,
+}
+
+impl MimePolicy {
+    const UNKNOWN: Self = Self {
+        formatter: ContentType::Unknown,
+        extension: None,
+        request_content_type: None,
+    };
+
+    const fn new(
+        formatter: ContentType,
+        extension: Option<&'static str>,
+        request_content_type: Option<&'static str>,
+    ) -> Self {
+        Self {
+            formatter,
+            extension,
+            request_content_type,
+        }
+    }
+}
+
+struct MimeRule {
+    typ: &'static str,
+    subtype: &'static str,
+    formatter: ContentType,
+    extension: Option<&'static str>,
+    request_content_type: &'static str,
+    request_extensions: &'static [&'static str],
+}
+
+impl MimeRule {
+    fn policy(&self) -> MimePolicy {
+        MimePolicy::new(
+            self.formatter,
+            self.extension,
+            Some(self.request_content_type),
+        )
+    }
+}
+
+const fn rule(
+    typ: &'static str,
+    subtype: &'static str,
+    formatter: ContentType,
+    extension: Option<&'static str>,
+    request_content_type: &'static str,
+    request_extensions: &'static [&'static str],
+) -> MimeRule {
+    MimeRule {
+        typ,
+        subtype,
+        formatter,
+        extension,
+        request_content_type,
+        request_extensions,
+    }
+}
+
+const MIME_RULES: &[MimeRule] = &[
+    rule(
+        "image",
+        "jpeg",
+        ContentType::Image,
+        Some(".jpg"),
+        "image/jpeg",
+        &["jpg", "jpeg"],
+    ),
+    rule(
+        "image",
+        "png",
+        ContentType::Image,
+        Some(".png"),
+        "image/png",
+        &["png"],
+    ),
+    rule(
+        "image",
+        "gif",
+        ContentType::Image,
+        Some(".gif"),
+        "image/gif",
+        &["gif"],
+    ),
+    rule(
+        "image",
+        "webp",
+        ContentType::Image,
+        Some(".webp"),
+        "image/webp",
+        &["webp"],
+    ),
+    rule(
+        "image",
+        "avif",
+        ContentType::Image,
+        Some(".avif"),
+        "image/avif",
+        &["avif"],
+    ),
+    rule(
+        "image",
+        "heif",
+        ContentType::Image,
+        Some(".heif"),
+        "image/heif",
+        &["heic", "heif"],
+    ),
+    rule(
+        "image",
+        "jxl",
+        ContentType::Image,
+        Some(".jxl"),
+        "image/jxl",
+        &["jxl"],
+    ),
+    rule(
+        "image",
+        "tiff",
+        ContentType::Image,
+        Some(".tiff"),
+        "image/tiff",
+        &["tif", "tiff"],
+    ),
+    rule(
+        "image",
+        "bmp",
+        ContentType::Image,
+        Some(".bmp"),
+        "image/bmp",
+        &["bmp"],
+    ),
+    rule(
+        "image",
+        "x-icon",
+        ContentType::Image,
+        Some(".ico"),
+        "image/x-icon",
+        &["ico"],
+    ),
+    rule(
+        "image",
+        "svg+xml",
+        ContentType::Image,
+        Some(".svg"),
+        "image/svg+xml",
+        &["svg"],
+    ),
+    rule(
+        "image",
+        "vnd.adobe.photoshop",
+        ContentType::Image,
+        Some(".psd"),
+        "image/vnd.adobe.photoshop",
+        &["psd"],
+    ),
+    rule(
+        "image",
+        "x-raw",
+        ContentType::Image,
+        Some(".raw"),
+        "image/x-raw",
+        &["raw", "dng", "nef", "cr2", "arw"],
+    ),
+    rule(
+        "video",
+        "mp4",
+        ContentType::Unknown,
+        Some(".mp4"),
+        "video/mp4",
+        &["mp4"],
+    ),
+    rule(
+        "video",
+        "x-m4v",
+        ContentType::Unknown,
+        Some(".m4v"),
+        "video/x-m4v",
+        &["m4v"],
+    ),
+    rule(
+        "video",
+        "webm",
+        ContentType::Unknown,
+        Some(".webm"),
+        "video/webm",
+        &["webm"],
+    ),
+    rule(
+        "video",
+        "quicktime",
+        ContentType::Unknown,
+        Some(".mov"),
+        "video/quicktime",
+        &["mov"],
+    ),
+    rule(
+        "video",
+        "x-matroska",
+        ContentType::Unknown,
+        Some(".mkv"),
+        "video/x-matroska",
+        &["mkv"],
+    ),
+    rule(
+        "video",
+        "x-msvideo",
+        ContentType::Unknown,
+        Some(".avi"),
+        "video/x-msvideo",
+        &["avi"],
+    ),
+    rule(
+        "video",
+        "x-ms-wmv",
+        ContentType::Unknown,
+        Some(".wmv"),
+        "video/x-ms-wmv",
+        &["wmv"],
+    ),
+    rule(
+        "video",
+        "x-flv",
+        ContentType::Unknown,
+        Some(".flv"),
+        "video/x-flv",
+        &["flv"],
+    ),
+    rule(
+        "video",
+        "mpeg",
+        ContentType::Unknown,
+        Some(".mpeg"),
+        "video/mpeg",
+        &["mpeg", "mpg"],
+    ),
+    rule(
+        "video",
+        "ogg",
+        ContentType::Unknown,
+        Some(".ogv"),
+        "video/ogg",
+        &["ogv"],
+    ),
+    rule(
+        "audio",
+        "mpeg",
+        ContentType::Unknown,
+        Some(".mp3"),
+        "audio/mpeg",
+        &["mp3"],
+    ),
+    rule(
+        "audio",
+        "mp4",
+        ContentType::Unknown,
+        Some(".m4a"),
+        "audio/mp4",
+        &["m4a"],
+    ),
+    rule(
+        "audio",
+        "aac",
+        ContentType::Unknown,
+        Some(".aac"),
+        "audio/aac",
+        &["aac"],
+    ),
+    rule(
+        "audio",
+        "wav",
+        ContentType::Unknown,
+        Some(".wav"),
+        "audio/wav",
+        &["wav"],
+    ),
+    rule(
+        "audio",
+        "flac",
+        ContentType::Unknown,
+        Some(".flac"),
+        "audio/flac",
+        &["flac"],
+    ),
+    rule(
+        "audio",
+        "ogg",
+        ContentType::Unknown,
+        Some(".ogg"),
+        "audio/ogg",
+        &["ogg"],
+    ),
+    rule(
+        "audio",
+        "opus",
+        ContentType::Unknown,
+        Some(".opus"),
+        "audio/opus",
+        &["opus"],
+    ),
+    rule(
+        "audio",
+        "aiff",
+        ContentType::Unknown,
+        Some(".aiff"),
+        "audio/aiff",
+        &["aiff", "aif"],
+    ),
+    rule(
+        "audio",
+        "midi",
+        ContentType::Unknown,
+        Some(".midi"),
+        "audio/midi",
+        &["mid", "midi"],
+    ),
+    rule(
+        "application",
+        "pdf",
+        ContentType::Unknown,
+        Some(".pdf"),
+        "application/pdf",
+        &["pdf"],
+    ),
+    rule(
+        "text",
+        "plain",
+        ContentType::Unknown,
+        Some(".txt"),
+        "text/plain; charset=utf-8",
+        &["txt", "text"],
+    ),
+    rule(
+        "text",
+        "html",
+        ContentType::Html,
+        Some(".html"),
+        "text/html; charset=utf-8",
+        &["html", "htm"],
+    ),
+    rule(
+        "text",
+        "css",
+        ContentType::Css,
+        Some(".css"),
+        "text/css; charset=utf-8",
+        &["css"],
+    ),
+    rule(
+        "text",
+        "csv",
+        ContentType::Csv,
+        Some(".csv"),
+        "text/csv; charset=utf-8",
+        &["csv"],
+    ),
+    rule(
+        "application",
+        "csv",
+        ContentType::Csv,
+        Some(".csv"),
+        "application/csv",
+        &[],
+    ),
+    rule(
+        "application",
+        "json",
+        ContentType::Json,
+        Some(".json"),
+        "application/json",
+        &["json"],
+    ),
+    rule(
+        "application",
+        "x-ndjson",
+        ContentType::Ndjson,
+        Some(".ndjson"),
+        "application/x-ndjson",
+        &["ndjson"],
+    ),
+    rule(
+        "application",
+        "ndjson",
+        ContentType::Ndjson,
+        Some(".ndjson"),
+        "application/ndjson",
+        &[],
+    ),
+    rule(
+        "application",
+        "x-jsonl",
+        ContentType::Ndjson,
+        Some(".jsonl"),
+        "application/x-jsonl",
+        &["jsonl"],
+    ),
+    rule(
+        "application",
+        "jsonl",
+        ContentType::Ndjson,
+        Some(".jsonl"),
+        "application/jsonl",
+        &[],
+    ),
+    rule(
+        "application",
+        "x-jsonlines",
+        ContentType::Ndjson,
+        Some(".jsonl"),
+        "application/x-jsonlines",
+        &[],
+    ),
+    rule(
+        "application",
+        "xml",
+        ContentType::Xml,
+        Some(".xml"),
+        "application/xml",
+        &["xml"],
+    ),
+    rule(
+        "text",
+        "xml",
+        ContentType::Xml,
+        Some(".xml"),
+        "text/xml",
+        &[],
+    ),
+    rule(
+        "application",
+        "yaml",
+        ContentType::Yaml,
+        Some(".yaml"),
+        "application/yaml",
+        &["yaml", "yml"],
+    ),
+    rule(
+        "application",
+        "x-yaml",
+        ContentType::Yaml,
+        Some(".yaml"),
+        "application/x-yaml",
+        &[],
+    ),
+    rule(
+        "text",
+        "yaml",
+        ContentType::Yaml,
+        Some(".yaml"),
+        "text/yaml",
+        &[],
+    ),
+    rule(
+        "text",
+        "x-yaml",
+        ContentType::Yaml,
+        Some(".yaml"),
+        "text/x-yaml",
+        &[],
+    ),
+    rule(
+        "text",
+        "markdown",
+        ContentType::Markdown,
+        Some(".md"),
+        "text/markdown; charset=utf-8",
+        &["md"],
+    ),
+    rule(
+        "text",
+        "x-markdown",
+        ContentType::Markdown,
+        Some(".md"),
+        "text/x-markdown; charset=utf-8",
+        &[],
+    ),
+    rule(
+        "text",
+        "event-stream",
+        ContentType::Sse,
+        Some(".sse"),
+        "text/event-stream",
+        &["sse"],
+    ),
+    rule(
+        "application",
+        "msgpack",
+        ContentType::MsgPack,
+        Some(".msgpack"),
+        "application/msgpack",
+        &["msgpack", "mpack"],
+    ),
+    rule(
+        "application",
+        "x-msgpack",
+        ContentType::MsgPack,
+        Some(".msgpack"),
+        "application/x-msgpack",
+        &[],
+    ),
+    rule(
+        "application",
+        "vnd.msgpack",
+        ContentType::MsgPack,
+        Some(".msgpack"),
+        "application/vnd.msgpack",
+        &[],
+    ),
+    rule(
+        "application",
+        "protobuf",
+        ContentType::Protobuf,
+        Some(".pb"),
+        "application/protobuf",
+        &["pb", "protobuf"],
+    ),
+    rule(
+        "application",
+        "x-protobuf",
+        ContentType::Protobuf,
+        Some(".pb"),
+        "application/x-protobuf",
+        &[],
+    ),
+    rule(
+        "application",
+        "x-google-protobuf",
+        ContentType::Protobuf,
+        Some(".pb"),
+        "application/x-google-protobuf",
+        &[],
+    ),
+    rule(
+        "application",
+        "vnd.google.protobuf",
+        ContentType::Protobuf,
+        Some(".pb"),
+        "application/vnd.google.protobuf",
+        &[],
+    ),
+    rule(
+        "application",
+        "rtf",
+        ContentType::Unknown,
+        Some(".rtf"),
+        "application/rtf",
+        &["rtf"],
+    ),
+    rule(
+        "application",
+        "msword",
+        ContentType::Unknown,
+        Some(".doc"),
+        "application/msword",
+        &["doc"],
+    ),
+    rule(
+        "application",
+        "vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ContentType::Unknown,
+        Some(".docx"),
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        &["docx"],
+    ),
+    rule(
+        "application",
+        "vnd.ms-excel",
+        ContentType::Unknown,
+        Some(".xls"),
+        "application/vnd.ms-excel",
+        &["xls"],
+    ),
+    rule(
+        "application",
+        "vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ContentType::Unknown,
+        Some(".xlsx"),
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        &["xlsx"],
+    ),
+    rule(
+        "application",
+        "vnd.ms-powerpoint",
+        ContentType::Unknown,
+        Some(".ppt"),
+        "application/vnd.ms-powerpoint",
+        &["ppt"],
+    ),
+    rule(
+        "application",
+        "vnd.openxmlformats-officedocument.presentationml.presentation",
+        ContentType::Unknown,
+        Some(".pptx"),
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        &["pptx"],
+    ),
+    rule(
+        "font",
+        "woff",
+        ContentType::Unknown,
+        Some(".woff"),
+        "font/woff",
+        &["woff"],
+    ),
+    rule(
+        "font",
+        "woff2",
+        ContentType::Unknown,
+        Some(".woff2"),
+        "font/woff2",
+        &["woff2"],
+    ),
+    rule(
+        "font",
+        "ttf",
+        ContentType::Unknown,
+        Some(".ttf"),
+        "font/ttf",
+        &["ttf"],
+    ),
+    rule(
+        "font",
+        "otf",
+        ContentType::Unknown,
+        Some(".otf"),
+        "font/otf",
+        &["otf"],
+    ),
+    rule(
+        "application",
+        "vnd.ms-fontobject",
+        ContentType::Unknown,
+        Some(".eot"),
+        "application/vnd.ms-fontobject",
+        &["eot"],
+    ),
+    rule(
+        "application",
+        "zip",
+        ContentType::Unknown,
+        Some(".zip"),
+        "application/zip",
+        &["zip"],
+    ),
+    rule(
+        "application",
+        "x-tar",
+        ContentType::Unknown,
+        Some(".tar"),
+        "application/x-tar",
+        &["tar"],
+    ),
+    rule(
+        "application",
+        "gzip",
+        ContentType::Unknown,
+        Some(".gz"),
+        "application/gzip",
+        &["gz", "tgz"],
+    ),
+    rule(
+        "application",
+        "x-bzip2",
+        ContentType::Unknown,
+        Some(".bz2"),
+        "application/x-bzip2",
+        &["bz2"],
+    ),
+    rule(
+        "application",
+        "x-xz",
+        ContentType::Unknown,
+        Some(".xz"),
+        "application/x-xz",
+        &["xz"],
+    ),
+    rule(
+        "application",
+        "x-7z-compressed",
+        ContentType::Unknown,
+        Some(".7z"),
+        "application/x-7z-compressed",
+        &["7z"],
+    ),
+    rule(
+        "application",
+        "vnd.rar",
+        ContentType::Unknown,
+        Some(".rar"),
+        "application/vnd.rar",
+        &["rar"],
+    ),
+    rule(
+        "application",
+        "vnd.microsoft.portable-executable",
+        ContentType::Unknown,
+        Some(".exe"),
+        "application/vnd.microsoft.portable-executable",
+        &["exe"],
+    ),
+    rule(
+        "application",
+        "x-msi",
+        ContentType::Unknown,
+        Some(".msi"),
+        "application/x-msi",
+        &["msi"],
+    ),
+    rule(
+        "application",
+        "vnd.debian.binary-package",
+        ContentType::Unknown,
+        Some(".deb"),
+        "application/vnd.debian.binary-package",
+        &["deb"],
+    ),
+    rule(
+        "application",
+        "x-rpm",
+        ContentType::Unknown,
+        Some(".rpm"),
+        "application/x-rpm",
+        &["rpm"],
+    ),
+    rule(
+        "application",
+        "javascript",
+        ContentType::Unknown,
+        Some(".js"),
+        "application/javascript",
+        &["js", "mjs"],
+    ),
+    rule(
+        "application",
+        "typescript",
+        ContentType::Unknown,
+        Some(".ts"),
+        "application/typescript",
+        &["ts"],
+    ),
+    rule(
+        "text",
+        "x-go",
+        ContentType::Unknown,
+        Some(".go"),
+        "text/x-go; charset=utf-8",
+        &["go"],
+    ),
+    rule(
+        "text",
+        "x-rust",
+        ContentType::Unknown,
+        Some(".rs"),
+        "text/x-rust; charset=utf-8",
+        &["rs"],
+    ),
+    rule(
+        "text",
+        "x-python",
+        ContentType::Unknown,
+        Some(".py"),
+        "text/x-python; charset=utf-8",
+        &["py"],
+    ),
+    rule(
+        "application",
+        "x-sh",
+        ContentType::Unknown,
+        Some(".sh"),
+        "application/x-sh",
+        &["sh"],
+    ),
+];
+
 pub fn get_content_type(content_type: Option<&str>) -> (ContentType, String) {
+    let (policy, charset) = get_mime_policy(content_type);
+    (policy.formatter, charset)
+}
+
+pub fn get_mime_policy(content_type: Option<&str>) -> (MimePolicy, String) {
     let Some(raw) = content_type else {
-        return (ContentType::Unknown, String::new());
+        return (MimePolicy::UNKNOWN, String::new());
     };
     if raw.is_empty() {
-        return (ContentType::Unknown, String::new());
+        return (MimePolicy::UNKNOWN, String::new());
     }
 
     let Ok(parsed) = raw.parse::<mime::Mime>() else {
-        return (ContentType::Unknown, String::new());
+        return (MimePolicy::UNKNOWN, String::new());
     };
     let charset = parsed
         .get_param(mime::CHARSET)
@@ -33,50 +820,65 @@ pub fn get_content_type(content_type: Option<&str>) -> (ContentType, String) {
         .unwrap_or_default();
 
     let typ = parsed.type_().as_str();
-    let subtype = parsed.subtype().as_str();
+    let subtype = parsed.subtype();
+    let suffix = parsed.suffix();
+    let subtype = if let Some(suffix) = suffix {
+        Cow::Owned(format!("{}+{}", subtype.as_str(), suffix.as_str()))
+    } else {
+        Cow::Borrowed(subtype.as_str())
+    };
+    (policy_for_parts(typ, subtype.as_ref()), charset)
+}
 
-    let detected = match typ {
-        "image" => ContentType::Image,
+pub fn extension_for_content_type(content_type: Option<&str>) -> Option<&'static str> {
+    get_mime_policy(content_type).0.extension
+}
+
+pub fn request_content_type_for_path(path: &Path) -> Option<&'static str> {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .and_then(request_content_type_for_extension)
+}
+
+pub fn request_content_type_for_extension(extension: &str) -> Option<&'static str> {
+    let extension = extension.strip_prefix('.').unwrap_or(extension);
+    MIME_RULES
+        .iter()
+        .find(|rule| {
+            rule.request_extensions
+                .iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(extension))
+        })
+        .map(|rule| rule.request_content_type)
+}
+
+fn policy_for_parts(typ: &str, subtype: &str) -> MimePolicy {
+    if let Some(rule) = MIME_RULES
+        .iter()
+        .find(|rule| rule.typ == typ && rule.subtype == subtype)
+    {
+        return rule.policy();
+    }
+
+    match typ {
+        "image" => MimePolicy::new(ContentType::Image, None, None),
         "application" => {
             if subtype == "grpc" || subtype.starts_with("grpc+") {
-                ContentType::Grpc
+                MimePolicy::new(ContentType::Grpc, None, None)
+            } else if subtype.ends_with("+json") || subtype.ends_with("-json") {
+                MimePolicy::new(ContentType::Json, Some(".json"), None)
+            } else if subtype.ends_with("+proto") {
+                MimePolicy::new(ContentType::Protobuf, Some(".pb"), None)
+            } else if subtype.ends_with("+xml") {
+                MimePolicy::new(ContentType::Xml, Some(".xml"), None)
+            } else if subtype.ends_with("+yaml") {
+                MimePolicy::new(ContentType::Yaml, Some(".yaml"), None)
             } else {
-                match subtype {
-                    "csv" => ContentType::Csv,
-                    "json" => ContentType::Json,
-                    "msgpack" | "x-msgpack" | "vnd.msgpack" => ContentType::MsgPack,
-                    "x-ndjson" | "ndjson" | "x-jsonl" | "jsonl" | "x-jsonlines" => {
-                        ContentType::Ndjson
-                    }
-                    "protobuf" | "x-protobuf" | "x-google-protobuf" | "vnd.google.protobuf" => {
-                        ContentType::Protobuf
-                    }
-                    "xml" => ContentType::Xml,
-                    "yaml" | "x-yaml" => ContentType::Yaml,
-                    _ if subtype.ends_with("+json") || subtype.ends_with("-json") => {
-                        ContentType::Json
-                    }
-                    _ if subtype.ends_with("+proto") => ContentType::Protobuf,
-                    _ if subtype.ends_with("+xml") => ContentType::Xml,
-                    _ if subtype.ends_with("+yaml") => ContentType::Yaml,
-                    _ => ContentType::Unknown,
-                }
+                MimePolicy::UNKNOWN
             }
         }
-        "text" => match subtype {
-            "css" => ContentType::Css,
-            "csv" => ContentType::Csv,
-            "html" => ContentType::Html,
-            "markdown" | "x-markdown" => ContentType::Markdown,
-            "event-stream" => ContentType::Sse,
-            "xml" => ContentType::Xml,
-            "yaml" | "x-yaml" => ContentType::Yaml,
-            _ => ContentType::Unknown,
-        },
-        _ => ContentType::Unknown,
-    };
-
-    (detected, charset)
+        _ => MimePolicy::UNKNOWN,
+    }
 }
 
 const PREFIX_XML_DECL: &[u8] = b"?xml";
@@ -448,5 +1250,43 @@ mod tests {
             assert_eq!(got_type, want_type, "{name}");
             assert_eq!(got_charset, want_charset, "{name}");
         }
+    }
+
+    #[test]
+    fn mime_policy_maps_formatter_extension_and_request_default() {
+        let (policy, charset) = get_mime_policy(Some("application/json; charset=utf-8"));
+        assert_eq!(policy.formatter, ContentType::Json);
+        assert_eq!(policy.extension, Some(".json"));
+        assert_eq!(policy.request_content_type, Some("application/json"));
+        assert_eq!(charset, "utf-8");
+
+        let (policy, charset) = get_mime_policy(Some("application/vnd.api+json; charset=utf-16"));
+        assert_eq!(policy.formatter, ContentType::Json);
+        assert_eq!(policy.extension, Some(".json"));
+        assert_eq!(policy.request_content_type, None);
+        assert_eq!(charset, "utf-16");
+
+        let (policy, charset) = get_mime_policy(Some("image/png"));
+        assert_eq!(policy.formatter, ContentType::Image);
+        assert_eq!(policy.extension, Some(".png"));
+        assert_eq!(policy.request_content_type, Some("image/png"));
+        assert_eq!(charset, "");
+    }
+
+    #[test]
+    fn request_content_type_uses_central_extension_policy() {
+        assert_eq!(
+            request_content_type_for_extension(".JSON"),
+            Some("application/json")
+        );
+        assert_eq!(
+            request_content_type_for_path(Path::new("archive.tgz")),
+            Some("application/gzip")
+        );
+        assert_eq!(
+            request_content_type_for_path(Path::new("notes.text")),
+            Some("text/plain; charset=utf-8")
+        );
+        assert_eq!(request_content_type_for_path(Path::new("payload")), None);
     }
 }

--- a/src/http/edit.rs
+++ b/src/http/edit.rs
@@ -12,6 +12,7 @@ use std::os::unix::fs::OpenOptionsExt;
 use reqwest::header::{CONTENT_TYPE, HeaderMap};
 
 use crate::error::FetchError;
+use crate::format::content_type;
 
 use super::{RequestBody, request_body_into_bytes};
 
@@ -76,14 +77,11 @@ fn edit_bytes_with_editor(
 }
 
 fn extension_for_content_type(headers: &HeaderMap) -> &'static str {
-    match headers
+    headers
         .get(CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
-    {
-        Some("application/json") => ".json",
-        Some("application/xml") | Some("text/xml") => ".xml",
-        _ => "",
-    }
+        .and_then(|value| content_type::extension_for_content_type(Some(value)))
+        .unwrap_or("")
 }
 
 fn find_editor() -> Option<Vec<String>> {
@@ -425,7 +423,7 @@ mod tests {
     }
 
     #[test]
-    fn content_type_extensions_match_go_edit_tempfile_policy() {
+    fn content_type_extensions_use_shared_mime_policy() {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
         assert_eq!(extension_for_content_type(&headers), ".json");
@@ -439,6 +437,21 @@ mod tests {
         headers.insert(
             CONTENT_TYPE,
             HeaderValue::from_static("application/json; charset=utf-8"),
+        );
+        assert_eq!(extension_for_content_type(&headers), ".json");
+
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/html"));
+        assert_eq!(extension_for_content_type(&headers), ".html");
+
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/vnd.api+json"),
+        );
+        assert_eq!(extension_for_content_type(&headers), ".json");
+
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/octet-stream"),
         );
         assert_eq!(extension_for_content_type(&headers), "");
     }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -3237,7 +3237,7 @@ fn expand_home(path: &str) -> String {
 }
 
 fn detect_body_file_content_type(path: &str) -> Result<String, FetchError> {
-    if let Some(content_type) = detect_type_by_extension(path) {
+    if let Some(content_type) = content_type::request_content_type_for_path(Path::new(path)) {
         return Ok(content_type.to_string());
     }
     Ok(sniff_content_type_like_go(&read_file_prefix(path, 512)?))
@@ -3249,86 +3249,6 @@ fn read_file_prefix(path: &str, limit: usize) -> Result<Vec<u8>, FetchError> {
     let len = file.read(&mut out)?;
     out.truncate(len);
     Ok(out)
-}
-
-fn detect_type_by_extension(path: &str) -> Option<&'static str> {
-    let ext = Path::new(path)
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(str::to_ascii_lowercase)?;
-    match ext.as_str() {
-        "jpg" | "jpeg" => Some("image/jpeg"),
-        "png" => Some("image/png"),
-        "gif" => Some("image/gif"),
-        "webp" => Some("image/webp"),
-        "avif" => Some("image/avif"),
-        "heic" | "heif" => Some("image/heif"),
-        "jxl" => Some("image/jxl"),
-        "tif" | "tiff" => Some("image/tiff"),
-        "bmp" => Some("image/bmp"),
-        "ico" => Some("image/x-icon"),
-        "svg" => Some("image/svg+xml"),
-        "psd" => Some("image/vnd.adobe.photoshop"),
-        "raw" | "dng" | "nef" | "cr2" | "arw" => Some("image/x-raw"),
-        "mp4" => Some("video/mp4"),
-        "m4v" => Some("video/x-m4v"),
-        "webm" => Some("video/webm"),
-        "mov" => Some("video/quicktime"),
-        "mkv" => Some("video/x-matroska"),
-        "avi" => Some("video/x-msvideo"),
-        "wmv" => Some("video/x-ms-wmv"),
-        "flv" => Some("video/x-flv"),
-        "mpeg" | "mpg" => Some("video/mpeg"),
-        "ogv" => Some("video/ogg"),
-        "mp3" => Some("audio/mpeg"),
-        "m4a" => Some("audio/mp4"),
-        "aac" => Some("audio/aac"),
-        "wav" => Some("audio/wav"),
-        "flac" => Some("audio/flac"),
-        "ogg" => Some("audio/ogg"),
-        "opus" => Some("audio/opus"),
-        "aiff" | "aif" => Some("audio/aiff"),
-        "mid" | "midi" => Some("audio/midi"),
-        "pdf" => Some("application/pdf"),
-        "txt" => Some("text/plain; charset=utf-8"),
-        "html" | "htm" => Some("text/html; charset=utf-8"),
-        "css" => Some("text/css; charset=utf-8"),
-        "csv" => Some("text/csv; charset=utf-8"),
-        "json" => Some("application/json"),
-        "xml" => Some("application/xml"),
-        "yaml" | "yml" => Some("application/yaml"),
-        "md" => Some("text/markdown; charset=utf-8"),
-        "rtf" => Some("application/rtf"),
-        "doc" => Some("application/msword"),
-        "docx" => Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
-        "xls" => Some("application/vnd.ms-excel"),
-        "xlsx" => Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
-        "ppt" => Some("application/vnd.ms-powerpoint"),
-        "pptx" => Some("application/vnd.openxmlformats-officedocument.presentationml.presentation"),
-        "woff" => Some("font/woff"),
-        "woff2" => Some("font/woff2"),
-        "ttf" => Some("font/ttf"),
-        "otf" => Some("font/otf"),
-        "eot" => Some("application/vnd.ms-fontobject"),
-        "zip" => Some("application/zip"),
-        "tar" => Some("application/x-tar"),
-        "gz" | "tgz" => Some("application/gzip"),
-        "bz2" => Some("application/x-bzip2"),
-        "xz" => Some("application/x-xz"),
-        "7z" => Some("application/x-7z-compressed"),
-        "rar" => Some("application/vnd.rar"),
-        "exe" => Some("application/vnd.microsoft.portable-executable"),
-        "msi" => Some("application/x-msi"),
-        "deb" => Some("application/vnd.debian.binary-package"),
-        "rpm" => Some("application/x-rpm"),
-        "js" | "mjs" => Some("application/javascript"),
-        "ts" => Some("application/typescript"),
-        "go" => Some("text/x-go; charset=utf-8"),
-        "rs" => Some("text/x-rust; charset=utf-8"),
-        "py" => Some("text/x-python; charset=utf-8"),
-        "sh" => Some("application/x-sh"),
-        _ => None,
-    }
 }
 
 fn sniff_content_type_like_go(body: &[u8]) -> String {

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -8,6 +8,8 @@ use futures_util::Stream;
 use thiserror::Error;
 use tokio::io::{AsyncRead, ReadBuf};
 
+use crate::format::content_type;
+
 #[derive(Debug, Error)]
 pub enum MultipartError {
     #[error("file does not exist: '{0}'")]
@@ -196,43 +198,13 @@ fn validate_multipart_disposition_value(
 }
 
 fn detect_content_type(path: &Path) -> Result<&'static str, MultipartError> {
-    if let Some(content_type) = detect_type_by_extension(path) {
+    if let Some(content_type) = content_type::request_content_type_for_path(path) {
         return Ok(content_type);
     }
     let mut file = std::fs::File::open(path)?;
     let mut bytes = [0_u8; 512];
     let len = file.read(&mut bytes)?;
     Ok(sniff_content_type(&bytes[..len]))
-}
-
-fn detect_type_by_extension(path: &Path) -> Option<&'static str> {
-    match path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(str::to_ascii_lowercase)
-        .as_deref()
-    {
-        Some("jpg" | "jpeg") => Some("image/jpeg"),
-        Some("png") => Some("image/png"),
-        Some("gif") => Some("image/gif"),
-        Some("webp") => Some("image/webp"),
-        Some("avif") => Some("image/avif"),
-        Some("heic" | "heif") => Some("image/heif"),
-        Some("jxl") => Some("image/jxl"),
-        Some("tif" | "tiff") => Some("image/tiff"),
-        Some("bmp") => Some("image/bmp"),
-        Some("ico") => Some("image/x-icon"),
-        Some("svg") => Some("image/svg+xml"),
-        Some("pdf") => Some("application/pdf"),
-        Some("json") => Some("application/json"),
-        Some("xml") => Some("application/xml"),
-        Some("yaml" | "yml") => Some("application/yaml"),
-        Some("html" | "htm") => Some("text/html; charset=utf-8"),
-        Some("css") => Some("text/css; charset=utf-8"),
-        Some("csv") => Some("text/csv; charset=utf-8"),
-        Some("txt" | "text") => Some("text/plain; charset=utf-8"),
-        _ => None,
-    }
 }
 
 fn sniff_content_type(bytes: &[u8]) -> &'static str {


### PR DESCRIPTION
## Summary
- Centralize MIME handling in `src/format/content_type.rs` so one policy now covers formatter selection, preferred file extensions, and request-body default `Content-Type` values.
- Reuse that helper from request file upload detection, multipart file parts, and `--edit` temp-file extension selection.
- Update docs and repo guidance to reflect the shared MIME policy.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`