### PR TITLE
Fix gRPC dry-run stdin reuse

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -56,31 +56,55 @@ pub(super) fn print_dry_run_body(cli: &Cli, body: &RequestBody) -> Result<(), Fe
     if cli.verbose < 2 {
         eprintln!();
     }
-    if matches!(body.source, RequestBodySource::Stdin) {
-        let mut bytes = Vec::new();
-        std::io::stdin().read_to_end(&mut bytes)?;
-        return print_dry_run_bytes(cli, &bytes);
+    if let Some(materialized) = materialize_dry_run_body(body)? {
+        return print_materialized_dry_run_body(cli, materialized);
     }
     let preview = request_body_preview(body)?;
     if is_printable(&preview) {
         write_request_body_to_stderr(body)?;
     } else {
-        let mut printer = core::Printer::stderr(cli.color.as_deref());
-        core::write_warning_msg_no_flush(&mut printer, "the request body appears to be binary");
-        flush_stderr(printer);
+        print_dry_run_binary_warning(cli);
     }
     Ok(())
 }
 
-pub(super) fn print_dry_run_bytes(cli: &Cli, bytes: &[u8]) -> Result<(), FetchError> {
-    if is_printable(bytes) {
-        std::io::stderr().write_all(bytes)?;
+enum DryRunMaterializedBody {
+    Bytes(Vec<u8>),
+    BinaryWarning,
+}
+
+fn materialize_dry_run_body(
+    body: &RequestBodyPayload,
+) -> Result<Option<DryRunMaterializedBody>, FetchError> {
+    if !matches!(
+        body.source,
+        RequestBodySource::Stdin | RequestBodySource::GrpcJsonStream { .. }
+    ) {
+        return Ok(None);
+    }
+    let bytes = request_body_source_to_bytes(body.source.clone())?;
+    Ok(Some(if is_printable(&bytes) {
+        DryRunMaterializedBody::Bytes(bytes)
     } else {
-        let mut printer = core::Printer::stderr(cli.color.as_deref());
-        core::write_warning_msg_no_flush(&mut printer, "the request body appears to be binary");
-        flush_stderr(printer);
+        DryRunMaterializedBody::BinaryWarning
+    }))
+}
+
+fn print_materialized_dry_run_body(
+    cli: &Cli,
+    body: DryRunMaterializedBody,
+) -> Result<(), FetchError> {
+    match body {
+        DryRunMaterializedBody::Bytes(bytes) => std::io::stderr().write_all(&bytes)?,
+        DryRunMaterializedBody::BinaryWarning => print_dry_run_binary_warning(cli),
     }
     Ok(())
+}
+
+fn print_dry_run_binary_warning(cli: &Cli) {
+    let mut printer = core::Printer::stderr(cli.color.as_deref());
+    core::write_warning_msg_no_flush(&mut printer, "the request body appears to be binary");
+    flush_stderr(printer);
 }
 
 pub(super) fn build_request(

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -279,6 +279,37 @@ service StreamService {
 }
 
 #[test]
+fn grpc_dry_run_materializes_streaming_stdin_body_once() {
+    let dir = TempDir::new().unwrap();
+    let stream_desc = write_stream_descriptor_set(dir.path());
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            stdin: Some(r#"{"value":"one"}{"value":"two"}"#.to_string()),
+            ..Default::default()
+        },
+        &[
+            "http://127.0.0.1:1/streampkg.StreamService/ClientStream",
+            "--grpc",
+            "--proto-desc",
+            stream_desc.to_str().unwrap(),
+            "-d",
+            "@-",
+            "--dry-run",
+        ],
+    );
+
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(
+        res.stderr
+            .contains("POST /streampkg.StreamService/ClientStream ")
+    );
+    assert!(res.stderr.contains("content-type: application/grpc+proto"));
+    assert!(res.stderr.contains("the request body appears to be binary"));
+}
+
+#[test]
 fn grpc_h2c_stream_frames_and_status_trailers_are_handled() {
     let server_url = start_status_grpc_h2c_server();
     let res = run_fetch(&[


### PR DESCRIPTION
## Summary
- Materialize dry-run request bodies once for stdin-backed gRPC streams and reuse the result for output.
- Preserve the existing preview path for non-streaming bodies while routing binary decisions through a shared helper.
- Add a regression test covering client-streaming gRPC dry-run with stdin input.

## Testing
- `cargo test --all-features --test grpc grpc_dry_run_materializes_streaming_stdin_body_once`
- `cargo test --all-features --test grpc`