### PR TITLE
Add separator-aware warning rendering before follow-on output

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -358,6 +358,10 @@ pub fn write_warning_msg_no_flush(printer: &mut Printer, msg: impl fmt::Display)
     printer.push_str("\n");
 }
 
+pub fn write_warning_separator_no_flush(printer: &mut Printer) {
+    printer.push('\n');
+}
+
 impl std::io::Write for Printer {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.buf.extend_from_slice(buf);
@@ -574,6 +578,20 @@ mod tests {
         assert_eq!(
             printer.into_string().unwrap(),
             "error: bad\nwarning: careful\n"
+        );
+    }
+
+    #[test]
+    fn warning_separator_separates_warnings_from_following_output() {
+        let mut printer = Printer::new(false);
+        write_warning_msg_no_flush(&mut printer, "one");
+        write_warning_msg_no_flush(&mut printer, "two");
+        write_warning_separator_no_flush(&mut printer);
+        printer.push_str("next\n");
+
+        assert_eq!(
+            printer.into_string().unwrap(),
+            "warning: one\nwarning: two\n\nnext\n"
         );
     }
 }

--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -10,7 +10,7 @@ use crate::core::{self, Printer, Sequence};
 use crate::dns::util::{dns_query_id, udp_dns_timeout};
 use crate::dns::wire;
 use crate::duration::{TimeoutBudget, duration_from_seconds};
-use crate::error::{FetchError, write_error_with_color, write_warning_with_color};
+use crate::error::{FetchError, write_error_with_color, write_warning_with_separator_with_color};
 
 const DNS_TYPE_A: u16 = wire::TYPE_A;
 const DNS_TYPE_NS: u16 = wire::TYPE_NS;
@@ -135,7 +135,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let url = crate::http::normalize_url(cli.url.as_deref().expect("URL checked by app"))?;
     let ignored = ignored_inspection_flags(cli);
     if !ignored.is_empty() {
-        write_warning_with_color(
+        write_warning_with_separator_with_color(
             format!("--inspect-dns ignores: {}", ignored.join(", ")),
             cli.color.as_deref(),
         );

--- a/src/error.rs
+++ b/src/error.rs
@@ -377,6 +377,30 @@ pub fn write_warning_with_color(msg: impl std::fmt::Display, color: Option<&str>
     flush_stderr(printer);
 }
 
+pub fn write_warning_with_separator_with_color(msg: impl std::fmt::Display, color: Option<&str>) {
+    let mut printer = Printer::stderr(color);
+    core::write_warning_msg_no_flush(&mut printer, msg);
+    core::write_warning_separator_no_flush(&mut printer);
+    flush_stderr(printer);
+}
+
+pub fn write_warnings_with_separator_with_color<I, M>(warnings: I, color: Option<&str>)
+where
+    I: IntoIterator<Item = M>,
+    M: std::fmt::Display,
+{
+    let mut printer = Printer::stderr(color);
+    let mut wrote_warning = false;
+    for warning in warnings {
+        core::write_warning_msg_no_flush(&mut printer, warning);
+        wrote_warning = true;
+    }
+    if wrote_warning {
+        core::write_warning_separator_no_flush(&mut printer);
+        flush_stderr(printer);
+    }
+}
+
 fn flush_stderr(mut printer: Printer) {
     let mut stderr = std::io::stderr();
     let _ = printer.flush_to(&mut stderr);

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -35,7 +35,10 @@ use crate::auth::digest;
 use crate::cli::{Cli, CompressionMode, HttpVersion};
 use crate::core;
 use crate::duration::{TimeoutBudget, duration_from_seconds, request_timeout_message};
-use crate::error::{FetchError, write_error_with_color, write_warning_with_color};
+use crate::error::{
+    FetchError, write_error_with_color, write_warning_with_color,
+    write_warning_with_separator_with_color,
+};
 use crate::format::content_type::{self, ContentType};
 use crate::format::css;
 use crate::format::csv;
@@ -447,7 +450,7 @@ pub(crate) fn load_session(cli: &Cli) -> Result<Option<crate::session::Session>,
     let loaded =
         crate::session::Session::load(name).map_err(|err| FetchError::Message(err.to_string()))?;
     if let Some(warning) = loaded.warning {
-        write_warning(
+        write_warning_before_output(
             cli,
             &format!("session '{name}' is corrupted, starting fresh: {warning}"),
         );
@@ -470,6 +473,12 @@ fn save_session(cli: &Cli, session: Option<&crate::session::Session>) {
 fn write_warning(cli: &Cli, message: &str) {
     if !cli.silent {
         write_warning_with_color(message, cli.color.as_deref());
+    }
+}
+
+fn write_warning_before_output(cli: &Cli, message: &str) {
+    if !cli.silent {
+        write_warning_with_separator_with_color(message, cli.color.as_deref());
     }
 }
 

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -17,13 +17,13 @@ use url::Url;
 use crate::cli::{Cli, HttpVersion};
 use crate::core::{self, Printer, Sequence};
 use crate::duration::{TimeoutBudget, duration_from_seconds};
-use crate::error::{FetchError, write_warning_with_color};
+use crate::error::{FetchError, write_warning_with_separator_with_color};
 
 pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let url = tls_url(cli.url.as_deref().expect("URL checked by app"))?;
     let ignored = ignored_inspection_flags(cli);
     if !ignored.is_empty() && !cli.silent {
-        write_warning_with_color(
+        write_warning_with_separator_with_color(
             format!("--inspect-tls ignores: {}", ignored.join(", ")),
             cli.color.as_deref(),
         );

--- a/src/update.rs
+++ b/src/update.rs
@@ -13,7 +13,7 @@ use time::format_description::well_known::Rfc3339;
 
 use crate::cli::Cli;
 use crate::core;
-use crate::error::{FetchError, write_warning_with_color};
+use crate::error::{FetchError, write_warning_with_separator_with_color};
 use crate::output::progress::{self, BarCounter, ProgressPrinter, SpinnerCounter};
 
 #[cfg(any(windows, test))]
@@ -996,7 +996,7 @@ fn acquire_update_lock(
         }
 
         if attempt == 0 && !silent {
-            write_warning_with_color("waiting on lock to begin updating", color);
+            write_warning_with_separator_with_color("waiting on lock to begin updating", color);
         }
         let multiplier = (attempt + 1).min(10) as u64;
         thread::sleep(Duration::from_millis(multiplier * 50));

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -22,7 +22,7 @@ use crate::auth::aws_sigv4;
 use crate::cli::Cli;
 use crate::core;
 use crate::duration::{TimeoutBudget, duration_from_seconds};
-use crate::error::{FetchError, write_warning_with_color};
+use crate::error::{FetchError, write_warnings_with_separator_with_color};
 use crate::format::json;
 
 pub mod interactive;
@@ -37,15 +37,17 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     crate::http::apply_query(&mut url, &cli.query);
 
     let method = effective_method(cli);
+    let mut warnings = Vec::new();
     if !cli.method().eq_ignore_ascii_case("GET") {
-        write_warning(
-            cli,
-            &format!("WebSocket requires GET; ignoring method {}", cli.method()),
-        );
+        warnings.push(format!(
+            "WebSocket requires GET; ignoring method {}",
+            cli.method()
+        ));
     }
     if cli.timing {
-        write_warning(cli, "--timing is not supported for WebSocket connections");
+        warnings.push("--timing is not supported for WebSocket connections".to_string());
     }
+    write_warnings(cli, &warnings);
     let interactive = should_use_interactive(cli)?;
 
     let initial_message = websocket_initial_message(cli)?;
@@ -647,11 +649,14 @@ fn websocket_io_error(err: FetchError) -> WsError {
     WsError::Io(io::Error::other(err.to_string()))
 }
 
-fn write_warning(cli: &Cli, message: &str) {
-    if cli.silent {
+fn write_warnings(cli: &Cli, warnings: &[String]) {
+    if cli.silent || warnings.is_empty() {
         return;
     }
-    write_warning_with_color(message, cli.color.as_deref());
+    write_warnings_with_separator_with_color(
+        warnings.iter().map(String::as_str),
+        cli.color.as_deref(),
+    );
 }
 
 fn should_use_interactive(cli: &Cli) -> Result<bool, FetchError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6422,9 +6422,16 @@ fn websocket_noninteractive_go_cases() {
     assert_exit(&res, 1);
     assert!(res.stderr.contains("websocket") || res.stderr.contains("grpc"));
 
-    let res = run_fetch(&[&ws_url, "--method", "POST", "--dry-run"]);
+    let res = run_fetch(&[&ws_url, "--method", "POST", "--timing", "--dry-run"]);
     assert_exit(&res, 0);
     assert!(res.stderr.contains("GET / HTTP/1.1"));
+    assert!(
+        res.stderr.contains(
+            "warning: WebSocket requires GET; ignoring method POST\nwarning: --timing is not supported for WebSocket connections\n\n> GET / HTTP/1.1"
+        ),
+        "{:?}",
+        res.stderr
+    );
 
     let res = run_fetch(&[
         &ws_url,


### PR DESCRIPTION
## Summary
- Added a shared warning separator helper so warnings can stay single-line terminated by default.
- Switched warning paths that are immediately followed by more output to use an explicit blank-line separator, including session, TLS/DNS inspection, update lock, and WebSocket warnings.
- Kept end-of-response warning output unchanged, so DNS inspection no longer adds an extra trailing blank line.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`