### PR TITLE
Reject TLS key-only config from merged sources

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -171,6 +171,7 @@ ca-cert = /path/to/api-ca.crt
 ### Certificate Formats
 
 - Certificates and keys must be in PEM format
+- TLS requests reject a private key without a client certificate, including values from config files or `--from-curl`
 - Encrypted private keys are not supported
 - Combined PEM files should have the certificate before the key
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -154,6 +154,7 @@ fetch --cert client.crt --key client.key example.com
 ### `--key PATH`
 
 Client private key file for mTLS. Required if `--cert` is a certificate-only file.
+TLS requests reject `--key` without a client certificate.
 
 ```sh
 fetch --cert client.crt --key client.key example.com

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -472,6 +472,7 @@ ca-cert = /path/to/api-ca.crt
 
 - If `cert` is provided without `key`, the tool will attempt to read the private key from the certificate file (combined PEM format)
 - If the private key cannot be found, an error will be displayed
+- TLS requests reject `key` without `cert`
 - Encrypted private keys are not supported
 
 #### `compress`

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -66,6 +66,7 @@ pub(crate) async fn build_client_for_url(
     context: &ClientBuildContext<'_>,
 ) -> Result<UrlClient, FetchError> {
     let http_version = context.mode.http_version();
+    validate_client_auth_for_url(cli, url)?;
     let dns_timeout = TimeoutBudget::for_connect(
         context.connect_timeout,
         context.request_timeout,
@@ -112,6 +113,13 @@ pub(crate) async fn build_client_for_url(
         client: builder.build()?,
         dns_resolution,
     })
+}
+
+fn validate_client_auth_for_url(cli: &Cli, url: &Url) -> Result<(), FetchError> {
+    if url.scheme() == "https" {
+        crate::tls::validate_client_auth_for_tls(cli.cert.as_deref(), cli.key.as_deref())?;
+    }
+    Ok(())
 }
 
 pub(crate) fn configure_unix_socket(

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -22,6 +22,7 @@ use crate::error::{FetchError, write_warning_with_separator_with_color};
 pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let request_start = Instant::now();
     let url = tls_url(cli.url.as_deref().expect("URL checked by app"))?;
+    super::validate_client_auth_for_tls(cli.cert.as_deref(), cli.key.as_deref())?;
     let ignored = ignored_inspection_flags(cli);
     if !ignored.is_empty() && !cli.silent {
         write_warning_with_separator_with_color(

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -268,6 +268,16 @@ pub fn validate_client_key_file(path: &str) -> Result<(), FetchError> {
     validate_client_key(path, &data)
 }
 
+pub(crate) fn validate_client_auth_for_tls(
+    cert_path: Option<&str>,
+    key_path: Option<&str>,
+) -> Result<(), FetchError> {
+    if key_path.is_some() && cert_path.is_none() {
+        return Err("client key requires a client certificate (use --cert)".into());
+    }
+    Ok(())
+}
+
 pub fn client_identity(
     cert_path: Option<&str>,
     key_path: Option<&str>,

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -149,6 +149,7 @@ fn websocket_connector(cli: &Cli, url: &Url) -> Result<Option<Connector>, FetchE
         return Ok(None);
     }
 
+    crate::tls::validate_client_auth_for_tls(cli.cert.as_deref(), cli.key.as_deref())?;
     let min_tls = cli.min_tls.as_deref().or(cli.tls.as_deref()).map(|value| {
         if cli.min_tls.is_some() {
             ("min-tls", value)

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -294,6 +294,13 @@ fn config_error_and_metadata_edges() {
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "key-only-config-ok");
 
+    let res = run_fetch(&["--config", config.to_str().unwrap(), "https://example.com"]);
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr
+            .contains("client key requires a client certificate")
+    );
+
     let config = dir.path().join("tls-config");
     fs::write(&config, "min-tls = 1.2\nmax-tls = 1.2\n").unwrap();
     let res = run_fetch(&[

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -1358,6 +1358,15 @@ fn from_curl_individual_go_cases() {
     ]);
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "key-only-curl-ok");
+    let res = run_fetch(&[
+        "--from-curl",
+        &format!("curl --key {} https://example.com/key-only", key.display()),
+    ]);
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr
+            .contains("client key requires a client certificate")
+    );
     let res = run_fetch(&["--from-curl", &format!("curl -v {}/verbose", server.url)]);
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "ok");


### PR DESCRIPTION
## Summary
- Reject `--key` without `--cert` once the effective request URL is TLS, so config and `--from-curl` values can no longer be silently ignored.
- Apply the same guard to HTTPS requests, WSS handshakes, and TLS inspection paths.
- Document the TLS client-auth requirement in the CLI, config, and authentication docs.

## Testing
- Added regression coverage for HTTPS config key-only failure and HTTPS `--from-curl` key-only failure.
- Existing HTTP key-only compatibility tests still pass.
- Verified with unit tests and the serial integration suite.