### PR TITLE
Scope platform-specific dependencies to their target OS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ http-body-util = "0.1"
 httpdate = "1"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "tiff", "webp"] }
 ipnet = "2"
-libc = "0.2"
 md-5 = "0.11"
 mime = "0.3"
 mimalloc = "0.1.52"
@@ -61,9 +60,14 @@ tokio-util = { version = "0.7", features = ["io"] }
 tower = "0.5"
 url = "2"
 webpki-roots = "1"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }
 zip = { version = "8", default-features = false, features = ["deflate"] }
 zstd = "0.13"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }
 
 [dev-dependencies]
 assert_cmd = "2"


### PR DESCRIPTION
## Summary
- Move `libc` into `cfg(unix)` dependencies so Unix-only code does not pull it in on Windows.
- Move `windows-sys` into `cfg(windows)` dependencies so Windows-only code does not build it on Unix-like targets.
- Keep the existing source-level `cfg` gates aligned with the manifest.

## Testing
- Not run (not requested)