### PR TITLE
Classify WebSocket runtime failures correctly

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -75,7 +75,7 @@ pub(crate) use request::{
     RequestBody, RequestBodyPayload, apply_builder_authorization_headers, basic_header,
     request_body, request_body_into_bytes,
 };
-pub(crate) use retry::total_attempts_for_retry;
+pub(crate) use retry::{is_certificate_validation_message, total_attempts_for_retry};
 
 use encoding::*;
 use metadata::*;

--- a/src/http/retry.rs
+++ b/src/http/retry.rs
@@ -358,7 +358,7 @@ pub(super) fn is_certificate_validation_error(err: &transport::Error) -> bool {
     false
 }
 
-pub(super) fn is_certificate_validation_message(message: &str) -> bool {
+pub(crate) fn is_certificate_validation_message(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
     lower.contains("hostnameerror")
         || (lower.contains("certificate")

--- a/src/websocket/interactive.rs
+++ b/src/websocket/interactive.rs
@@ -10,6 +10,8 @@ use tokio_tungstenite::tungstenite::{Error as WsError, Message};
 use crate::error::FetchError;
 use crate::format::json;
 
+use super::websocket_error;
+
 pub const PROMPT: &str = "❯ ";
 const MIN_ROWS: usize = 5;
 const READ_BUF_SIZE: usize = 256;
@@ -811,10 +813,6 @@ async fn detect_cursor_row_async<W: Write>(
 fn teardown<W: Write>(mode: &mut InteractiveMode, out: &mut W) -> io::Result<()> {
     mode.teardown_screen(out)?;
     out.flush()
-}
-
-fn websocket_error(err: WsError) -> FetchError {
-    FetchError::Message(err.to_string())
 }
 
 fn utf8_sequence_width(byte: u8) -> Option<usize> {

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -1,3 +1,4 @@
+use std::error::Error as StdError;
 use std::future::Future;
 use std::io::{self, BufRead, Read, Write};
 use std::sync::Arc;
@@ -87,11 +88,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let request_timeout = websocket_request_timeout(cli)?;
     let request_budget = TimeoutBudget::started_at(request_timeout, request_start);
     let connect_timeout = websocket_connect_timeout(cli, request_timeout, request_start)?;
-    let connect = async {
-        connect_websocket(cli, &url, request, connector, connect_timeout)
-            .await
-            .map_err(websocket_error)
-    };
+    let connect = async { connect_websocket(cli, &url, request, connector, connect_timeout).await };
     let (stream, response) = request_budget.run(connect).await?;
 
     print_response_metadata(cli, &response);
@@ -177,11 +174,11 @@ async fn connect_websocket(
         tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<DialStream>>,
         tokio_tungstenite::tungstenite::handshake::client::Response,
     ),
-    WsError,
+    FetchError,
 > {
     let stream = dial_websocket(cli, url, timeout)
         .await
-        .map_err(websocket_io_error)?;
+        .map_err(websocket_network_error)?;
     timeout_ws(
         timeout,
         client_async_tls_with_config(request, stream, None, connector),
@@ -224,17 +221,22 @@ fn websocket_connect_timeout(
 async fn timeout_ws<T>(
     timeout: TimeoutBudget,
     future: impl Future<Output = Result<T, WsError>>,
-) -> Result<T, WsError> {
-    let Some(remaining) = timeout.remaining().map_err(websocket_io_error)? else {
-        return future.await;
+) -> Result<T, FetchError> {
+    let Some(remaining) = timeout.remaining()? else {
+        return future.await.map_err(websocket_error);
     };
     tokio::time::timeout(remaining, future)
         .await
-        .map_err(|_| websocket_io_error(timeout.timeout_error()))?
+        .map_err(|_| timeout.timeout_error())?
+        .map_err(websocket_error)
 }
 
-fn websocket_io_error(err: FetchError) -> WsError {
-    WsError::Io(io::Error::other(err.to_string()))
+fn websocket_network_error(err: FetchError) -> FetchError {
+    match err {
+        FetchError::Io(err) => FetchError::Runtime(err.to_string()),
+        FetchError::Transport(err) => FetchError::Runtime(err.to_string()),
+        err => err,
+    }
 }
 
 fn write_warnings(cli: &Cli, warnings: &[String]) {
@@ -700,10 +702,32 @@ fn write_binary_terminal_warning(cli: &Cli) {
 
 fn websocket_error(err: WsError) -> FetchError {
     let message = err.to_string();
+    if websocket_certificate_validation_error(&err, &message) {
+        return FetchError::CertificateValidation(message);
+    }
     if let Some(start) = message.find("request timed out after ") {
         return FetchError::Runtime(message[start..].to_string());
     }
-    FetchError::Message(message)
+    match err {
+        WsError::Url(_) | WsError::HttpFormat(_) => FetchError::Message(message),
+        _ => FetchError::Runtime(message),
+    }
+}
+
+fn websocket_certificate_validation_error(err: &WsError, message: &str) -> bool {
+    if crate::http::is_certificate_validation_message(message) {
+        return true;
+    }
+
+    let mut source = err.source();
+    while let Some(err) = source {
+        if crate::http::is_certificate_validation_message(&err.to_string()) {
+            return true;
+        }
+        source = err.source();
+    }
+
+    false
 }
 
 #[cfg(test)]

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -148,6 +148,24 @@ fn websocket_noninteractive_go_cases() {
     assert!(res.stderr.contains("WebSocket requires HTTP/1.1"));
     assert!(res.stderr.contains("HTTP/3.0 is not supported"));
 
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind unused websocket port");
+    let addr = listener
+        .local_addr()
+        .expect("unused websocket port local addr");
+    drop(listener);
+    let refused_url = format!("ws://{addr}");
+    let res = run_fetch_once(
+        FetchOpts::default(),
+        &[&refused_url, "--ws-interactive", "off"],
+    );
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr.to_ascii_lowercase().contains("refused"),
+        "stderr:\n{}",
+        res.stderr
+    );
+    assert!(!res.stderr.contains("--help"), "stderr:\n{}", res.stderr);
+
     let res = run_fetch(&[&ws_url, "--method", "POST", "--timing", "--dry-run"]);
     assert_exit(&res, 0);
     assert!(res.stderr.contains("GET / HTTP/1.1"));
@@ -485,6 +503,29 @@ fn websocket_wss_trusts_custom_ca_go_case() {
         "secure websocket"
     );
     assert!(res.stdout.contains("echo: secure websocket"));
+}
+
+#[test]
+fn websocket_wss_bad_certificate_suggests_insecure_go_case() {
+    let (wss, _seen) = start_wss_echo_server(|_| Ok(()));
+    let res = run_fetch(&[
+        &wss.url,
+        "-d",
+        "secure websocket",
+        "--format",
+        "off",
+        "--ws-interactive",
+        "off",
+    ]);
+
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr.to_ascii_lowercase().contains("certificate"),
+        "stderr:\n{}",
+        res.stderr
+    );
+    assert!(res.stderr.contains("--insecure"), "stderr:\n{}", res.stderr);
+    assert!(!res.stderr.contains("--help"), "stderr:\n{}", res.stderr);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Map WebSocket connection, TLS, and handshake failures to runtime errors instead of CLI errors.
- Detect certificate-validation failures through the shared HTTP classifier so WSS errors show the `--insecure` hint.
- Add integration coverage for WSS bad-certificate failures and refused connections.

## Testing
- `cargo fmt`
- `cargo test --all-features --test websocket`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`