### PR TITLE
Apply connect timeout budgets to DNS and TLS inspection

### DIFF
--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -132,6 +132,7 @@ enum ResolverTarget {
 }
 
 pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
+    let request_start = Instant::now();
     let url = crate::http::normalize_url(cli.url.as_deref().expect("URL checked by app"))?;
     let ignored = ignored_inspection_flags(cli);
     if !ignored.is_empty() {
@@ -141,17 +142,15 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
         );
     }
 
-    let timeout = cli
-        .timeout
-        .map(|seconds| duration_from_seconds("timeout", seconds))
-        .transpose()?;
+    let request_timeout = inspection_request_timeout(cli)?;
+    let connect_timeout = inspection_connect_timeout(cli, request_timeout, request_start)?;
     let mut printer = core::stdio().stderr_printer(cli.color.as_deref());
-    let inspected = TimeoutBudget::new(timeout)
+    let inspected = connect_timeout
         .run(inspect_to(
             &url,
             cli.dns_server.as_deref(),
             &mut printer,
-            timeout,
+            connect_timeout,
         ))
         .await;
 
@@ -167,6 +166,24 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     }
 }
 
+fn inspection_request_timeout(cli: &Cli) -> Result<Option<Duration>, FetchError> {
+    cli.timeout
+        .map(|seconds| duration_from_seconds("timeout", seconds))
+        .transpose()
+}
+
+fn inspection_connect_timeout(
+    cli: &Cli,
+    request_timeout: Option<Duration>,
+    request_start: Instant,
+) -> Result<TimeoutBudget, FetchError> {
+    let connect_timeout = cli
+        .connect_timeout
+        .map(|seconds| duration_from_seconds("connect-timeout", seconds))
+        .transpose()?;
+    TimeoutBudget::for_connect(connect_timeout, request_timeout, request_start)
+}
+
 #[cfg(test)]
 async fn inspect(url: &Url, dns_server: Option<&str>) -> Result<String, FetchError> {
     let (out, _) = inspect_with_code(url, dns_server).await?;
@@ -179,7 +196,7 @@ async fn inspect_with_code(
     dns_server: Option<&str>,
 ) -> Result<(String, i32), FetchError> {
     let mut out = Printer::new(false);
-    let code = inspect_to(url, dns_server, &mut out, None).await?;
+    let code = inspect_to(url, dns_server, &mut out, TimeoutBudget::new(None)).await?;
     Ok((
         out.into_string().expect("DNS inspection output is UTF-8"),
         code,
@@ -190,7 +207,7 @@ async fn inspect_to(
     url: &Url,
     dns_server: Option<&str>,
     out: &mut Printer,
-    timeout: Option<Duration>,
+    timeout: TimeoutBudget,
 ) -> Result<i32, FetchError> {
     let host = url
         .host_str()
@@ -213,7 +230,7 @@ async fn lookup(
     host: &str,
     target: ResolverTarget,
     start: Instant,
-    timeout: Option<Duration>,
+    timeout: TimeoutBudget,
 ) -> Result<Inspection, FetchError> {
     let mut out = Inspection {
         host: host.to_string(),
@@ -225,7 +242,7 @@ async fn lookup(
     };
 
     if matches!(target, ResolverTarget::Default { .. }) {
-        let records = lookup_default_resolver_records(host).await?;
+        let records = timeout.run(lookup_default_resolver_records(host)).await?;
         out.duration = start.elapsed();
         for record in records {
             out.records
@@ -239,10 +256,12 @@ async fn lookup(
         return Ok(out);
     }
 
-    let udp_timeout = udp_dns_timeout(timeout);
+    let remaining_timeout = timeout.remaining()?;
+    let udp_timeout = udp_dns_timeout(remaining_timeout);
     let doh_client = match &target {
         ResolverTarget::Doh { .. } => Some(
-            crate::dns::doh::client(timeout).map_err(|err| FetchError::Message(err.to_string()))?,
+            crate::dns::doh::client(remaining_timeout)
+                .map_err(|err| FetchError::Message(err.to_string()))?,
         ),
         _ => None,
     };
@@ -267,7 +286,9 @@ async fn lookup(
             (query_type, result)
         }
     });
-    let results = join_all(futures).await;
+    let results = timeout
+        .run(async { Ok::<_, FetchError>(join_all(futures).await) })
+        .await?;
 
     let mut first_err = None;
     let mut truncated_types = Vec::new();
@@ -1218,7 +1239,7 @@ mod tests {
                 url: server_url,
             },
             Instant::now(),
-            None,
+            TimeoutBudget::new(None),
         )
         .await
         .unwrap();
@@ -1258,7 +1279,7 @@ mod tests {
                 url: server_url,
             },
             Instant::now(),
-            None,
+            TimeoutBudget::new(None),
         )
         .await
         .unwrap();

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use quinn::crypto::rustls::{HandshakeData, QuicClientConfig};
 use rustls::client::WebPkiServerVerifier;
@@ -20,6 +20,7 @@ use crate::duration::{TimeoutBudget, duration_from_seconds};
 use crate::error::{FetchError, write_warning_with_separator_with_color};
 
 pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
+    let request_start = Instant::now();
     let url = tls_url(cli.url.as_deref().expect("URL checked by app"))?;
     let ignored = ignored_inspection_flags(cli);
     if !ignored.is_empty() && !cli.silent {
@@ -32,12 +33,10 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let http_version =
         crate::cli::parse_http_version(cli.http.as_deref()).map_err(FetchError::Message)?;
 
-    let timeout = cli
-        .timeout
-        .map(|seconds| duration_from_seconds("timeout", seconds))
-        .transpose()?;
-    let inspection = TimeoutBudget::new(timeout)
-        .run(inspect(cli, &url, http_version, timeout))
+    let request_timeout = inspection_request_timeout(cli)?;
+    let connect_timeout = inspection_connect_timeout(cli, request_timeout, request_start)?;
+    let inspection = TimeoutBudget::started_at(request_timeout, request_start)
+        .run(inspect(cli, &url, http_version, connect_timeout))
         .await?;
 
     if !cli.silent {
@@ -46,6 +45,24 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
         printer.flush_to(&mut std::io::stderr())?;
     }
     Ok(0)
+}
+
+fn inspection_request_timeout(cli: &Cli) -> Result<Option<Duration>, FetchError> {
+    cli.timeout
+        .map(|seconds| duration_from_seconds("timeout", seconds))
+        .transpose()
+}
+
+fn inspection_connect_timeout(
+    cli: &Cli,
+    request_timeout: Option<Duration>,
+    request_start: Instant,
+) -> Result<TimeoutBudget, FetchError> {
+    let connect_timeout = cli
+        .connect_timeout
+        .map(|seconds| duration_from_seconds("connect-timeout", seconds))
+        .transpose()?;
+    TimeoutBudget::for_connect(connect_timeout, request_timeout, request_start)
 }
 
 fn tls_url(raw: &str) -> Result<Url, FetchError> {
@@ -76,7 +93,7 @@ async fn inspect(
     cli: &Cli,
     url: &Url,
     http_version: Option<HttpVersion>,
-    timeout: Option<Duration>,
+    timeout: TimeoutBudget,
 ) -> Result<Inspection, FetchError> {
     if http_version == Some(HttpVersion::Http3) {
         inspect_quic(cli, url, timeout).await
@@ -89,7 +106,7 @@ async fn inspect_tcp(
     cli: &Cli,
     url: &Url,
     http_version: Option<HttpVersion>,
-    timeout: Option<Duration>,
+    timeout: TimeoutBudget,
 ) -> Result<Inspection, FetchError> {
     let host = tls_host(url)?;
     let port = url.port_or_known_default().unwrap_or(443);
@@ -108,10 +125,14 @@ async fn inspect_tcp(
         .map_err(|_| FetchError::Message(format!("invalid server name '{host}'")))?;
     let stream = connect_tcp_host(&host, port, cli.dns_server.as_deref(), timeout).await?;
     let connector = TlsConnector::from(Arc::new(config));
-    let stream = connector
-        .connect(server_name, stream)
-        .await
-        .map_err(go_style_tls_inspect_error)?;
+    let stream = timeout
+        .run(async move {
+            connector
+                .connect(server_name, stream)
+                .await
+                .map_err(go_style_tls_inspect_error)
+        })
+        .await?;
     let (_, conn) = stream.get_ref();
 
     let mut peer_chain = Vec::new();
@@ -139,50 +160,66 @@ async fn connect_tcp_host(
     host: &str,
     port: u16,
     dns_server: Option<&str>,
-    timeout: Option<Duration>,
+    timeout: TimeoutBudget,
 ) -> Result<TcpStream, FetchError> {
     let addrs = resolve_tls_host(host, port, dns_server, timeout).await?;
     let mut last_err = None;
 
     for addr in addrs {
-        match TcpStream::connect(addr).await {
+        match timeout
+            .run(async move { TcpStream::connect(addr).await.map_err(FetchError::from) })
+            .await
+        {
             Ok(stream) => return Ok(stream),
             Err(err) => last_err = Some(err),
         }
     }
 
-    Err(last_err
-        .map(FetchError::from)
-        .unwrap_or_else(|| FetchError::Message("no addresses found".to_string())))
+    Err(last_err.unwrap_or_else(|| FetchError::Message("no addresses found".to_string())))
 }
 
 async fn resolve_tls_host(
     host: &str,
     port: u16,
     dns_server: Option<&str>,
-    timeout: Option<Duration>,
+    timeout: TimeoutBudget,
 ) -> Result<Vec<SocketAddr>, FetchError> {
     let Some(dns_server) = dns_server else {
-        return tokio::net::lookup_host((host, port))
-            .await
-            .map(|addrs| addrs.collect())
-            .map_err(FetchError::from);
+        return timeout
+            .run(async {
+                tokio::net::lookup_host((host, port))
+                    .await
+                    .map(|addrs| addrs.collect())
+                    .map_err(FetchError::from)
+            })
+            .await;
     };
     if host.parse::<IpAddr>().is_ok() {
-        return tokio::net::lookup_host((host, port))
-            .await
-            .map(|addrs| addrs.collect())
-            .map_err(FetchError::from);
+        return timeout
+            .run(async {
+                tokio::net::lookup_host((host, port))
+                    .await
+                    .map(|addrs| addrs.collect())
+                    .map_err(FetchError::from)
+            })
+            .await;
     }
 
-    let addrs = crate::dns::custom::lookup_ips(dns_server, host, timeout).await?;
+    let dns_timeout = timeout.remaining()?;
+    let addrs = timeout
+        .run(crate::dns::custom::lookup_ips(
+            dns_server,
+            host,
+            dns_timeout,
+        ))
+        .await?;
     Ok(crate::dns::custom::socket_addrs_with_port(addrs, port))
 }
 
 async fn inspect_quic(
     cli: &Cli,
     url: &Url,
-    timeout: Option<Duration>,
+    timeout: TimeoutBudget,
 ) -> Result<Inspection, FetchError> {
     let host = tls_host(url)?;
     ensure_quic_protocol_versions(cli)?;
@@ -210,6 +247,7 @@ async fn inspect_quic(
             &trusted_roots,
             !cli.insecure,
             &ocsp_capture,
+            timeout,
         )
         .await
         {
@@ -238,6 +276,7 @@ async fn inspect_quic_addr(
     trusted_roots: &[ParsedCert],
     verified: bool,
     ocsp_capture: &OcspCapture,
+    timeout: TimeoutBudget,
 ) -> Result<Inspection, FetchError> {
     let bind_addr = if addr.is_ipv4() {
         "0.0.0.0:0"
@@ -250,11 +289,16 @@ async fn inspect_quic_addr(
     let mut endpoint = quinn::Endpoint::client(bind_addr)?;
     endpoint.set_default_client_config(quic_config);
 
-    let connection = endpoint
+    let connecting = endpoint
         .connect(addr, host)
-        .map_err(|err| FetchError::Message(err.to_string()))?
-        .await
         .map_err(|err| FetchError::Message(err.to_string()))?;
+    let connection = timeout
+        .run(async {
+            connecting
+                .await
+                .map_err(|err| FetchError::Message(err.to_string()))
+        })
+        .await?;
     let alpn = quic_alpn(&connection);
     let chain =
         certificate_chain_for_display(quic_peer_certificates(&connection), trusted_roots, verified);
@@ -1800,7 +1844,12 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
 
         let inspection = tokio::time::timeout(
             Duration::from_secs(5),
-            inspect_tcp(&cli, &url, Some(HttpVersion::Http2), None),
+            inspect_tcp(
+                &cli,
+                &url,
+                Some(HttpVersion::Http2),
+                TimeoutBudget::new(None),
+            ),
         )
         .await
         .expect("IPv6 TLS inspection timed out")
@@ -1843,9 +1892,14 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
         .unwrap();
         let url = tls_url(&raw_url).unwrap();
 
-        let inspection = inspect(&cli, &url, Some(HttpVersion::Http3), None)
-            .await
-            .unwrap();
+        let inspection = inspect(
+            &cli,
+            &url,
+            Some(HttpVersion::Http3),
+            TimeoutBudget::new(None),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(inspection.alpn.as_deref(), Some("h3"));
         assert_eq!(inspection.version, Some(ProtocolVersion::TLSv1_3));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -589,7 +589,8 @@ fn is_transient_local_server_error(res: &FetchOutput) -> bool {
             .stderr
             .contains("connection closed before message completed")
             || res.stderr.contains("connection was not ready")
-            || res.stderr.contains("Connection reset by peer"))
+            || res.stderr.contains("Connection reset by peer")
+            || res.stderr.contains("Connection refused"))
 }
 
 fn assert_exit(res: &FetchOutput, code: i32) {
@@ -3894,7 +3895,7 @@ fn compressed_sse_retry_drains_first_response_before_replay() {
         let result = (|| -> Result<Duration, String> {
             let mut first_stream = accept_tcp_connection(
                 &listener,
-                Duration::from_secs(3),
+                Duration::from_secs(10),
                 "first compressed SSE request",
             )?;
             first_stream
@@ -3931,7 +3932,7 @@ fn compressed_sse_retry_drains_first_response_before_replay() {
             let retry_started_at = Instant::now();
             let mut retry_stream = accept_tcp_connection(
                 &listener,
-                Duration::from_secs(3),
+                Duration::from_secs(10),
                 "uncompressed SSE retry on a new connection",
             )?;
             let retry_elapsed = retry_started_at.elapsed();
@@ -5987,6 +5988,20 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
     assert!(res.stderr.contains("Addresses: 2"));
     assert!(res.stderr.contains("Records:"));
 
+    let unresponsive_inspect_dns_addr = start_unresponsive_udp_dns_server();
+    let res = run_fetch(&[
+        "--inspect-dns",
+        "--dns-server",
+        &unresponsive_inspect_dns_addr,
+        "--connect-timeout",
+        "0.05",
+        "--timeout",
+        "1",
+        "https://fetch-inspect-dns-timeout.test",
+    ]);
+    assert_exit(&res, 1);
+    assert!(res.stderr.contains("request timed out after 50ms"));
+
     let res = run_fetch(&[
         "--inspect-dns",
         "--dns-server",
@@ -6307,6 +6322,19 @@ fn tls_certificate_validation_inspection_and_bounds_cases() {
     assert!(res.stdout.is_empty());
     assert!(res.stderr.contains("TLS"));
     assert!(res.stderr.contains("Certificate") || res.stderr.contains("certificate"));
+
+    let stalling_tls = start_stalling_proxy("https");
+    let res = run_fetch(&[
+        "--inspect-tls",
+        "--insecure",
+        "--connect-timeout",
+        "0.05",
+        "--timeout",
+        "1",
+        &stalling_tls,
+    ]);
+    assert_exit(&res, 1);
+    assert!(res.stderr.contains("request timed out after 50ms"));
 
     let dns_addr = start_udp_dns_server("fetch-tls.test.", Ipv4Addr::new(127, 0, 0, 1));
     let tls_url = Url::parse(&tls.url).unwrap();


### PR DESCRIPTION
## Summary
- Parse `--connect-timeout` in `--inspect-dns` and `--inspect-tls` entry points.
- Use `TimeoutBudget::for_connect(...)` so connect budgets bound DNS lookup, TCP connect, TLS handshake, and QUIC inspection.
- Add regression coverage proving a short connect timeout overrides a longer request timeout for both inspection paths.
- Tighten a flaky integration harness wait so the serial suite stays reliable.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test integration -- --test-threads=1`