### PR TITLE
Remove dead redirect compatibility code

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -387,9 +387,6 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                 .await;
             }
             Err(err) => {
-                if let Some(message) = redirect_error_message(&err) {
-                    break Err(FetchError::Runtime(message));
-                }
                 if attempt < retry_count && is_retryable_error(&err) {
                     ensure_body_replayable(original_body_replayable, "retry")?;
                     let requested_delay = compute_delay(retry_delay, attempt, Duration::ZERO);

--- a/src/http/retry.rs
+++ b/src/http/retry.rs
@@ -264,22 +264,6 @@ pub(super) fn print_redirect_status(cli: &Cli, response: &Response) {
     flush_stderr(printer);
 }
 
-pub(super) fn redirect_error_message(err: &transport::Error) -> Option<String> {
-    if !err.is_redirect() {
-        return None;
-    }
-
-    let mut source = err.source();
-    while let Some(err) = source {
-        let message = err.to_string();
-        if message.contains("exceeded maximum number of redirects") {
-            return Some(message);
-        }
-        source = err.source();
-    }
-    None
-}
-
 pub(super) fn timeout_error_message(cli: &Cli, err: &transport::Error) -> Option<String> {
     if !err.is_timeout() {
         return None;

--- a/src/http/transport.rs
+++ b/src/http/transport.rs
@@ -117,10 +117,6 @@ impl Error {
     pub(crate) fn is_connect(&self) -> bool {
         self.kind == ErrorKind::Connect
     }
-
-    pub(crate) fn is_redirect(&self) -> bool {
-        false
-    }
 }
 
 impl fmt::Display for Error {


### PR DESCRIPTION
## Summary
- Remove the unreachable redirect compatibility branch from HTTP request handling
- Delete the unused redirect error helper and the dead `Error::is_redirect()` method
- Keep the existing manual redirect-limit coverage intact

## Testing
- `cargo test --all-features redirect_limit`
- `cargo test --all-features --test http detailed_output_status_range_redirect_and_unix_edges`
- `cargo test --all-features --test http redirects_range_status_and_timeouts`