### PR TITLE
Handle broken pipes cleanly on stdout writes

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -195,9 +195,27 @@ pub fn format_enabled(setting: Option<&str>, is_terminal: bool) -> bool {
     Format::from_setting(setting).enabled(is_terminal)
 }
 
-pub fn write_stdout(bytes: impl AsRef<[u8]>) -> std::io::Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StdoutWriteStatus {
+    Open,
+    Closed,
+}
+
+pub fn is_broken_pipe(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::BrokenPipe
+}
+
+pub fn stdout_write_status(result: std::io::Result<()>) -> std::io::Result<StdoutWriteStatus> {
+    match result {
+        Ok(()) => Ok(StdoutWriteStatus::Open),
+        Err(err) if is_broken_pipe(&err) => Ok(StdoutWriteStatus::Closed),
+        Err(err) => Err(err),
+    }
+}
+
+pub fn write_stdout(bytes: impl AsRef<[u8]>) -> std::io::Result<StdoutWriteStatus> {
     let mut stdout = std::io::stdout().lock();
-    stdout.write_all(bytes.as_ref())
+    stdout_write_status(stdout.write_all(bytes.as_ref()))
 }
 
 pub fn bytes_appear_printable(bytes: &[u8]) -> bool {
@@ -548,6 +566,20 @@ mod tests {
         assert!(!format_enabled(None, false));
         assert!(format_enabled(Some("auto"), true));
         assert!(!format_enabled(Some("auto"), false));
+    }
+
+    #[test]
+    fn stdout_write_status_treats_broken_pipe_as_closed() {
+        let err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "stdout closed");
+
+        assert_eq!(
+            stdout_write_status(Err(err)).unwrap(),
+            StdoutWriteStatus::Closed
+        );
+        assert_eq!(
+            stdout_write_status(Ok(())).unwrap(),
+            StdoutWriteStatus::Open
+        );
     }
 
     #[test]

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -215,7 +215,7 @@ pub(super) fn write_stdout_bytes(cli: &Cli, body: &StdoutBody) -> Result<(), Fet
         return write_stdout_bytes_with_pager(&body.bytes);
     }
 
-    std::io::stdout().write_all(&body.bytes)?;
+    core::write_stdout(&body.bytes)?;
     Ok(())
 }
 
@@ -244,7 +244,7 @@ pub(super) fn write_stdout_bytes_with_pager(bytes: &[u8]) -> Result<(), FetchErr
     {
         Ok(child) => child,
         Err(err) if err.kind() == ErrorKind::NotFound => {
-            std::io::stdout().write_all(bytes)?;
+            core::write_stdout(bytes)?;
             return Ok(());
         }
         Err(err) => return Err(err.into()),
@@ -547,8 +547,26 @@ where
     loop {
         let n = reader.read(&mut buf).await?;
         if n == 0 {
-            write_formatted_stream_outputs(&mut stdout, formatter.finish()?, false).await?;
-            stdout.flush().await?;
+            if write_formatted_stream_outputs(&mut stdout, formatter.finish()?, false).await?
+                == core::StdoutWriteStatus::Closed
+            {
+                let clipboard = capture.map(clipboard::Capture::copy);
+                let trailers = captured_trailers(&trailers);
+                return Ok(StreamedOutput {
+                    trailers,
+                    bytes_written: bytes_read,
+                    clipboard,
+                });
+            }
+            if flush_stdout(&mut stdout).await? == core::StdoutWriteStatus::Closed {
+                let clipboard = capture.map(clipboard::Capture::copy);
+                let trailers = captured_trailers(&trailers);
+                return Ok(StreamedOutput {
+                    trailers,
+                    bytes_written: bytes_read,
+                    clipboard,
+                });
+            }
             let clipboard = capture.map(clipboard::Capture::copy);
             let trailers = captured_trailers(&trailers);
             return Ok(StreamedOutput {
@@ -562,7 +580,18 @@ where
             capture.push(&buf[..n]);
         }
         bytes_read = bytes_read.saturating_add(i64::try_from(n).unwrap_or(i64::MAX));
-        write_formatted_stream_outputs(&mut stdout, formatter.push_chunk(&buf[..n])?, true).await?;
+        if write_formatted_stream_outputs(&mut stdout, formatter.push_chunk(&buf[..n])?, true)
+            .await?
+            == core::StdoutWriteStatus::Closed
+        {
+            let clipboard = capture.map(clipboard::Capture::copy);
+            let trailers = captured_trailers(&trailers);
+            return Ok(StreamedOutput {
+                trailers,
+                bytes_written: bytes_read,
+                clipboard,
+            });
+        }
     }
 }
 
@@ -570,17 +599,27 @@ pub(super) async fn write_formatted_stream_outputs(
     stdout: &mut tokio::io::Stdout,
     outputs: Vec<Vec<u8>>,
     flush_after_each: bool,
-) -> Result<(), FetchError> {
+) -> Result<core::StdoutWriteStatus, FetchError> {
     for output in outputs {
         if output.is_empty() {
             continue;
         }
-        stdout.write_all(&output).await?;
-        if flush_after_each {
-            stdout.flush().await?;
+        if core::stdout_write_status(stdout.write_all(&output).await)?
+            == core::StdoutWriteStatus::Closed
+        {
+            return Ok(core::StdoutWriteStatus::Closed);
+        }
+        if flush_after_each && flush_stdout(stdout).await? == core::StdoutWriteStatus::Closed {
+            return Ok(core::StdoutWriteStatus::Closed);
         }
     }
-    Ok(())
+    Ok(core::StdoutWriteStatus::Open)
+}
+
+async fn flush_stdout(
+    stdout: &mut tokio::io::Stdout,
+) -> Result<core::StdoutWriteStatus, FetchError> {
+    Ok(core::stdout_write_status(stdout.flush().await)?)
 }
 
 pub(super) struct FormattedSseStream {
@@ -924,7 +963,7 @@ pub(super) async fn copy_async_reader_to_stdout_target(
         StdoutStreamTarget::Direct => {
             let mut stdout = tokio::io::stdout();
             Ok(
-                copy_async_reader_to_writer_with_prefix(reader, &mut stdout, prefix, capture)
+                copy_async_reader_to_stdout_with_prefix(reader, &mut stdout, prefix, capture)
                     .await?,
             )
         }
@@ -956,6 +995,36 @@ where
     }
 }
 
+pub(super) async fn copy_async_reader_to_stdout<W>(
+    reader: &mut AsyncReadBox,
+    writer: &mut W,
+    mut capture: Option<&mut clipboard::Capture>,
+) -> std::io::Result<i64>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = vec![0; 64 * 1024];
+    let mut written = 0i64;
+    loop {
+        let n = reader.read(&mut buf).await?;
+        if n == 0 {
+            return match core::stdout_write_status(writer.flush().await)? {
+                core::StdoutWriteStatus::Open => Ok(written),
+                core::StdoutWriteStatus::Closed => Ok(written),
+            };
+        }
+        match core::stdout_write_status(writer.write_all(&buf[..n]).await)? {
+            core::StdoutWriteStatus::Open => {
+                if let Some(capture) = capture.as_mut() {
+                    capture.push(&buf[..n]);
+                }
+                written = written.saturating_add(i64::try_from(n).unwrap_or(i64::MAX));
+            }
+            core::StdoutWriteStatus::Closed => return Ok(written),
+        }
+    }
+}
+
 pub(super) async fn copy_async_reader_to_writer_with_prefix<W>(
     reader: &mut AsyncReadBox,
     writer: &mut W,
@@ -976,6 +1045,30 @@ where
     Ok(written.saturating_add(copy_async_reader_to_writer(reader, writer, capture).await?))
 }
 
+pub(super) async fn copy_async_reader_to_stdout_with_prefix<W>(
+    reader: &mut AsyncReadBox,
+    writer: &mut W,
+    prefix: &[u8],
+    mut capture: Option<&mut clipboard::Capture>,
+) -> std::io::Result<i64>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut written = 0i64;
+    if !prefix.is_empty() {
+        match core::stdout_write_status(writer.write_all(prefix).await)? {
+            core::StdoutWriteStatus::Open => {
+                if let Some(capture) = capture.as_mut() {
+                    capture.push(prefix);
+                }
+                written = i64::try_from(prefix.len()).unwrap_or(i64::MAX);
+            }
+            core::StdoutWriteStatus::Closed => return Ok(0),
+        }
+    }
+    Ok(written.saturating_add(copy_async_reader_to_stdout(reader, writer, capture).await?))
+}
+
 pub(super) async fn stream_async_reader_to_pager(
     reader: &mut AsyncReadBox,
     prefix: &[u8],
@@ -991,7 +1084,7 @@ pub(super) async fn stream_async_reader_to_pager(
         Ok(child) => child,
         Err(err) if err.kind() == ErrorKind::NotFound => {
             let mut stdout = tokio::io::stdout();
-            return Ok(copy_async_reader_to_writer_with_prefix(
+            return Ok(copy_async_reader_to_stdout_with_prefix(
                 reader,
                 &mut stdout,
                 prefix,

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -674,10 +674,9 @@ fn write_stdout_message(
         stdout.flush()
     });
 
-    match result {
-        Ok(()) => Ok(MessageOutput::Continue),
-        Err(err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(MessageOutput::Closed),
-        Err(err) => Err(err.into()),
+    match core::stdout_write_status(result)? {
+        core::StdoutWriteStatus::Open => Ok(MessageOutput::Continue),
+        core::StdoutWriteStatus::Closed => Ok(MessageOutput::Closed),
     }
 }
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -53,6 +53,53 @@ fn request_construction_and_data_sources() {
     assert!(req.header("content-length").is_empty());
 }
 
+#[cfg(unix)]
+#[test]
+fn http_stdout_broken_pipe_exits_cleanly() {
+    let body = vec![b'a'; 2 * 1024 * 1024];
+    let server = TestServer::start(move |_| {
+        TestResponse::ok(body.clone()).header("Content-Type", "text/plain")
+    });
+
+    let mut fetch = Command::new(fetch_bin());
+    fetch.arg(server.url.as_str());
+    fetch.stdout(Stdio::piped()).stderr(Stdio::piped());
+    fetch.env("NO_COLOR", "");
+    fetch.env("HTTP_PROXY", "");
+    fetch.env("HTTPS_PROXY", "");
+    fetch.env("ALL_PROXY", "");
+    fetch.env("NO_PROXY", "*");
+
+    let mut fetch_child = fetch.spawn().expect("spawn fetch");
+    let fetch_stdout = fetch_child.stdout.take().expect("fetch stdout");
+    let head_output = Command::new("head")
+        .args(["-c", "1"])
+        .stdin(Stdio::from(fetch_stdout))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run head");
+    let fetch_output = fetch_child.wait_with_output().expect("wait fetch");
+
+    assert!(
+        head_output.status.success(),
+        "head stderr: {:?}",
+        head_output.stderr
+    );
+    assert_eq!(head_output.stdout, b"a");
+    assert_eq!(
+        fetch_output.status.code(),
+        Some(0),
+        "fetch stderr:\n{}",
+        String::from_utf8_lossy(&fetch_output.stderr)
+    );
+    let fetch_stderr = String::from_utf8_lossy(&fetch_output.stderr);
+    assert!(
+        !fetch_stderr.contains("error") && !fetch_stderr.contains("Broken pipe"),
+        "fetch stderr:\n{fetch_stderr}"
+    );
+}
+
 #[test]
 fn duplicate_cli_headers_are_sent_as_separate_wire_lines() {
     let server = TestServer::start(|_| TestResponse::ok("ok"));


### PR DESCRIPTION
## Summary
- Centralized broken-pipe detection in `core` and made stdout writes return a closed/open status.
- Updated HTTP buffered and streaming stdout paths to stop cleanly on closed pipes while keeping output-file writes strict.
- Reused the shared stdout handling in WebSocket output and added an HTTP regression test for `fetch URL | head -c 1`.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test cli --test formatting --test grpc --test http --test network --test terminal --test update --test websocket -- --test-threads=1`