### PR TITLE
Fix redirect verbose status labels for negotiated HTTP versions

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -302,7 +302,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                     if let Some(redirect) = redirect_target(cli, &response, redirect_count)? {
                         timing.mark_response_headers();
                         timing.set_connect(connect_timing.duration());
-                        print_redirect_status(cli, response.status());
+                        print_redirect_status(cli, &response);
                         redirect_statuses.push(response.status());
                         let redirected =
                             redirected_request(request_method, request_body, response.status())?;
@@ -2709,13 +2709,14 @@ fn ensure_body_replayable(replayable: bool, action: &str) -> Result<(), FetchErr
     )))
 }
 
-fn print_redirect_status(cli: &Cli, status: StatusCode) {
+fn print_redirect_status(cli: &Cli, response: &Response) {
     if cli.verbose < 2 || cli.silent {
         return;
     }
+    let status = response.status();
     let mut printer = core::Printer::stderr(cli.color.as_deref());
     printer.write_response_prefix();
-    printer.write_styled("HTTP/1.1", &[core::Sequence::Dim]);
+    printer.write_styled(version_label(response.version()), &[core::Sequence::Dim]);
     printer.push_str(" ");
     let status_color = color_for_status(status.as_u16());
     printer.write_styled(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4990,6 +4990,7 @@ fn http3_go_harness_cases() {
         &format!("{}/start", redirect.url),
         "--http",
         "3",
+        "-vv",
         "--ca-cert",
         redirect.ca_cert_path.to_str().unwrap(),
         "--method",
@@ -4999,6 +5000,8 @@ fn http3_go_harness_cases() {
     ]);
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "h3 redirected");
+    assert!(res.stderr.contains("< HTTP/3.0 307 Temporary Redirect"));
+    assert!(!res.stderr.contains("< HTTP/1.1 307 Temporary Redirect"));
     assert!(res.stderr.contains("HTTP/3.0 200 OK"));
     let requests = wait_for_h3_requests(&redirect, 2);
     assert_eq!(requests[0].path, "/start");


### PR DESCRIPTION
## Summary
- Pass the full response into redirect status printing so the protocol label comes from `response.version()` instead of a hard-coded `HTTP/1.1`
- Add a regression check for HTTP/3 redirects to verify the intermediate verbose line reports `HTTP/3.0`

## Testing
- Ran `cargo fmt`
- Ran `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Ran the focused integration test for the HTTP/3 redirect case