### PR TITLE
Share DNS timeout budgets across DoH and UDP fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - Custom/pre-resolved DNS observes timeout budgets before the transport client is built: `--connect-timeout` bounds DNS resolution when set, otherwise DNS uses the remaining `--timeout` budget, and DoH lookup clients receive the same budget.
 - Custom/pre-resolved DNS is scoped to the request URL; manual redirects that change scheme, host, or port rebuild the transport client and resolve the redirect target so `--dns-server`, `-vvv`, and `--timing` stay aligned with the actual target.
 - Custom/pre-resolved DNS runs A and AAAA lookups concurrently for both UDP and DoH, preserving any successful records when the other family fails.
+- DNS fallback paths share the top-level lookup timeout budget: DoH RFC 8484 POST and JSON fallback requests use one `TimeoutBudget`, and truncated UDP responses use the remaining budget for TCP fallback instead of restarting the timeout.
 - Custom UDP DNS uses random query IDs and applies a 5s per-query receive timeout when no request/connect timeout is available, so unresponsive UDP resolvers cannot hang indefinitely.
 - DoH lookups use the main HTTP transport client's ALPN-negotiated pool so concurrent HTTPS query types share an HTTP/2 connection when the resolver supports `h2`, falling back to HTTP/1.1 only when needed. Avoid regressing to one TLS connection per A/AAAA query.
 - DoH responses are capped at 1 MiB while buffering; oversized responses must fail with a DNS error instead of growing memory without bound.

--- a/src/dns/doh.rs
+++ b/src/dns/doh.rs
@@ -48,7 +48,7 @@ pub(crate) struct DohRecord {
 }
 
 pub(crate) struct DohClient {
-    timeout: Option<Duration>,
+    budget: TimeoutBudget,
     client: Client,
 }
 
@@ -95,13 +95,17 @@ pub async fn lookup_doh_type(
 }
 
 pub(crate) fn client(timeout: Option<Duration>) -> Result<DohClient, DnsError> {
+    client_with_budget(TimeoutBudget::new(timeout))
+}
+
+pub(crate) fn client_with_budget(budget: TimeoutBudget) -> Result<DohClient, DnsError> {
     let tls_config =
         crate::tls::rustls_platform_client_config().map_err(|err| DnsError(err.to_string()))?;
     let client = Client::builder()
         .tls_config(tls_config)
         .build()
         .map_err(|err| DnsError(err.to_string()))?;
-    Ok(DohClient { timeout, client })
+    Ok(DohClient { budget, client })
 }
 
 async fn lookup_doh_type_with_client(
@@ -246,8 +250,7 @@ impl DohClient {
         headers: HeaderMap,
         body: Option<Vec<u8>>,
     ) -> Result<DohResponseBody, DnsError> {
-        let budget = TimeoutBudget::new(self.timeout);
-        budget
+        self.budget
             .run(async {
                 let mut request = self.client.request(method, url).headers(headers);
                 if let Some(body) = body {
@@ -712,6 +715,37 @@ mod tests {
         )
     }
 
+    async fn start_delayed_415_fallback_server(
+        post_delay: Duration,
+    ) -> (Url, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let Some(request) = read_wire_test_request(&mut stream).await else {
+                    continue;
+                };
+                if request.method.eq_ignore_ascii_case("POST") {
+                    tokio::time::sleep(post_delay).await;
+                    let _ = stream
+                        .write_all(
+                            b"HTTP/1.1 415 Unsupported Media Type\r\ncontent-length: 0\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n",
+                        )
+                        .await;
+                    continue;
+                }
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        });
+        (
+            Url::parse(&format!("http://{addr}/dns-query")).unwrap(),
+            task,
+        )
+    }
+
     #[derive(Debug)]
     struct WireTestRequest {
         method: String,
@@ -1026,6 +1060,25 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(400),
             "lookup took {elapsed:?}, expected parallel A/AAAA queries near {delay:?}"
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn lookup_doh_timeout_budget_covers_415_json_fallback() {
+        let timeout = Duration::from_millis(250);
+        let (url, task) = start_delayed_415_fallback_server(Duration::from_millis(150)).await;
+
+        let start = Instant::now();
+        let err = lookup_doh_type(&url, "example.com", "A", DNS_TYPE_A, Some(timeout))
+            .await
+            .unwrap_err();
+        let elapsed = start.elapsed();
+
+        assert_eq!(err.to_string(), "request timed out after 250ms");
+        assert!(
+            elapsed < Duration::from_millis(350),
+            "lookup took {elapsed:?}, expected timeout to cover POST and JSON fallback"
         );
         task.abort();
     }

--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -292,11 +292,9 @@ async fn lookup(
         return Ok(out);
     }
 
-    let remaining_timeout = timeout.remaining()?;
-    let udp_timeout = udp_dns_timeout(remaining_timeout);
     let doh_client = match &target {
         ResolverTarget::Doh { .. } => Some(
-            crate::dns::doh::client(remaining_timeout)
+            crate::dns::doh::client_with_budget(timeout)
                 .map_err(|err| FetchError::Message(err.to_string()))?,
         ),
         _ => None,
@@ -310,7 +308,7 @@ async fn lookup(
                     lookup_doh_records(client, url, host, query_type).await
                 }
                 (ResolverTarget::Udp { addr, .. }, _) => {
-                    lookup_udp_records(addr, host, query_type, udp_timeout).await
+                    lookup_udp_records(addr, host, query_type, timeout).await
                 }
                 (ResolverTarget::Default { .. }, _) => {
                     unreachable!("default resolver handled earlier")
@@ -421,17 +419,19 @@ async fn lookup_udp_records(
     server_addr: &str,
     host: &str,
     query_type: QueryType,
-    timeout: Duration,
+    timeout: TimeoutBudget,
 ) -> Result<Vec<Record>, QueryError> {
     let id = dns_query_id();
     let raw = wire::build_query(id, host, query_type.dns_type).map_err(QueryError::other)?;
-    let mut response = crate::dns::transport::query_udp(server_addr, &raw, timeout)
+    let udp_timeout = udp_dns_timeout(timeout.remaining().map_err(QueryError::other)?);
+    let mut response = crate::dns::transport::query_udp(server_addr, &raw, udp_timeout)
         .await
         .map_err(QueryError::other)?;
     let raw_records = match wire::parse_response(&response, id) {
         Ok(records) => records,
         Err(err) if err.is_truncated() => {
-            response = crate::dns::transport::query_tcp(server_addr, &raw, timeout)
+            let tcp_timeout = udp_dns_timeout(timeout.remaining().map_err(QueryError::other)?);
+            response = crate::dns::transport::query_tcp(server_addr, &raw, tcp_timeout)
                 .await
                 .map_err(QueryError::truncated)?;
             wire::parse_response(&response, id).map_err(QueryError::truncated)?
@@ -1349,7 +1349,7 @@ mod tests {
                 label: "A",
                 dns_type: DNS_TYPE_A,
             },
-            Duration::from_secs(1),
+            TimeoutBudget::new(Some(Duration::from_secs(1))),
         )
         .await
         .unwrap();

--- a/src/dns/resolver.rs
+++ b/src/dns/resolver.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::dns::util::{dns_query_id, udp_dns_timeout};
 use crate::dns::wire;
+use crate::duration::TimeoutBudget;
 
 const DNS_TYPE_A: u16 = wire::TYPE_A;
 const DNS_TYPE_AAAA: u16 = wire::TYPE_AAAA;
@@ -35,10 +36,10 @@ pub async fn lookup_udp(
         return Ok(vec![ip]);
     }
 
-    let timeout = udp_dns_timeout(timeout);
+    let budget = TimeoutBudget::new(timeout);
     let (a, aaaa) = tokio::join!(
-        lookup_udp_type(server_addr, host, DNS_TYPE_A, timeout),
-        lookup_udp_type(server_addr, host, DNS_TYPE_AAAA, timeout)
+        lookup_udp_type_with_budget(server_addr, host, DNS_TYPE_A, budget),
+        lookup_udp_type_with_budget(server_addr, host, DNS_TYPE_AAAA, budget)
     );
 
     let mut addrs = Vec::new();
@@ -63,14 +64,31 @@ pub async fn lookup_udp_type(
     dns_type: u16,
     timeout: Duration,
 ) -> Result<Vec<DnsRecord>, ResolverError> {
+    lookup_udp_type_with_budget(
+        server_addr,
+        host,
+        dns_type,
+        TimeoutBudget::new(Some(timeout)),
+    )
+    .await
+}
+
+async fn lookup_udp_type_with_budget(
+    server_addr: &str,
+    host: &str,
+    dns_type: u16,
+    budget: TimeoutBudget,
+) -> Result<Vec<DnsRecord>, ResolverError> {
     let id = dns_query_id();
     let raw = wire::build_query(id, host, dns_type).map_err(resolver_error)?;
+    let timeout = udp_dns_timeout(budget.remaining().map_err(resolver_error)?);
     let response = crate::dns::transport::query_udp(server_addr, &raw, timeout)
         .await
         .map_err(resolver_error)?;
     match dns_records_from_response(&response, id) {
         Ok(records) => Ok(records),
         Err(err) if err.is_truncated() => {
+            let timeout = udp_dns_timeout(budget.remaining().map_err(resolver_error)?);
             let response = crate::dns::transport::query_tcp(server_addr, &raw, timeout)
                 .await
                 .map_err(resolver_error)?;
@@ -143,7 +161,10 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::net::{TcpListener, TcpStream as StdTcpStream, UdpSocket as StdUdpSocket};
-    use std::sync::{Arc, Barrier, Mutex};
+    use std::sync::{
+        Arc, Barrier, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
     use std::thread;
     use std::time::{Duration, Instant};
 
@@ -208,6 +229,27 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].ip.to_string(), "203.0.113.10");
         assert_eq!(records[0].ttl, Some(55));
+        stop();
+    }
+
+    #[tokio::test]
+    async fn lookup_udp_type_timeout_budget_covers_truncated_tcp_fallback() {
+        let timeout = Duration::from_millis(250);
+        let (addr, tcp_accepts, stop) =
+            start_delayed_truncated_udp_slow_tcp_server(Duration::from_millis(150));
+
+        let start = Instant::now();
+        let err = lookup_udp_type(&addr, "example.com", DNS_TYPE_A, timeout)
+            .await
+            .unwrap_err();
+        let elapsed = start.elapsed();
+
+        assert_eq!(err.to_string(), "DNS lookup timed out");
+        assert_eq!(tcp_accepts.load(Ordering::SeqCst), 1);
+        assert!(
+            elapsed < Duration::from_millis(350),
+            "lookup took {elapsed:?}, expected timeout to cover UDP and TCP fallback"
+        );
         stop();
     }
 
@@ -398,6 +440,77 @@ mod tests {
                 .unwrap()
                 .send_to(&[0], "127.0.0.1:9");
             handle.join().unwrap();
+        })
+    }
+
+    fn start_delayed_truncated_udp_slow_tcp_server(
+        udp_delay: Duration,
+    ) -> (String, Arc<AtomicUsize>, impl FnOnce()) {
+        let udp_socket = StdUdpSocket::bind("127.0.0.1:0").unwrap();
+        udp_socket
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .unwrap();
+        let addr = udp_socket.local_addr().unwrap();
+        let tcp_listener = TcpListener::bind(addr).unwrap();
+        tcp_listener.set_nonblocking(true).unwrap();
+        let done = Arc::new(Mutex::new(false));
+        let tcp_accepts = Arc::new(AtomicUsize::new(0));
+
+        let udp_done = done.clone();
+        let udp_handle = thread::spawn(move || {
+            let mut buf = [0u8; 512];
+            loop {
+                if *udp_done.lock().unwrap() {
+                    return;
+                }
+                let Ok((n, peer)) = udp_socket.recv_from(&mut buf) else {
+                    continue;
+                };
+                if n < 12 {
+                    continue;
+                }
+                thread::sleep(udp_delay);
+                let response = truncated_response(&buf[..n]);
+                let _ = udp_socket.send_to(&response, peer);
+            }
+        });
+
+        let tcp_done = done.clone();
+        let tcp_accepts_for_thread = tcp_accepts.clone();
+        let tcp_handle = thread::spawn(move || {
+            loop {
+                if *tcp_done.lock().unwrap() {
+                    return;
+                }
+                match tcp_listener.accept() {
+                    Ok((mut stream, _)) => {
+                        tcp_accepts_for_thread.fetch_add(1, Ordering::SeqCst);
+                        if read_tcp_query(&mut stream).is_none() {
+                            continue;
+                        }
+                        loop {
+                            if *tcp_done.lock().unwrap() {
+                                return;
+                            }
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => {}
+                }
+            }
+        });
+
+        (addr.to_string(), tcp_accepts, move || {
+            *done.lock().unwrap() = true;
+            let _ = StdUdpSocket::bind("127.0.0.1:0")
+                .unwrap()
+                .send_to(&[0], addr);
+            let _ = StdTcpStream::connect(addr);
+            udp_handle.join().unwrap();
+            tcp_handle.join().unwrap();
         })
     }
 


### PR DESCRIPTION
## Summary
- Keep one `TimeoutBudget` alive across DoH POST and JSON fallback so RFC8484 retries cannot restart the timeout.
- Carry the same budget through UDP A/AAAA lookups and truncated UDP-to-TCP fallback so the TCP retry uses the remaining time.
- Update DNS inspection to reuse the budgeted DoH/UDP paths and document the invariant in `AGENTS.md`.
- Add regressions for delayed DoH 415 fallback and truncated UDP fallback to verify elapsed time stays bounded by the original timeout.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`