### PR TITLE
Pin Cargo dependencies to exact latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -286,9 +286,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1079,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1416,9 +1416,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -1438,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mimalloc"
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2020,9 +2020,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2221,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2271,9 +2271,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2583,9 +2583,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -3179,18 +3179,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,69 +16,69 @@ opt-level = 3
 strip = true
 
 [dependencies]
-anyhow = "1"
-async-compression = { version = "0.4", features = ["brotli", "gzip", "tokio", "zstd"] }
-base64 = "0.22"
-brotli = "8.0.3"
-bytes = "1"
-clap = { version = "4", features = ["derive"] }
-cookie = "0.18"
-cookie_store = "0.22"
-encoding_rs = "0.8"
-flate2 = "1"
-futures-util = "0.3"
-h2 = "0.4"
-h3 = "0.0.8"
-h3-quinn = "0.0.10"
-hmac = "0.13"
-http = "1"
-http-body = "1"
-http-body-util = "0.1"
-httpdate = "1"
-hyper = { version = "1", features = ["client", "http1", "http2"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "client-proxy-system", "http1", "http2", "tokio"] }
-image = { version = "0.25", default-features = false, features = ["jpeg", "png", "tiff", "webp"] }
-ipnet = "2"
-md-5 = "0.11"
-mime = "0.3"
-mimalloc = "0.1.52"
-percent-encoding = "2"
-prost = "0.14"
-prost-reflect = { version = "0.16", features = ["serde"] }
-prost-types = "0.14"
-psl = "2"
-rand = "0.10"
-quick-xml = "0.40"
-quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-aws-lc-rs"] }
-rustls = { version = "0.23", default-features = false, features = ["std", "aws-lc-rs", "prefer-post-quantum", "tls12"] }
-rustls-native-certs = "0.8"
-rustls-platform-verifier = "0.7"
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["arbitrary_precision", "preserve_order"] }
-sha2 = "0.11"
-socket2 = { version = "0.6", features = ["all"] }
-tar = "0.4"
-thiserror = "2"
-time = "0.3"
-tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
-tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
-tokio-util = { version = "0.7", features = ["io"] }
-tower-service = "0.3"
-url = "2"
-webpki-roots = "1"
-zip = { version = "8", default-features = false, features = ["deflate"] }
-zstd = "0.13"
+anyhow = "=1.0.102"
+async-compression = { version = "=0.4.42", features = ["brotli", "gzip", "tokio", "zstd"] }
+base64 = "=0.22.1"
+brotli = "=8.0.3"
+bytes = "=1.11.1"
+clap = { version = "=4.6.1", features = ["derive"] }
+cookie = "=0.18.1"
+cookie_store = "=0.22.1"
+encoding_rs = "=0.8.35"
+flate2 = "=1.1.9"
+futures-util = "=0.3.32"
+h2 = "=0.4.14"
+h3 = "=0.0.8"
+h3-quinn = "=0.0.10"
+hmac = "=0.13.0"
+http = "=1.4.1"
+http-body = "=1.0.1"
+http-body-util = "=0.1.3"
+httpdate = "=1.0.3"
+hyper = { version = "=1.10.1", features = ["client", "http1", "http2"] }
+hyper-util = { version = "=0.1.20", features = ["client-legacy", "client-proxy", "client-proxy-system", "http1", "http2", "tokio"] }
+image = { version = "=0.25.10", default-features = false, features = ["jpeg", "png", "tiff", "webp"] }
+ipnet = "=2.12.0"
+md-5 = "=0.11.0"
+mime = "=0.3.17"
+mimalloc = "=0.1.52"
+percent-encoding = "=2.3.2"
+prost = "=0.14.3"
+prost-reflect = { version = "=0.16.4", features = ["serde"] }
+prost-types = "=0.14.3"
+psl = "=2.1.212"
+rand = "=0.10.1"
+quick-xml = "=0.40.1"
+quinn = { version = "=0.11.9", default-features = false, features = ["runtime-tokio", "rustls-aws-lc-rs"] }
+rustls = { version = "=0.23.40", default-features = false, features = ["std", "aws-lc-rs", "prefer-post-quantum", "tls12"] }
+rustls-native-certs = "=0.8.4"
+rustls-platform-verifier = "=0.7.0"
+serde = { version = "=1.0.228", features = ["derive"] }
+serde_json = { version = "=1.0.150", features = ["arbitrary_precision", "preserve_order"] }
+sha2 = "=0.11.0"
+socket2 = { version = "=0.6.4", features = ["all"] }
+tar = "=0.4.46"
+thiserror = "=2.0.18"
+time = "=0.3.47"
+tokio = { version = "=1.52.3", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-rustls = { version = "=0.26.4", default-features = false, features = ["aws-lc-rs"] }
+tokio-tungstenite = { version = "=0.29.0", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+tokio-util = { version = "=0.7.18", features = ["io"] }
+tower-service = "=0.3.3"
+url = "=2.5.8"
+webpki-roots = "=1.0.7"
+zip = { version = "=8.6.0", default-features = false, features = ["deflate"] }
+zstd = "=0.13.3"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = "=0.2.186"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }
+windows-sys = { version = "=0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }
 
 [dev-dependencies]
-assert_cmd = "2"
-predicates = "3"
-rcgen = { version = "0.14", features = ["aws_lc_rs"] }
-sha1 = "0.11"
-tempfile = "3"
+assert_cmd = "=2.2.2"
+predicates = "=3.1.4"
+rcgen = { version = "=0.14.8", features = ["aws_lc_rs"] }
+sha1 = "=0.11.0"
+tempfile = "=3.27.0"


### PR DESCRIPTION
## Summary
- Pin every direct dependency in `Cargo.toml` to an exact `x.y.z` version.
- Refresh `Cargo.lock` to the latest Rust 1.96-compatible resolved set.
- Keep feature flags and target-specific dependency sections unchanged.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`