### PR TITLE
Allow cli key with config cert

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -237,7 +237,7 @@ async fn run_inner(cli: &mut Cli) -> Result<i32, FetchError> {
     crate::cli::parse_http_version(cli.http.as_deref()).map_err(FetchError::Message)?;
     crate::cli::normalize_range_values(&mut cli.ranges).map_err(FetchError::Message)?;
     validate_proto_schema_files(cli)?;
-    validate_client_certificate_flags(direct_cli_sources)?;
+    validate_client_certificate_flags(cli, direct_cli_sources)?;
     validate_auth_credentials(cli)?;
     print_config_debug(cli, config_path.as_deref());
 
@@ -332,8 +332,11 @@ impl DirectCliSources {
     }
 }
 
-fn validate_client_certificate_flags(sources: DirectCliSources) -> Result<(), FetchError> {
-    if sources.key && !sources.cert {
+fn validate_client_certificate_flags(
+    cli: &Cli,
+    sources: DirectCliSources,
+) -> Result<(), FetchError> {
+    if sources.key && cli.cert.is_none() {
         return Err("flag '--key' requires '--cert'".into());
     }
     Ok(())
@@ -1372,11 +1375,21 @@ mod tests {
             Cli::try_parse_from(["fetch", "https://example.com", "--key", "client.key"]).unwrap();
         let sources = DirectCliSources::capture(&cli);
 
-        let err = validate_client_certificate_flags(sources)
+        let err = validate_client_certificate_flags(&cli, sources)
             .unwrap_err()
             .to_string();
 
         assert_eq!(err, "flag '--key' requires '--cert'");
+    }
+
+    #[test]
+    fn direct_key_with_merged_cert_is_allowed() {
+        let mut cli =
+            Cli::try_parse_from(["fetch", "https://example.com", "--key", "client.key"]).unwrap();
+        let sources = DirectCliSources::capture(&cli);
+        cli.cert = Some("client.crt".to_string());
+
+        validate_client_certificate_flags(&cli, sources).unwrap();
     }
 
     #[test]
@@ -1385,7 +1398,7 @@ mod tests {
         let sources = DirectCliSources::capture(&cli);
         cli.key = Some("client.key".to_string());
 
-        validate_client_certificate_flags(sources).unwrap();
+        validate_client_certificate_flags(&cli, sources).unwrap();
     }
 
     #[test]

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -965,6 +965,22 @@ fn mtls_client_certificate_go_cases() {
     assert_eq!(res.stdout, "mtls-success");
     assert!(res.stderr.contains("200 OK"));
 
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("mtls-config-cert");
+    fs::write(&config, format!("cert = {cert}\n")).unwrap();
+    let res = run_fetch(&[
+        "--config",
+        config.to_str().unwrap(),
+        "--ca-cert",
+        ca,
+        "--key",
+        key,
+        &mtls.url,
+    ]);
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "mtls-success");
+    assert!(res.stderr.contains("200 OK"));
+
     let res = run_fetch(&["--ca-cert", ca, "--cert", combined, &mtls.url]);
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "mtls-success");


### PR DESCRIPTION
## Summary

This fixes client certificate validation so a directly supplied `--key` can pair with a `cert = ...` value supplied by config after configuration merging.

## Root Cause

`DirectCliSources` was captured before `--from-curl` and config were applied, and the later validation rejected direct `--key` unless `--cert` had also been directly supplied. That meant the merged CLI state could contain both `cert` and `key` but still be rejected.

## Changes

- Validate direct `--key` against the merged `Cli` certificate state.
- Keep rejecting direct key-only usage when no final certificate is present.
- Add unit coverage for a merged certificate satisfying direct key validation.
- Add an mTLS regression where `cert` comes from config and `--key` comes from CLI.

## Validation

- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features direct_key_with_merged_cert_is_allowed`
- `cargo test --all-features --test network mtls_client_certificate_go_cases -- --test-threads=1`
- `cargo test --all-features`
- `cargo test --all-features --test cli --test formatting --test grpc --test http --test network --test terminal --test update --test websocket -- --test-threads=1`