### PR TITLE
Apply AWS SigV4 signing to gRPC reflection

### DIFF
--- a/src/grpc/reflection.rs
+++ b/src/grpc/reflection.rs
@@ -14,6 +14,7 @@ use crate::grpc::framing;
 use crate::grpc::headers as grpc_headers;
 use crate::grpc::status;
 use crate::http::transport::Client;
+use crate::http::{RequestBodyPayload, apply_aws_sigv4, aws_config};
 use crate::proto::Schema;
 
 const REFLECTION_V1_PATH: &str = "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo";
@@ -178,9 +179,10 @@ async fn invoke(
     let request_body =
         framing::frame(&payload, false).map_err(|err| FetchError::Message(err.to_string()))?;
 
+    let headers = reflection_headers(cli, &url, &request_body)?;
     let response = client
         .post(url)
-        .headers(reflection_headers(cli)?)
+        .headers(headers)
         .body(request_body)
         .send()
         .await?;
@@ -209,7 +211,7 @@ async fn invoke(
     Ok(body.messages)
 }
 
-fn reflection_headers(cli: &Cli) -> Result<HeaderMap, FetchError> {
+fn reflection_headers(cli: &Cli, url: &Url, request_body: &[u8]) -> Result<HeaderMap, FetchError> {
     let mut headers = HeaderMap::new();
     headers.insert(
         USER_AGENT,
@@ -217,6 +219,10 @@ fn reflection_headers(cli: &Cli) -> Result<HeaderMap, FetchError> {
     );
     crate::http::apply_headers(&mut headers, &cli.headers)?;
     grpc_headers::apply_standard_headers(&mut headers);
+    if let Some(config) = aws_config(cli.aws_sigv4.as_deref())? {
+        let signed_body = Some(RequestBodyPayload::from_bytes(request_body.to_vec(), None));
+        apply_aws_sigv4(cli, "POST", url, &mut headers, &signed_body, &config)?;
+    }
     crate::http::apply_builder_authorization_headers(&mut headers, cli, None)?;
     Ok(headers)
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -72,8 +72,8 @@ pub(crate) use metadata::{
     apply_headers, apply_query, load_session, normalize_url, request_target,
 };
 pub(crate) use request::{
-    RequestBody, RequestBodyPayload, apply_builder_authorization_headers, basic_header,
-    request_body, request_body_into_bytes,
+    RequestBody, RequestBodyPayload, apply_aws_sigv4, apply_builder_authorization_headers,
+    aws_config, basic_header, request_body, request_body_into_bytes,
 };
 pub(crate) use retry::{is_certificate_validation_message, total_attempts_for_retry};
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -347,7 +347,7 @@ pub(super) fn digest_credentials(
     Ok(Some((username.to_string(), password.to_string())))
 }
 
-pub(super) fn aws_config(value: Option<&str>) -> Result<Option<aws_sigv4::Config>, FetchError> {
+pub(crate) fn aws_config(value: Option<&str>) -> Result<Option<aws_sigv4::Config>, FetchError> {
     value
         .map(aws_sigv4::parse_config)
         .transpose()
@@ -358,7 +358,7 @@ pub(super) fn aws_unsigned_payload(cli: &Cli, config: &aws_sigv4::Config) -> boo
     config.service == "s3" && cli.data.as_deref() == Some("@-") && !cli.data_is_literal
 }
 
-pub(super) fn apply_aws_sigv4(
+pub(crate) fn apply_aws_sigv4(
     cli: &Cli,
     method: &str,
     url: &Url,

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -1,6 +1,18 @@
 mod support;
 
+use sha2::{Digest as Sha2Digest, Sha256};
 use support::*;
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest.iter().copied() {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
 
 #[test]
 fn grpc_schema_descriptor_and_client_streaming_cases() {
@@ -590,4 +602,46 @@ fn grpc_reflection_h2c_go_cases() {
     ]);
     assert_exit(&res, 0);
     assert!(!res.stdout.is_empty());
+}
+
+#[test]
+fn grpc_reflection_requests_include_aws_sigv4_headers() {
+    let server = start_reflection_grpc_h2c_server(true);
+    let res = run_fetch_opts(
+        FetchOpts {
+            env: vec![
+                ("AWS_ACCESS_KEY_ID".to_string(), "1234".to_string()),
+                ("AWS_SECRET_ACCESS_KEY".to_string(), "5678".to_string()),
+                ("AWS_SESSION_TOKEN".to_string(), "session-token".to_string()),
+            ],
+            ..Default::default()
+        },
+        &[
+            "--grpc-list",
+            "--aws-sigv4",
+            "us-east-1/execute-api",
+            &server.url,
+        ],
+    );
+    assert_exit(&res, 0);
+
+    let requests = server.requests();
+    let reflection = requests
+        .iter()
+        .find(|req| req.path == "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo")
+        .expect("captured reflection request");
+    let auth = reflection.header("authorization");
+    assert_eq!(reflection.method, "POST");
+    assert!(auth.starts_with("AWS4-HMAC-SHA256 "));
+    assert!(auth.contains("Credential=1234/"));
+    assert!(auth.contains("/us-east-1/execute-api/aws4_request"));
+    assert!(auth.contains("x-amz-content-sha256"));
+    assert!(auth.contains("x-amz-date"));
+    assert!(auth.contains("x-amz-security-token"));
+    assert!(!reflection.header("x-amz-date").is_empty());
+    assert_eq!(reflection.header("x-amz-security-token"), "session-token");
+    assert_eq!(
+        reflection.header("x-amz-content-sha256"),
+        sha256_hex(&reflection.body)
+    );
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -243,6 +243,13 @@ pub(crate) struct H3TestServer {
 pub(crate) struct ReflectionGrpcServer {
     pub(crate) url: String,
     pub(crate) ca_cert_path: Option<PathBuf>,
+    pub(crate) requests: Arc<Mutex<Vec<TestRequest>>>,
+}
+
+impl ReflectionGrpcServer {
+    pub(crate) fn requests(&self) -> Vec<TestRequest> {
+        self.requests.lock().unwrap().clone()
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1669,6 +1676,8 @@ pub(crate) fn start_reflection_grpc_h2c_server_with_behavior(
     listener.set_nonblocking(true).unwrap();
     let url = format!("http://{}", listener.local_addr().unwrap());
     let descriptor = reflection_health_descriptor();
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let captured_requests = Arc::clone(&requests);
     thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -1681,8 +1690,9 @@ pub(crate) fn start_reflection_grpc_h2c_server_with_behavior(
                     break;
                 };
                 let descriptor = descriptor.clone();
+                let requests = Arc::clone(&captured_requests);
                 tokio::spawn(async move {
-                    serve_reflection_h2_connection(stream, descriptor, behavior).await;
+                    serve_reflection_h2_connection(stream, descriptor, behavior, requests).await;
                 });
             }
         });
@@ -1690,6 +1700,7 @@ pub(crate) fn start_reflection_grpc_h2c_server_with_behavior(
     ReflectionGrpcServer {
         url,
         ca_cert_path: None,
+        requests,
     }
 }
 
@@ -1733,6 +1744,8 @@ pub(crate) fn start_reflection_grpc_tls_server_with_versions(
         listener.local_addr().unwrap().port()
     );
     let descriptor = reflection_health_descriptor();
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let captured_requests = Arc::clone(&requests);
     thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -1746,11 +1759,12 @@ pub(crate) fn start_reflection_grpc_tls_server_with_versions(
                 };
                 let acceptor = acceptor.clone();
                 let descriptor = descriptor.clone();
+                let requests = Arc::clone(&captured_requests);
                 tokio::spawn(async move {
                     let Ok(tls) = acceptor.accept(stream).await else {
                         return;
                     };
-                    serve_reflection_h2_connection(tls, descriptor, behavior).await;
+                    serve_reflection_h2_connection(tls, descriptor, behavior, requests).await;
                 });
             }
         });
@@ -1758,6 +1772,7 @@ pub(crate) fn start_reflection_grpc_tls_server_with_versions(
     ReflectionGrpcServer {
         url,
         ca_cert_path: Some(ca_cert_path),
+        requests,
     }
 }
 
@@ -1772,6 +1787,7 @@ async fn serve_reflection_h2_connection<T>(
     stream: T,
     descriptor: Vec<u8>,
     behavior: ReflectionBehavior,
+    requests: Arc<Mutex<Vec<TestRequest>>>,
 ) where
     T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
@@ -1783,8 +1799,9 @@ async fn serve_reflection_h2_connection<T>(
             break;
         };
         let descriptor = descriptor.clone();
+        let requests = Arc::clone(&requests);
         tokio::spawn(async move {
-            handle_reflection_h2_request(request, respond, descriptor, behavior).await;
+            handle_reflection_h2_request(request, respond, descriptor, behavior, requests).await;
         });
     }
 }
@@ -2063,9 +2080,31 @@ async fn handle_reflection_h2_request(
     mut respond: h2::server::SendResponse<bytes::Bytes>,
     descriptor: Vec<u8>,
     behavior: ReflectionBehavior,
+    requests: Arc<Mutex<Vec<TestRequest>>>,
 ) {
-    let path = request.uri().path().to_string();
-    let mut body = request.into_body();
+    let (parts, mut body) = request.into_parts();
+    let path = parts.uri.path().to_string();
+    let request_path = parts
+        .uri
+        .path_and_query()
+        .map(|path| path.as_str())
+        .unwrap_or("/")
+        .to_string();
+    let mut headers = HashMap::new();
+    let mut header_lines = Vec::new();
+    let mut current_name = None;
+    for (name, value) in parts.headers {
+        if let Some(name) = name {
+            current_name = Some(name.as_str().to_ascii_lowercase());
+        }
+        if let Some(name) = &current_name
+            && let Ok(value) = value.to_str()
+        {
+            let value = value.to_string();
+            header_lines.push((name.clone(), value.clone()));
+            headers.insert(name.clone(), value);
+        }
+    }
     let mut raw = Vec::new();
     while let Some(chunk) = body.data().await {
         let Ok(chunk) = chunk else {
@@ -2073,6 +2112,13 @@ async fn handle_reflection_h2_request(
         };
         raw.extend_from_slice(&chunk);
     }
+    requests.lock().unwrap().push(TestRequest {
+        method: parts.method.to_string(),
+        path: request_path,
+        headers,
+        header_lines,
+        body: raw.clone(),
+    });
     let (headers, payload) = match path.as_str() {
         "/grpc.health.v1.Health/Check" => (
             vec![("content-type", "application/grpc+proto")],


### PR DESCRIPTION
## Summary
- Sign gRPC reflection requests with the existing AWS SigV4 helper before sending them.
- Preserve the normal gRPC/basic/bearer auth flow after SigV4 header generation.
- Extend the test reflection server to capture request headers so reflection signing can be asserted directly.

## Testing
- Added an integration test that verifies reflection requests carry `Authorization`, `x-amz-date`, `x-amz-content-sha256`, and session token headers when `--aws-sigv4` is set.
- Ran `cargo fmt`.
- Ran `cargo clippy --locked --all-targets --all-features -- -D warnings`.
- Ran `cargo test --all-features --test grpc grpc_reflection_requests_include_aws_sigv4_headers -- --test-threads=1`.
- Ran `cargo test --all-features --test grpc -- --test-threads=1`.