### PR TITLE
Reject unsupported curl semantic flags in --from-curl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - `--sort-headers` or `sort-headers = true` sorts displayed request/response headers alphabetically by name in verbose output without changing the actual request header order.
 - Default HTTP requests send `Accept: application/json, */*;q=0.5`, preferring JSON while allowing any other response type as a lower-priority fallback.
 - `--basic` and `--digest` credentials preserve exact bytes around the first colon; leading/trailing spaces in usernames or passwords are significant and are not trimmed after CLI or `--from-curl` parsing.
+- `--from-curl` should only no-op curl flags that already match fetch defaults or curl presentation-only progress flags. Unsupported semantic flags such as `-n`/`--netrc`, `-f`/`--fail`, `-N`/`--no-buffer`, `--proto-default`, and `--proto-redir` return clear diagnostics instead of being ignored.
 - The HTTP/2/3 environment-proxy guard mirrors reqwest `NO_PROXY` matching for hosts, domains, IP literals, CIDR ranges, and `*` so env proxies do not incorrectly block direct private-network requests.
 
 Retryable requests use replayable request bodies so retries and 307/308 redirects can resend data without holding unrelated state.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -646,23 +646,26 @@ fetch --from-curl 'https://example.com'
 
 **Supported curl flags:**
 
-| Category     | Curl Flags                                                                                                                                    |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Request      | `-X`, `-H`, `-d`, `--data-raw`, `--data-binary`, `--data-urlencode`, `--json`, `-F`, `-T`, `-I`, `-G`                                         |
-| Auth         | `-u`, `--digest`, `--aws-sigv4`, `--oauth2-bearer`                                                                                            |
-| TLS          | `-k`, `--cacert`, `-E`/`--cert`, `--key`, `--tlsv1.2`, `--tlsv1.3`, `--tls-max`                                                               |
-| Output       | `-o`, `-O`, `-J`                                                                                                                              |
-| Network      | `-L`, `--max-redirs`, `-m`/`--max-time`, `--connect-timeout`, `-x`, `--unix-socket`, `--doh-url`, `--retry`, `--retry-delay`, `-r`            |
-| HTTP version | `-0`, `--http1.1`, `--http2`, `--http3`                                                                                                       |
-| Headers      | `-A`, `-e`, `-b`                                                                                                                              |
-| Verbosity    | `-v`, `-s`                                                                                                                                    |
-| Protocol     | `--proto` (restricts allowed protocols; errors if URL scheme is not allowed)                                                                  |
-| No-ops       | `--compressed`, `-S`, `-N`, `--no-keepalive`, `-#`, `--no-progress-meter`, `-n`, `-f`, `--fail-with-body`, `--proto-default`, `--proto-redir` |
+| Category                   | Curl Flags                                                                                                                         |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Request                    | `-X`, `-H`, `-d`, `--data-raw`, `--data-binary`, `--data-urlencode`, `--json`, `-F`, `-T`, `-I`, `-G`                              |
+| Auth                       | `-u`, `--digest`, `--aws-sigv4`, `--oauth2-bearer`                                                                                 |
+| TLS                        | `-k`, `--cacert`, `-E`/`--cert`, `--key`, `--tlsv1.2`, `--tlsv1.3`, `--tls-max`                                                    |
+| Output                     | `-o`, `-O`, `-J`                                                                                                                   |
+| Network                    | `-L`, `--max-redirs`, `-m`/`--max-time`, `--connect-timeout`, `-x`, `--unix-socket`, `--doh-url`, `--retry`, `--retry-delay`, `-r` |
+| HTTP version               | `-0`, `--http1.1`, `--http2`, `--http3`                                                                                            |
+| Headers                    | `-A`, `-e`, `-b`                                                                                                                   |
+| Verbosity                  | `-v`, `-s`                                                                                                                         |
+| Protocol                   | `--proto` (restricts allowed protocols; errors if URL scheme is not allowed)                                                       |
+| Default-compatible no-ops  | `--compressed`, `-S`/`--show-error`, `--fail-with-body`, `--no-keepalive`                                                          |
+| Presentation compatibility | `-#`/`--progress-bar`, `--no-progress-meter`                                                                                       |
 
 **Notes:**
 
 - `-b`/`--cookie` only supports inline cookie strings (e.g., `-b 'name=value'`). Cookie jar files are not supported and will return an error.
 - `--data-urlencode` supports `@filename` and `name@filename` forms for reading and URL-encoding file contents.
+- `-n`/`--netrc` is not supported. Use `--basic`, `--bearer`, or an explicit `Authorization` header instead.
+- Semantic curl flags that `fetch` cannot faithfully translate, such as `-f`/`--fail`, `-N`/`--no-buffer`, `--proto-default`, and `--proto-redir`, return an error instead of being ignored.
 
 Unknown curl flags return an error.
 

--- a/src/cli/from_curl.rs
+++ b/src/cli/from_curl.rs
@@ -235,6 +235,10 @@ fn parse_long_flag(
     has_value: bool,
     rest: &[String],
 ) -> Result<usize, String> {
+    if let Some(message) = unsupported_semantic_long_flag(name) {
+        return Err(message);
+    }
+
     let consume_arg = |flag_name: &str| -> Result<(String, usize), String> {
         if has_value {
             Ok((value.clone(), 0))
@@ -497,20 +501,78 @@ fn parse_long_flag(
             parsed.silent = true;
             Ok(0)
         }
-        "fail" | "fail-with-body" => Ok(0),
-        "show-error" | "compressed" | "no-buffer" | "no-keepalive" | "progress-bar"
-        | "no-progress-meter" | "netrc" => Ok(0),
+        name if long_flag_matches_fetch_default(name) => Ok(0),
+        name if long_flag_is_curl_presentation_only(name) => Ok(0),
         "proto" => {
             let (value, consumed) = consume_arg(name)?;
             parsed.allowed_proto = value;
             Ok(consumed)
         }
-        "proto-default" | "proto-redir" => {
-            let (_value, consumed) = consume_arg(name)?;
-            Ok(consumed)
-        }
         _ => Err(format!("unsupported curl flag '--{name}'")),
     }
+}
+
+fn long_flag_matches_fetch_default(name: &str) -> bool {
+    matches!(
+        name,
+        "compressed" | "fail-with-body" | "no-keepalive" | "show-error"
+    )
+}
+
+fn long_flag_is_curl_presentation_only(name: &str) -> bool {
+    matches!(name, "no-progress-meter" | "progress-bar")
+}
+
+fn unsupported_semantic_long_flag(name: &str) -> Option<String> {
+    match name {
+        "fail" => Some(unsupported_fail_flag("--fail")),
+        "netrc" => Some(unsupported_netrc_flag("--netrc")),
+        "no-buffer" => Some(unsupported_no_buffer_flag("--no-buffer")),
+        "proto-default" => Some(
+            "curl --proto-default is not supported by --from-curl; specify the URL scheme explicitly"
+                .to_string(),
+        ),
+        "proto-redir" => Some(
+            "curl --proto-redir is not supported by --from-curl; fetch only follows HTTP(S) redirects and --from-curl cannot further restrict them"
+                .to_string(),
+        ),
+        _ => None,
+    }
+}
+
+fn short_flag_matches_fetch_default(flag: char) -> bool {
+    matches!(flag, 'S')
+}
+
+fn short_flag_is_curl_presentation_only(flag: char) -> bool {
+    matches!(flag, '#')
+}
+
+fn unsupported_semantic_short_flag(flag: char) -> Option<String> {
+    match flag {
+        'f' => Some(unsupported_fail_flag("-f")),
+        'n' => Some(unsupported_netrc_flag("-n/--netrc")),
+        'N' => Some(unsupported_no_buffer_flag("-N/--no-buffer")),
+        _ => None,
+    }
+}
+
+fn unsupported_fail_flag(flag: &str) -> String {
+    format!(
+        "curl {flag} is not supported by --from-curl; fetch already exits non-zero for HTTP error statuses but does not suppress the response body"
+    )
+}
+
+fn unsupported_netrc_flag(flag: &str) -> String {
+    format!(
+        "curl {flag} is not supported by --from-curl; use --basic USER:PASS, --bearer TOKEN, or an explicit Authorization header (-H 'Authorization: ...') instead"
+    )
+}
+
+fn unsupported_no_buffer_flag(flag: &str) -> String {
+    format!(
+        "curl {flag} is not supported by --from-curl; fetch does not implement curl's unbuffered output mode"
+    )
 }
 
 fn parse_short_flags(
@@ -622,9 +684,15 @@ fn parse_short_flags(
             'G' => parsed.get_flag = true,
             'v' => parsed.verbose = parsed.verbose.saturating_add(1),
             's' => parsed.silent = true,
-            'S' | 'N' | 'n' | 'f' | '#' => {}
             '0' => parsed.http_version = "1.0".to_string(),
-            _ => return Err(format!("unsupported curl flag '-{flag}'")),
+            flag if short_flag_matches_fetch_default(flag) => {}
+            flag if short_flag_is_curl_presentation_only(flag) => {}
+            flag => {
+                if let Some(message) = unsupported_semantic_short_flag(flag) {
+                    return Err(message);
+                }
+                return Err(format!("unsupported curl flag '-{flag}'"));
+            }
         }
 
         i += 1;
@@ -851,6 +919,66 @@ mod tests {
         let parsed =
             parse(r#"curl --aws-sigv4 "aws:amz:us-east-1:s3" https://example.com"#).unwrap();
         assert_eq!(parsed.aws_sigv4, "aws:amz:us-east-1:s3");
+    }
+
+    #[test]
+    fn test_parse_default_matching_and_unsupported_semantic_flags() {
+        let parsed = parse(
+            "curl --compressed --show-error --fail-with-body --no-keepalive --no-progress-meter --progress-bar -S -# https://example.com",
+        )
+        .unwrap();
+        assert_eq!(parsed.url, "https://example.com");
+
+        for (command, flag, want) in [
+            (
+                "curl --fail https://example.com",
+                "--fail",
+                "does not suppress the response body",
+            ),
+            (
+                "curl -f https://example.com",
+                "-f",
+                "does not suppress the response body",
+            ),
+            (
+                "curl --no-buffer https://example.com",
+                "--no-buffer",
+                "unbuffered output mode",
+            ),
+            (
+                "curl -N https://example.com",
+                "-N/--no-buffer",
+                "unbuffered output mode",
+            ),
+            (
+                "curl --proto-default https https://example.com",
+                "--proto-default",
+                "specify the URL scheme explicitly",
+            ),
+            (
+                "curl --proto-redir =https https://example.com",
+                "--proto-redir",
+                "cannot further restrict",
+            ),
+        ] {
+            let err = parse(command).unwrap_err();
+            assert!(err.contains(flag), "{command}: {err}");
+            assert!(err.contains(want), "{command}: {err}");
+        }
+    }
+
+    #[test]
+    fn test_parse_netrc_is_rejected_with_auth_advice() {
+        for (command, flag) in [
+            ("curl --netrc https://example.com", "--netrc"),
+            ("curl -n https://example.com", "-n/--netrc"),
+        ] {
+            let err = parse(command).unwrap_err();
+            assert!(err.contains(flag), "{command}: {err}");
+            assert!(err.contains("--basic"), "{command}: {err}");
+            assert!(err.contains("--bearer"), "{command}: {err}");
+            assert!(err.contains("Authorization"), "{command}: {err}");
+        }
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4523,6 +4523,16 @@ fn from_curl_parses_common_forms_and_errors() {
     let res = run_fetch(&["--from-curl", "curl --not-a-real-flag http://example.com"]);
     assert_exit(&res, 1);
     assert!(res.stderr.contains("unsupported curl flag"));
+
+    let netrc_server = TestServer::start(|_| TestResponse::ok("netrc should not be requested"));
+    let curl = format!("curl --netrc {}", netrc_server.url);
+    let res = run_fetch(&["--from-curl", &curl]);
+    assert_exit(&res, 1);
+    assert!(res.stderr.contains("--netrc"));
+    assert!(res.stderr.contains("--basic"));
+    assert!(res.stderr.contains("--bearer"));
+    assert!(res.stderr.contains("Authorization"));
+    assert!(netrc_server.requests().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Split `--from-curl` handling into fetch-compatible no-ops, curl presentation flags, and unsupported semantic flags.
- Make `-n`/`--netrc`, `-f`/`--fail`, `-N`/`--no-buffer`, `--proto-default`, and `--proto-redir` fail with explicit diagnostics instead of silently dropping them.
- Document the supported flag groups and the new rejection behavior.
- Add parser and integration coverage, including a regression test that `curl --netrc ...` does not proceed to send a request.

## Testing
- `cargo test --all-features from_curl`
- `cargo test --all-features --test integration from_curl_parses_common_forms_and_errors -- --test-threads=1`
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `git diff --check`