### PR TITLE
Fix retry replayability checks to use the original request body

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -225,6 +225,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let retry_count = cli.retry();
     let retry_delay = duration_from_seconds("retry-delay", cli.retry_delay())?;
     let total_attempts = total_attempts_for_retry(retry_count)?;
+    let original_body_replayable = request_body_replayable(&body);
     let mut attempt = 0;
     let result = loop {
         let mut request_method = method.clone();
@@ -361,14 +362,17 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                 let retry_sse_uncompressed =
                     should_retry_sse_without_compression(&response, compression);
                 if retry_sse_uncompressed {
-                    ensure_request_body_replayable(&request_body, "retry SSE without compression")?;
+                    ensure_body_replayable(
+                        original_body_replayable,
+                        "retry SSE without compression",
+                    )?;
                     headers.remove(ACCEPT_ENCODING);
                     compression = CompressionMode::Off;
                     drain_response_body_bounded(response).await;
                     continue;
                 }
                 if attempt < retry_count && should_retry_status(status) {
-                    ensure_request_body_replayable(&request_body, "retry")?;
+                    ensure_body_replayable(original_body_replayable, "retry")?;
                     let requested_delay =
                         compute_delay(retry_delay, attempt, parse_retry_after(response.headers()));
                     drain_response_body_bounded(response).await;
@@ -409,7 +413,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                     break Err(FetchError::Runtime(message));
                 }
                 if attempt < retry_count && is_retryable_error(&err) {
-                    ensure_request_body_replayable(&request_body, "retry")?;
+                    ensure_body_replayable(original_body_replayable, "retry")?;
                     let requested_delay = compute_delay(retry_delay, attempt, Duration::ZERO);
                     let delay = retry_delay_within_timeout(
                         requested_delay,
@@ -2688,7 +2692,11 @@ fn request_body_source_uses_stdin(source: &RequestBodySource) -> bool {
 }
 
 fn ensure_request_body_replayable(body: &RequestBody, action: &str) -> Result<(), FetchError> {
-    if request_body_replayable(body) {
+    ensure_body_replayable(request_body_replayable(body), action)
+}
+
+fn ensure_body_replayable(replayable: bool, action: &str) -> Result<(), FetchError> {
+    if replayable {
         return Ok(());
     }
     Err(FetchError::Runtime(format!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3806,6 +3806,57 @@ fn retry_status_rejects_stdin_body_replay() {
 }
 
 #[test]
+fn retry_after_bodyless_redirect_rejects_original_stdin_body_replay() {
+    let server = TestServer::start(|req| match req.path.as_str() {
+        "/start" => TestResponse::status(303, "See Other", "")
+            .header("Location", "/final")
+            .header("Connection", "keep-alive"),
+        "/final" => TestResponse::status(503, "Service Unavailable", "retry")
+            .header("Connection", "keep-alive"),
+        _ => TestResponse::status(404, "Not Found", "missing"),
+    });
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            stdin: Some("payload".to_string()),
+            ..Default::default()
+        },
+        &[
+            &format!("{}/start", server.url),
+            "-m",
+            "POST",
+            "--retry",
+            "1",
+            "--retry-delay",
+            FAST_RETRY_DELAY,
+            "--data",
+            "@-",
+        ],
+    );
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr
+            .contains("request body from stdin cannot be replayed for retry"),
+        "stderr:\n{}",
+        res.stderr
+    );
+
+    let requests = server.requests();
+    assert_eq!(requests.len(), 2, "requests: {requests:?}");
+    assert_eq!(requests[0].path, "/start");
+    assert_eq!(requests[0].method, "POST");
+    assert_eq!(requests[0].body_string(), "payload");
+    assert_eq!(requests[1].path, "/final");
+    assert_eq!(requests[1].method, "GET");
+    assert!(requests[1].body.is_empty());
+    assert_eq!(
+        requests.iter().filter(|req| req.path == "/start").count(),
+        1,
+        "unexpected second initial request: {requests:?}"
+    );
+}
+
+#[test]
 #[cfg_attr(
     windows,
     ignore = "Windows can report a socket abort when the bounded retry drain abandons a large body"


### PR DESCRIPTION
## Summary
- Capture the original request body replayability before redirects mutate the active request body.
- Use that original replayability for outer retry and SSE retry decisions.
- Keep per-attempt body checks for redirect-specific replay paths.
- Add an integration test covering `POST --data @-` through `303` to `503` and asserting the initial request is not replayed.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features --lib`
- `cargo test --all-features --test integration -- --test-threads=1`