### PR TITLE
Preserve duplicate request headers in HTTP metadata

### DIFF
--- a/src/http/metadata.rs
+++ b/src/http/metadata.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use std::collections::HashSet;
+
 pub(crate) fn load_session(cli: &Cli) -> Result<Option<crate::session::Session>, FetchError> {
     let Some(name) = cli.session.as_deref() else {
         return Ok(None);
@@ -331,6 +333,7 @@ pub(crate) fn apply_query(url: &mut Url, query: &[String]) {
 }
 
 pub(crate) fn apply_headers(headers: &mut HeaderMap, values: &[String]) -> Result<(), FetchError> {
+    let mut seen = HashSet::new();
     for raw in values {
         let Some((key, val)) = raw.split_once(':') else {
             return Err(FetchError::Message(format!(
@@ -351,7 +354,10 @@ pub(crate) fn apply_headers(headers: &mut HeaderMap, values: &[String]) -> Resul
         let value = HeaderValue::from_str(val.trim()).map_err(|err| {
             FetchError::Message(format!("invalid header value for '{key}': {err}"))
         })?;
-        headers.insert(name, value);
+        if seen.insert(name.clone()) {
+            headers.remove(&name);
+        }
+        headers.append(name, value);
     }
     Ok(())
 }
@@ -489,6 +495,42 @@ mod tests {
             err,
             "invalid value 'Bad Header: value' for option '--header': must be in the format NAME:VALUE with a valid non-empty header name"
         );
+    }
+
+    #[test]
+    fn apply_headers_appends_duplicates_after_clearing_defaults() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static(core::DEFAULT_ACCEPT_HEADER),
+        );
+        headers.insert(USER_AGENT, HeaderValue::from_static("fetch-test"));
+
+        apply_headers(
+            &mut headers,
+            &[
+                "Accept: application/xml".to_string(),
+                "X-Test: one".to_string(),
+                "Accept: application/yaml".to_string(),
+                "X-Test: two".to_string(),
+            ],
+        )
+        .unwrap();
+
+        let accept_values = headers
+            .get_all(ACCEPT)
+            .iter()
+            .map(|value| value.to_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(accept_values, ["application/xml", "application/yaml"]);
+
+        let test_values = headers
+            .get_all("x-test")
+            .iter()
+            .map(|value| value.to_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(test_values, ["one", "two"]);
+        assert_eq!(headers.get(USER_AGENT).unwrap(), "fetch-test");
     }
 
     #[test]

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -54,6 +54,23 @@ fn request_construction_and_data_sources() {
 }
 
 #[test]
+fn duplicate_cli_headers_are_sent_as_separate_wire_lines() {
+    let server = TestServer::start(|_| TestResponse::ok("ok"));
+
+    let res = run_fetch(&[
+        &server.url,
+        "--header",
+        "X-Test: one",
+        "--header",
+        "X-Test: two",
+    ]);
+    assert_exit(&res, 0);
+
+    let req = wait_for_requests(&server, 1).remove(0);
+    assert_eq!(req.header_values("x-test"), ["one", "two"]);
+}
+
+#[test]
 fn config_merges_global_host_and_cli_options() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let attempts_for_handler = Arc::clone(&attempts);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -56,6 +56,7 @@ pub(crate) struct TestRequest {
     pub(crate) method: String,
     pub(crate) path: String,
     pub(crate) headers: HashMap<String, String>,
+    pub(crate) header_lines: Vec<(String, String)>,
     pub(crate) body: Vec<u8>,
 }
 
@@ -65,6 +66,14 @@ impl TestRequest {
             .get(&name.to_ascii_lowercase())
             .cloned()
             .unwrap_or_default()
+    }
+
+    pub(crate) fn header_values(&self, name: &str) -> Vec<String> {
+        self.header_lines
+            .iter()
+            .filter(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.clone())
+            .collect()
     }
 
     pub(crate) fn body_string(&self) -> String {
@@ -460,6 +469,7 @@ pub(crate) fn read_request(reader: &mut impl BufRead) -> Option<TestRequest> {
     let _version = parts.next()?.to_string();
 
     let mut headers = HashMap::new();
+    let mut header_lines = Vec::new();
     loop {
         let mut line = String::new();
         if reader.read_line(&mut line).ok()? == 0 {
@@ -470,7 +480,10 @@ pub(crate) fn read_request(reader: &mut impl BufRead) -> Option<TestRequest> {
             break;
         }
         if let Some((name, value)) = line.split_once(':') {
-            headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+            let name = name.trim().to_ascii_lowercase();
+            let value = value.trim().to_string();
+            header_lines.push((name.clone(), value.clone()));
+            headers.insert(name, value);
         }
     }
 
@@ -509,6 +522,7 @@ pub(crate) fn read_request(reader: &mut impl BufRead) -> Option<TestRequest> {
         method,
         path,
         headers,
+        header_lines,
         body,
     })
 }
@@ -1308,11 +1322,18 @@ async fn handle_test_h2_request(
         body_bytes.extend_from_slice(&chunk);
     }
     let mut headers = HashMap::new();
+    let mut header_lines = Vec::new();
+    let mut current_name = None;
     for (name, value) in parts.headers {
-        if let Some(name) = name
+        if let Some(name) = name {
+            current_name = Some(name.as_str().to_ascii_lowercase());
+        }
+        if let Some(name) = &current_name
             && let Ok(value) = value.to_str()
         {
-            headers.insert(name.as_str().to_ascii_lowercase(), value.to_string());
+            let value = value.to_string();
+            header_lines.push((name.clone(), value.clone()));
+            headers.insert(name.clone(), value);
         }
     }
     let resp = handler(TestRequest {
@@ -1324,6 +1345,7 @@ async fn handle_test_h2_request(
             .unwrap_or("/")
             .to_string(),
         headers,
+        header_lines,
         body: body_bytes,
     });
     if let Some(reason) = resp.h2_reset {


### PR DESCRIPTION
## Summary
- Stop `--header` parsing from overwriting repeated names; the first user-supplied occurrence now clears any default and every value is appended in order.
- Extend the HTTP test harness to retain raw header lines so duplicate wire entries can be asserted directly.
- Add regression coverage for both the header application logic and a raw request integration case.

## Testing
- Unit test added for duplicate header application behavior.
- Integration test added to verify both duplicate `X-Test` lines are sent on the wire.
- Formatting and lint checks passed locally.