### PR TITLE
Preserve query parameter order when appending --query values

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io::{Cursor, ErrorKind, Read, Write};
@@ -3001,28 +3000,11 @@ pub(crate) fn apply_query(url: &mut Url, query: &[String]) {
         return;
     }
 
-    let mut values = BTreeMap::<String, Vec<String>>::new();
-    for (key, val) in url.query_pairs() {
-        values
-            .entry(key.into_owned())
-            .or_default()
-            .push(val.into_owned());
-    }
+    let mut pairs = url.query_pairs_mut();
     for raw in query {
         let (key, val) = raw.split_once('=').unwrap_or((raw, ""));
-        values
-            .entry(key.trim().to_string())
-            .or_default()
-            .push(val.to_string());
+        pairs.append_pair(key.trim(), val);
     }
-
-    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
-    for (key, vals) in values {
-        for val in vals {
-            serializer.append_pair(&key, &val);
-        }
-    }
-    url.set_query(Some(&serializer.finish()));
 }
 
 pub(crate) fn apply_headers(headers: &mut HeaderMap, values: &[String]) -> Result<(), FetchError> {
@@ -3579,7 +3561,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_query_sorts_and_encodes_like_go_url_values() {
+    fn apply_query_appends_and_encodes_in_order() {
         let mut url = Url::parse("https://example.com/path?z=old&space=hello+world").unwrap();
         apply_query(
             &mut url,
@@ -3594,7 +3576,7 @@ mod tests {
 
         assert_eq!(
             url.as_str(),
-            "https://example.com/path?a=one&blank=&space=hello+world&space=second+value&spaced=+hello+&z=old&z=two"
+            "https://example.com/path?z=old&space=hello+world&a=one&z=two&blank=&space=second+value&spaced=+hello+"
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4582,7 +4582,7 @@ fn request_construction_host_header_form_and_http_version() {
     assert_exit(&res, 0);
     let req = wait_for_requests(&server, 1).remove(0);
     assert_eq!(req.method, "PUT");
-    assert_eq!(req.path, "/?a=one&z=old&z=two");
+    assert_eq!(req.path, "/?z=old&a=one&z=two");
     assert_eq!(req.header("content-type"), "application/json");
     assert_eq!(req.header("x-custom"), "value");
     assert_eq!(req.body_string(), r#"{"ok":true}"#);
@@ -4798,7 +4798,7 @@ fn http3_go_harness_cases() {
     let req = wait_for_h3_requests(&h3, 1).remove(0);
     assert_eq!(req.method, "PUT");
     assert_eq!(req.path, "/h3");
-    assert_eq!(req.query, "cli=1&existing=1");
+    assert_eq!(req.query, "existing=1&cli=1");
     assert_eq!(req.header("x-h3"), "yes");
     assert_eq!(req.body_string(), "payload");
 


### PR DESCRIPTION
## Summary
- Switch `--query` handling to append pairs in URL and CLI/config order instead of rebuilding through a sorted map.
- Preserve existing query ordering, including duplicate keys and prior parameters.
- Update unit and integration expectations to match append semantics.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`