### PR TITLE
Avoid reparsing successful UDP DNS inspection responses

### DIFF
--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -393,7 +393,7 @@ async fn lookup_udp_records(
         .await
         .map_err(QueryError::other)?;
     let raw_records = match wire::parse_response(&response, id) {
-        Ok(_) => wire::parse_response(&response, id).map_err(QueryError::other)?,
+        Ok(records) => records,
         Err(err) if err.is_truncated() => {
             response = crate::dns::transport::query_tcp(server_addr, &raw, timeout)
                 .await


### PR DESCRIPTION
## Summary
- Bind the successful UDP parse result directly in DNS inspection instead of calling `wire::parse_response` twice
- Keep the truncated-response TCP fallback path unchanged
- Remove duplicate decompression and record parsing work from direct UDP inspection queries

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Focused DNS inspection tests covering UDP truncation and TCP fallback passed