### PR TITLE
Guard MessagePack and protobuf formatters against deep nesting

### DIFF
--- a/src/format/msgpack.rs
+++ b/src/format/msgpack.rs
@@ -6,6 +6,8 @@ use base64::Engine;
 use crate::core::Printer;
 use crate::format::json;
 
+const MAX_MSGPACK_NESTING_DEPTH: usize = 128;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MsgPackError(String);
 
@@ -39,7 +41,7 @@ pub fn format_msgpack_to(buf: &[u8], out: &mut Printer) -> Result<(), MsgPackErr
 fn msgpack_to_json(buf: &[u8]) -> Result<String, MsgPackError> {
     let mut parser = MsgPackParser::new(buf);
     let mut out = String::new();
-    parser.write_value(&mut out)?;
+    parser.write_value(&mut out, 0)?;
     if !parser.is_eof() {
         return Err(MsgPackError::new("unexpected trailing MessagePack data"));
     }
@@ -60,12 +62,18 @@ impl<'a> MsgPackParser<'a> {
         self.pos == self.input.len()
     }
 
-    fn write_value(&mut self, out: &mut String) -> Result<(), MsgPackError> {
+    fn write_value(&mut self, out: &mut String, depth: usize) -> Result<(), MsgPackError> {
+        if depth > MAX_MSGPACK_NESTING_DEPTH {
+            return Err(MsgPackError::new(format!(
+                "MessagePack nesting too deep (max {MAX_MSGPACK_NESTING_DEPTH})"
+            )));
+        }
+
         let marker = self.read_u8()?;
         match marker {
             0x00..=0x7f => write!(out, "{marker}").expect("write to string cannot fail"),
-            0x80..=0x8f => self.write_map(out, u32::from(marker & 0x0f))?,
-            0x90..=0x9f => self.write_array(out, u32::from(marker & 0x0f))?,
+            0x80..=0x8f => self.write_map(out, u32::from(marker & 0x0f), depth)?,
+            0x90..=0x9f => self.write_array(out, u32::from(marker & 0x0f), depth)?,
             0xa0..=0xbf => self.write_string(out, usize::from(marker & 0x1f))?,
             0xc0 => out.push_str("null"),
             0xc1 => return Err(MsgPackError::new("reserved MessagePack marker 0xc1")),
@@ -134,19 +142,19 @@ impl<'a> MsgPackParser<'a> {
             }
             0xdc => {
                 let len = u32::from(self.read_u16()?);
-                self.write_array(out, len)?;
+                self.write_array(out, len, depth)?;
             }
             0xdd => {
                 let len = self.read_u32()?;
-                self.write_array(out, len)?;
+                self.write_array(out, len, depth)?;
             }
             0xde => {
                 let len = u32::from(self.read_u16()?);
-                self.write_map(out, len)?;
+                self.write_map(out, len, depth)?;
             }
             0xdf => {
                 let len = self.read_u32()?;
-                self.write_map(out, len)?;
+                self.write_map(out, len, depth)?;
             }
             0xe0..=0xff => {
                 write!(out, "{}", marker as i8).expect("write to string cannot fail");
@@ -155,19 +163,24 @@ impl<'a> MsgPackParser<'a> {
         Ok(())
     }
 
-    fn write_array(&mut self, out: &mut String, len: u32) -> Result<(), MsgPackError> {
+    fn write_array(
+        &mut self,
+        out: &mut String,
+        len: u32,
+        depth: usize,
+    ) -> Result<(), MsgPackError> {
         out.push('[');
         for index in 0..len {
             if index > 0 {
                 out.push(',');
             }
-            self.write_value(out)?;
+            self.write_value(out, depth + 1)?;
         }
         out.push(']');
         Ok(())
     }
 
-    fn write_map(&mut self, out: &mut String, len: u32) -> Result<(), MsgPackError> {
+    fn write_map(&mut self, out: &mut String, len: u32, depth: usize) -> Result<(), MsgPackError> {
         out.push('{');
         for index in 0..len {
             if index > 0 {
@@ -175,7 +188,7 @@ impl<'a> MsgPackParser<'a> {
             }
             self.write_map_key(out)?;
             out.push(':');
-            self.write_value(out)?;
+            self.write_value(out, depth + 1)?;
         }
         out.push('}');
         Ok(())
@@ -414,6 +427,36 @@ mod tests {
         assert!(format_msgpack(&[0xa2, b'a'], false).is_err());
         assert!(format_msgpack(&[0xc1], false).is_err());
         assert!(format_msgpack(&[0x01, 0x02], false).is_err());
+    }
+
+    #[test]
+    fn deeply_nested_msgpack_arrays_are_rejected() {
+        let mut input = vec![0x00];
+        for _ in 0..=MAX_MSGPACK_NESTING_DEPTH {
+            input.insert(0, 0x91);
+        }
+
+        let err = format_msgpack(&input, false).unwrap_err();
+        assert!(
+            err.to_string().contains("MessagePack nesting too deep"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn deeply_nested_msgpack_maps_are_rejected() {
+        let mut input = vec![0x00];
+        for _ in 0..=MAX_MSGPACK_NESTING_DEPTH {
+            let mut wrapper = vec![0x81, 0xa1, b'x'];
+            wrapper.extend_from_slice(&input);
+            input = wrapper;
+        }
+
+        let err = format_msgpack(&input, false).unwrap_err();
+        assert!(
+            err.to_string().contains("MessagePack nesting too deep"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/src/format/protobuf.rs
+++ b/src/format/protobuf.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::fmt::Write as _;
 
+const MAX_PROTOBUF_NESTING_DEPTH: usize = 128;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProtobufError(String);
 
@@ -14,11 +16,16 @@ impl std::error::Error for ProtobufError {}
 
 pub fn format_protobuf(buf: &[u8]) -> Result<String, ProtobufError> {
     let mut out = String::new();
-    format_message(buf, &mut out, 0)?;
+    format_message(buf, &mut out, 0, 0)?;
     Ok(out)
 }
 
-fn format_message(mut buf: &[u8], out: &mut String, indent: usize) -> Result<(), ProtobufError> {
+fn format_message(
+    mut buf: &[u8],
+    out: &mut String,
+    indent: usize,
+    depth: usize,
+) -> Result<(), ProtobufError> {
     while !buf.is_empty() {
         let (key, n) = consume_varint(buf)?;
         buf = &buf[n..];
@@ -66,9 +73,9 @@ fn format_message(mut buf: &[u8], out: &mut String, indent: usize) -> Result<(),
                 let value = &buf[..len];
                 buf = &buf[len..];
 
-                if is_valid_protobuf(value) {
+                if depth < MAX_PROTOBUF_NESTING_DEPTH && is_valid_protobuf(value) {
                     out.push_str(" (message) {\n");
-                    format_message(value, out, indent + 1)?;
+                    format_message(value, out, indent + 1, depth + 1)?;
                     write_indent(out, indent);
                     out.push_str("}\n");
                 } else if is_printable_bytes(value) {
@@ -305,6 +312,22 @@ mod tests {
         assert!(output.contains("789"));
         assert_eq!(output.matches('{').count(), 2);
         assert_eq!(output.matches('}').count(), 2);
+    }
+
+    #[test]
+    fn deeply_nested_protobuf_messages_render_remaining_value_as_bytes() {
+        let mut input = append_varint(Vec::new(), 1, 7);
+        for _ in 0..=MAX_PROTOBUF_NESTING_DEPTH {
+            input = append_bytes(Vec::new(), 1, &input);
+        }
+
+        let output = format_protobuf(&input).unwrap();
+        assert_eq!(
+            output.matches("(message)").count(),
+            MAX_PROTOBUF_NESTING_DEPTH
+        );
+        assert!(output.contains("(bytes)"), "{output}");
+        assert!(!output.contains("(varint) 7"), "{output}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Added a 128-level nesting cap to MessagePack array/map formatting and return a clear formatter error when exceeded.
- Added a matching depth guard to protobuf embedded-message detection so deeply nested length-delimited fields stop recursing and render as bytes instead.
- Added focused regression tests for nested MessagePack arrays/maps and protobuf message nesting beyond the limit.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`