### PR TITLE
Use the Rust release version in build info

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,8 @@ fn main() {
 
     set_env(
         "FETCH_RUSTC_VERSION",
-        command_output("rustc", &["--version"]),
+        command_output("rustc", &["--version"])
+            .and_then(|version| rustc_release_version(&version).map(str::to_string)),
     );
     set_env("FETCH_VERSION", Some(build_version()));
     if let Ok(profile) = env::var("PROFILE") {
@@ -73,4 +74,12 @@ fn command_output(program: &str, args: &[&str]) -> Option<String> {
         return None;
     }
     Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn rustc_release_version(version: &str) -> Option<&str> {
+    version
+        .strip_prefix("rustc ")?
+        .split_whitespace()
+        .next()
+        .filter(|version| !version.is_empty())
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1368,7 +1368,9 @@ mod tests {
         let value: Value = serde_json::from_slice(&build_info_json(false)).unwrap();
 
         assert_eq!(value["fetch"], core::version());
-        assert!(value["rust"].as_str().unwrap_or_default().contains("rustc"));
+        let rust = value["rust"].as_str().unwrap_or_default();
+        assert!(!rust.contains("rustc"));
+        assert!(!rust.contains(char::is_whitespace));
         assert_eq!(
             value["settings"]["target_os"].as_str().unwrap_or_default(),
             std::env::consts::OS


### PR DESCRIPTION
## Summary
- Store the compiler version as the plain Rust release number in `FETCH_RUSTC_VERSION`
- Keep `--buildinfo` output compact by showing values like `1.95.0` instead of the full `rustc ...` banner
- Update the build-info test to assert the `rust` field is whitespace-free and no longer includes `rustc`

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Focused unit test for build-info JSON passed