### PR TITLE
Bound SSE formatted stream buffer growth

### DIFF
--- a/src/format/sse.rs
+++ b/src/format/sse.rs
@@ -3,10 +3,7 @@ use serde_json::Value;
 use crate::core::{Printer, Sequence};
 
 #[cfg(test)]
-pub(crate) fn format_event_stream(
-    bytes: &[u8],
-    color: bool,
-) -> Result<String, std::str::Utf8Error> {
+pub(crate) fn format_event_stream(bytes: &[u8], color: bool) -> Result<String, EventStreamError> {
     let mut out = Printer::new(color);
     format_event_stream_to(bytes, &mut out)?;
     Ok(out
@@ -14,12 +11,65 @@ pub(crate) fn format_event_stream(
         .expect("event stream formatter output is valid UTF-8"))
 }
 
-pub fn format_event_stream_to(bytes: &[u8], out: &mut Printer) -> Result<(), std::str::Utf8Error> {
+pub fn format_event_stream_to(bytes: &[u8], out: &mut Printer) -> Result<(), EventStreamError> {
     let input = std::str::from_utf8(bytes)?;
     let mut formatter = EventStreamFormatter::new();
-    formatter.push_str(input, out);
-    formatter.finish(out);
-    Ok(())
+    formatter.push_str(input, out)?;
+    formatter.finish(out)
+}
+
+#[derive(Debug)]
+pub enum EventStreamError {
+    InvalidUtf8(std::str::Utf8Error),
+    PendingBufferTooLarge {
+        kind: PendingBufferKind,
+        max_bytes: usize,
+    },
+}
+
+impl std::fmt::Display for EventStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidUtf8(err) => write!(f, "invalid UTF-8 in event stream: {err}"),
+            Self::PendingBufferTooLarge { kind, max_bytes } => write!(
+                f,
+                "SSE {kind} exceeds {max_bytes} bytes and cannot be formatted as a stream"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EventStreamError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidUtf8(err) => Some(err),
+            Self::PendingBufferTooLarge { .. } => None,
+        }
+    }
+}
+
+impl From<std::str::Utf8Error> for EventStreamError {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::InvalidUtf8(err)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum PendingBufferKind {
+    Event,
+    Line,
+    Utf8,
+}
+
+impl std::fmt::Display for PendingBufferKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::Event => "event",
+            Self::Line => "line",
+            Self::Utf8 => "UTF-8 buffer",
+        };
+        f.write_str(label)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -29,6 +79,7 @@ pub struct EventStreamFormatter {
     line: String,
     seen_first_line: bool,
     pending_cr: bool,
+    max_pending_bytes: Option<usize>,
 }
 
 impl EventStreamFormatter {
@@ -36,7 +87,18 @@ impl EventStreamFormatter {
         Self::default()
     }
 
-    pub fn push_str(&mut self, input: &str, out: &mut Printer) {
+    pub fn with_pending_limit(max_pending_bytes: usize) -> Self {
+        Self {
+            max_pending_bytes: Some(max_pending_bytes),
+            ..Self::default()
+        }
+    }
+
+    pub fn max_pending_bytes(&self) -> Option<usize> {
+        self.max_pending_bytes
+    }
+
+    pub fn push_str(&mut self, input: &str, out: &mut Printer) -> Result<(), EventStreamError> {
         for ch in input.chars() {
             if self.pending_cr {
                 self.pending_cr = false;
@@ -46,47 +108,85 @@ impl EventStreamFormatter {
             }
 
             match ch {
-                '\n' => self.process_line(out),
+                '\n' => self.process_line(out)?,
                 '\r' => {
-                    self.process_line(out);
+                    self.process_line(out)?;
                     self.pending_cr = true;
                 }
-                _ => self.line.push(ch),
+                _ => {
+                    self.ensure_pending_line_len(ch.len_utf8())?;
+                    self.line.push(ch);
+                }
             }
         }
+        Ok(())
     }
 
-    pub fn finish(&mut self, out: &mut Printer) {
+    pub fn finish(&mut self, out: &mut Printer) -> Result<(), EventStreamError> {
         if !self.line.is_empty() {
-            self.process_line(out);
+            self.process_line(out)?;
         }
         if !self.data.is_empty() {
             self.dispatch_event(out);
         }
+        Ok(())
     }
 
-    fn process_line(&mut self, out: &mut Printer) {
+    fn ensure_pending_line_len(&self, additional_bytes: usize) -> Result<(), EventStreamError> {
+        if self
+            .max_pending_bytes
+            .is_some_and(|max| self.line.len().saturating_add(additional_bytes) > max)
+        {
+            return Err(EventStreamError::PendingBufferTooLarge {
+                kind: PendingBufferKind::Line,
+                max_bytes: self.max_pending_bytes.unwrap(),
+            });
+        }
+        Ok(())
+    }
+
+    fn ensure_pending_event_len(
+        &self,
+        current_len: usize,
+        additional_bytes: usize,
+    ) -> Result<(), EventStreamError> {
+        if self
+            .max_pending_bytes
+            .is_some_and(|max| current_len.saturating_add(additional_bytes) > max)
+        {
+            return Err(EventStreamError::PendingBufferTooLarge {
+                kind: PendingBufferKind::Event,
+                max_bytes: self.max_pending_bytes.unwrap(),
+            });
+        }
+        Ok(())
+    }
+
+    fn process_line(&mut self, out: &mut Printer) -> Result<(), EventStreamError> {
+        let mut line = std::mem::take(&mut self.line);
         if !self.seen_first_line {
-            if self.line.starts_with('\u{feff}') {
-                self.line.drain(..'\u{feff}'.len_utf8());
+            if line.starts_with('\u{feff}') {
+                line.drain(..'\u{feff}'.len_utf8());
             }
             self.seen_first_line = true;
         }
 
-        if self.line.is_empty() {
+        if line.is_empty() {
             self.dispatch_event(out);
-            return;
+            return Ok(());
         }
 
-        let (name, value) = self.line.split_once(':').unwrap_or((&self.line, ""));
+        let (name, value) = line.split_once(':').unwrap_or((&line, ""));
         if !name.is_empty() {
             let value = value.strip_prefix(' ').unwrap_or(value);
             match name {
                 "event" => {
+                    self.ensure_pending_event_len(0, value.len())?;
                     self.event_type.clear();
                     self.event_type.push_str(value);
                 }
                 "data" => {
+                    self.ensure_pending_event_len(self.data.len(), value.len().saturating_add(1))?;
                     self.data.push_str(value);
                     self.data.push('\n');
                 }
@@ -94,7 +194,7 @@ impl EventStreamFormatter {
                 _ => {}
             }
         }
-        self.line.clear();
+        Ok(())
     }
 
     fn dispatch_event(&mut self, out: &mut Printer) {
@@ -230,12 +330,14 @@ mod tests {
         let mut formatter = EventStreamFormatter::new();
         let mut got = Printer::new(false);
 
-        formatter.push_str("data: {\"a\"", &mut got);
+        formatter.push_str("data: {\"a\"", &mut got).unwrap();
         assert!(got.bytes().is_empty());
-        formatter.push_str(":1}\r\n", &mut got);
+        formatter.push_str(":1}\r\n", &mut got).unwrap();
         assert!(got.bytes().is_empty());
-        formatter.push_str("\nevent: done\ndata: two\n\n", &mut got);
-        formatter.finish(&mut got);
+        formatter
+            .push_str("\nevent: done\ndata: two\n\n", &mut got)
+            .unwrap();
+        formatter.finish(&mut got).unwrap();
         let got = got
             .into_string()
             .expect("event stream formatter output is valid UTF-8");
@@ -253,6 +355,58 @@ mod tests {
         assert_eq!(
             got,
             "\x1b[1m\x1b[36mevent\x1b[0m: ev1\n\x1b[1m\x1b[36mdata\x1b[0m: { \x1b[34m\x1b[1m\"key\"\x1b[0m: \x1b[32m\"val\"\x1b[0m }\n\n"
+        );
+    }
+
+    #[test]
+    fn errors_when_pending_line_exceeds_limit() {
+        let mut formatter = EventStreamFormatter::with_pending_limit(8);
+        let mut got = Printer::new(false);
+
+        let err = formatter.push_str("data: 123", &mut got).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "SSE line exceeds 8 bytes and cannot be formatted as a stream"
+        );
+        assert!(got.bytes().is_empty());
+    }
+
+    #[test]
+    fn errors_when_pending_event_exceeds_limit() {
+        let mut formatter = EventStreamFormatter::with_pending_limit(8);
+        let mut got = Printer::new(false);
+
+        formatter.push_str("data: ab\n", &mut got).unwrap();
+        formatter.push_str("data: cd\n", &mut got).unwrap();
+        let err = formatter.push_str("data: ef\n", &mut got).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "SSE event exceeds 8 bytes and cannot be formatted as a stream"
+        );
+        assert!(got.bytes().is_empty());
+    }
+
+    #[test]
+    fn pending_event_limit_resets_after_dispatch() {
+        let mut formatter = EventStreamFormatter::with_pending_limit(10);
+        let mut got = Printer::new(false);
+
+        formatter
+            .push_str("data: 1234\ndata: 5678\n\n", &mut got)
+            .unwrap();
+        formatter
+            .push_str("data: abcd\ndata: efgh\n\n", &mut got)
+            .unwrap();
+        formatter.finish(&mut got).unwrap();
+        let got = got
+            .into_string()
+            .expect("event stream formatter output is valid UTF-8");
+
+        assert_eq!(
+            got,
+            "event: message\ndata: 1234\ndata: 5678\n\nevent: message\ndata: abcd\ndata: efgh\n\n"
         );
     }
 }

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -630,11 +630,30 @@ pub(super) struct FormattedSseStream {
 
 impl FormattedSseStream {
     fn new(use_color: bool) -> Self {
+        Self::with_pending_limit(use_color, MAX_BUFFERED_RESPONSE_BYTES)
+    }
+
+    fn with_pending_limit(use_color: bool, max_pending_bytes: usize) -> Self {
         Self {
-            formatter: sse::EventStreamFormatter::new(),
+            formatter: sse::EventStreamFormatter::with_pending_limit(max_pending_bytes),
             pending: Vec::new(),
             use_color,
         }
+    }
+
+    fn ensure_pending_utf8_len_within_limit(&self) -> Result<(), FetchError> {
+        if let Some(max) = self.formatter.max_pending_bytes()
+            && self.pending.len() > max
+        {
+            return Err(FetchError::Message(
+                sse::EventStreamError::PendingBufferTooLarge {
+                    kind: sse::PendingBufferKind::Utf8,
+                    max_bytes: max,
+                }
+                .to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -643,20 +662,17 @@ impl StdoutStreamFormatter for FormattedSseStream {
         self.pending.extend_from_slice(chunk);
         let formatted =
             push_sse_stream_bytes(&mut self.pending, &mut self.formatter, self.use_color)
-                .map_err(invalid_sse_utf8_error)?;
+                .map_err(|err| FetchError::Message(err.to_string()))?;
+        self.ensure_pending_utf8_len_within_limit()?;
         Ok(vec![formatted.into_bytes()])
     }
 
     fn finish(&mut self) -> Result<Vec<Vec<u8>>, FetchError> {
         let formatted =
             finish_sse_stream_formatter(&mut self.pending, &mut self.formatter, self.use_color)
-                .map_err(invalid_sse_utf8_error)?;
+                .map_err(|err| FetchError::Message(err.to_string()))?;
         Ok(vec![formatted.into_bytes()])
     }
-}
-
-pub(super) fn invalid_sse_utf8_error(err: std::str::Utf8Error) -> FetchError {
-    FetchError::Message(format!("invalid UTF-8 in event stream: {err}"))
 }
 
 pub(super) struct FormattedNdjsonStream {
@@ -792,12 +808,12 @@ pub(super) fn push_sse_stream_bytes(
     pending: &mut Vec<u8>,
     formatter: &mut sse::EventStreamFormatter,
     use_color: bool,
-) -> Result<String, std::str::Utf8Error> {
+) -> Result<String, sse::EventStreamError> {
     let mut out = core::Printer::new(use_color);
     loop {
         match std::str::from_utf8(pending) {
             Ok(input) => {
-                formatter.push_str(input, &mut out);
+                formatter.push_str(input, &mut out)?;
                 pending.clear();
                 return Ok(out
                     .into_string()
@@ -810,11 +826,13 @@ pub(super) fn push_sse_stream_bytes(
                         .into_string()
                         .expect("event stream formatter output is valid UTF-8"));
                 }
-                let input = std::str::from_utf8(&pending[..valid_up_to])?.to_string();
-                formatter.push_str(&input, &mut out);
+                {
+                    let input = std::str::from_utf8(&pending[..valid_up_to])?;
+                    formatter.push_str(input, &mut out)?;
+                }
                 pending.drain(..valid_up_to);
             }
-            Err(err) => return Err(err),
+            Err(err) => return Err(err.into()),
         }
     }
 }
@@ -823,11 +841,11 @@ pub(super) fn finish_sse_stream_formatter(
     pending: &mut Vec<u8>,
     formatter: &mut sse::EventStreamFormatter,
     use_color: bool,
-) -> Result<String, std::str::Utf8Error> {
+) -> Result<String, sse::EventStreamError> {
     let mut out = core::Printer::new(use_color);
     let chunk = push_sse_stream_bytes(pending, formatter, use_color)?;
     out.push_str(&chunk);
-    formatter.finish(&mut out);
+    formatter.finish(&mut out)?;
     Ok(out
         .into_string()
         .expect("event stream formatter output is valid UTF-8"))
@@ -1745,6 +1763,39 @@ mod tests {
 
         let cli = Cli::try_parse_from(["fetch", "--format", "off", "https://example.com"]).unwrap();
         assert!(!should_stream_formatted_sse_stdout(&cli, &headers, true));
+    }
+
+    #[test]
+    fn formatted_sse_errors_on_oversized_unterminated_event() {
+        let mut formatter = FormattedSseStream::with_pending_limit(false, 8);
+
+        let err = formatter.push_chunk(b"data: 123").unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "SSE line exceeds 8 bytes and cannot be formatted as a stream"
+        );
+    }
+
+    #[test]
+    fn formatted_sse_pending_limit_resets_after_dispatch() {
+        let mut formatter = FormattedSseStream::with_pending_limit(false, 8);
+        let mut got = Vec::new();
+
+        for output in formatter.push_chunk(b"data: ab\ndata: cd\n\n").unwrap() {
+            got.extend(output);
+        }
+        for output in formatter.push_chunk(b"data: ef\ndata: gh\n\n").unwrap() {
+            got.extend(output);
+        }
+        for output in formatter.finish().unwrap() {
+            got.extend(output);
+        }
+
+        assert_eq!(
+            String::from_utf8(got).unwrap(),
+            "event: message\ndata: ab\ndata: cd\n\nevent: message\ndata: ef\ndata: gh\n\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add bounded pending-buffer handling to the SSE formatter so unterminated lines and events cannot grow without limit
- Thread the new fallible SSE formatter API through the HTTP streaming path and reuse the existing response buffer ceiling
- Add unit coverage for oversized pending input and for counter reset after event dispatch

## Testing
- `cargo test --all-features`
- `cargo test --all-features --test cli --test formatting --test grpc --test http --test network --test terminal --test update --test websocket -- --test-threads=1`