### PR TITLE
Limit WebSocket and gRPC request bodies

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -74,6 +74,7 @@ pub(crate) use metadata::{
 pub(crate) use request::{
     RequestBody, RequestBodyPayload, apply_aws_sigv4, apply_builder_authorization_headers,
     aws_config, basic_header, request_body, request_body_into_bytes,
+    request_body_into_bytes_limited,
 };
 #[cfg(test)]
 pub(crate) use request::{request_body_bytes, request_body_content_len, request_body_preview};

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -589,6 +589,19 @@ pub(crate) fn request_body_into_bytes(
     Ok(Some((bytes, content_type)))
 }
 
+pub(crate) fn request_body_into_bytes_limited(
+    body: RequestBody,
+    max_bytes: usize,
+    limit_error: &str,
+) -> Result<MaterializedRequestBody, FetchError> {
+    let Some(body) = body else {
+        return Ok(None);
+    };
+    let content_type = body.content_type.clone();
+    let bytes = request_body_source_to_bytes_limited(body.source, max_bytes, limit_error)?;
+    Ok(Some((bytes, content_type)))
+}
+
 pub(crate) fn request_body_source_to_bytes(
     source: RequestBodySource,
 ) -> Result<Vec<u8>, FetchError> {
@@ -608,6 +621,114 @@ pub(crate) fn request_body_source_to_bytes(
             proto::stream_json_to_grpc_frames(&bytes, &desc)
                 .map_err(|err| FetchError::Message(err.to_string()))
         }
+    }
+}
+
+fn request_body_source_to_bytes_limited(
+    source: RequestBodySource,
+    max_bytes: usize,
+    limit_error: &str,
+) -> Result<Vec<u8>, FetchError> {
+    match source {
+        RequestBodySource::Bytes(bytes) => {
+            ensure_materialized_len(bytes.len(), max_bytes, limit_error)?;
+            Ok(bytes.to_vec())
+        }
+        RequestBodySource::File { path, len } => {
+            ensure_materialized_len_u64(len, max_bytes, limit_error)?;
+            let file = std::fs::File::open(path)?;
+            read_to_end_limited(file, max_bytes, limit_error)
+        }
+        RequestBodySource::Stdin => {
+            let stdin = std::io::stdin();
+            read_to_end_limited(stdin.lock(), max_bytes, limit_error)
+        }
+        RequestBodySource::Multipart(multipart) => {
+            ensure_materialized_len_u64(
+                multipart
+                    .content_len()
+                    .map_err(|err| FetchError::Message(err.to_string()))?,
+                max_bytes,
+                limit_error,
+            )?;
+            let mut out = Vec::new();
+            multipart
+                .write_to(LimitedBytesWriter {
+                    out: &mut out,
+                    limit: max_bytes,
+                    limit_error,
+                })
+                .map_err(|err| FetchError::Message(err.to_string()))?;
+            Ok(out)
+        }
+        RequestBodySource::GrpcJsonStream { source, desc } => {
+            let bytes = request_body_source_to_bytes_limited(*source, max_bytes, limit_error)?;
+            let framed = proto::stream_json_to_grpc_frames(&bytes, &desc)
+                .map_err(|err| FetchError::Message(err.to_string()))?;
+            ensure_materialized_len(framed.len(), max_bytes, limit_error)?;
+            Ok(framed)
+        }
+    }
+}
+
+fn read_to_end_limited<R: Read>(
+    reader: R,
+    max_bytes: usize,
+    limit_error: &str,
+) -> Result<Vec<u8>, FetchError> {
+    let mut out = Vec::new();
+    let read_limit = u64::try_from(max_bytes)
+        .unwrap_or(u64::MAX)
+        .saturating_add(1);
+    reader.take(read_limit).read_to_end(&mut out)?;
+    ensure_materialized_len(out.len(), max_bytes, limit_error)?;
+    Ok(out)
+}
+
+fn ensure_materialized_len(
+    len: usize,
+    max_bytes: usize,
+    limit_error: &str,
+) -> Result<(), FetchError> {
+    if len > max_bytes {
+        return Err(FetchError::Message(limit_error.to_string()));
+    }
+    Ok(())
+}
+
+fn ensure_materialized_len_u64(
+    len: u64,
+    max_bytes: usize,
+    limit_error: &str,
+) -> Result<(), FetchError> {
+    if len > u64::try_from(max_bytes).unwrap_or(u64::MAX) {
+        return Err(FetchError::Message(limit_error.to_string()));
+    }
+    Ok(())
+}
+
+struct LimitedBytesWriter<'a> {
+    out: &'a mut Vec<u8>,
+    limit: usize,
+    limit_error: &'a str,
+}
+
+impl Write for LimitedBytesWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if self
+            .out
+            .len()
+            .checked_add(buf.len())
+            .is_none_or(|len| len > self.limit)
+        {
+            return Err(std::io::Error::other(self.limit_error.to_string()));
+        }
+        self.out.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 
@@ -1067,6 +1188,32 @@ mod tests {
         assert_eq!(
             framed.0,
             crate::grpc::framing::frame(b"hello", false).unwrap()
+        );
+    }
+
+    #[test]
+    fn grpc_request_body_rejects_oversized_file_before_reading() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large.bin");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(crate::grpc::framing::MAX_MESSAGE_SIZE as u64 + 1)
+            .unwrap();
+        let body = Some(RequestBodyPayload {
+            source: RequestBodySource::File {
+                path: path.display().to_string(),
+                len: crate::grpc::framing::MAX_MESSAGE_SIZE as u64 + 1,
+            },
+            content_type: None,
+        });
+
+        let err = proto::grpc_request_body(body, None).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "gRPC request body exceeds maximum of {} bytes",
+                crate::grpc::framing::MAX_MESSAGE_SIZE
+            )
         );
     }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -223,7 +223,10 @@ pub(crate) fn grpc_request_body(
         ));
     }
 
-    let raw = if let Some((bytes, _)) = crate::http::request_body_into_bytes(body)? {
+    let limit_error = grpc_request_body_limit_error();
+    let raw = if let Some((bytes, _)) =
+        crate::http::request_body_into_bytes_limited(body, framing::MAX_MESSAGE_SIZE, &limit_error)?
+    {
         json_to_protobuf(&bytes, &method.input())
             .map_err(|err| FetchError::Message(err.to_string()))?
     } else {
@@ -389,13 +392,25 @@ fn field_type(field: &FieldDescriptor) -> String {
 }
 
 fn frame_raw_body(body: crate::http::RequestBody) -> Result<crate::http::RequestBody, FetchError> {
-    let raw = crate::http::request_body_into_bytes(body)?
-        .map(|(bytes, _)| bytes)
-        .unwrap_or_default();
+    let limit_error = grpc_request_body_limit_error();
+    let raw = crate::http::request_body_into_bytes_limited(
+        body,
+        framing::MAX_MESSAGE_SIZE,
+        &limit_error,
+    )?
+    .map(|(bytes, _)| bytes)
+    .unwrap_or_default();
     Ok(Some(crate::http::RequestBodyPayload::from_bytes(
         framing::frame(&raw, false).map_err(|err| FetchError::Message(err.to_string()))?,
         Some(grpc_content_type()),
     )))
+}
+
+fn grpc_request_body_limit_error() -> String {
+    format!(
+        "gRPC request body exceeds maximum of {} bytes",
+        framing::MAX_MESSAGE_SIZE
+    )
 }
 
 pub fn json_to_protobuf(json: &[u8], desc: &MessageDescriptor) -> Result<Vec<u8>, ProtoError> {

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -290,10 +290,14 @@ fn interactive_for_mode(mode: Option<&str>, all_terms: bool) -> Result<bool, Fet
 }
 
 fn websocket_initial_message(cli: &Cli) -> Result<Option<Vec<u8>>, FetchError> {
-    Ok(
-        crate::http::request_body_into_bytes(crate::http::request_body(cli)?)?
-            .map(|(bytes, _content_type)| bytes),
-    )
+    let limit_error =
+        format!("WebSocket initial message exceeds maximum of {WEBSOCKET_MAX_MESSAGE_BYTES} bytes");
+    Ok(crate::http::request_body_into_bytes_limited(
+        crate::http::request_body(cli)?,
+        WEBSOCKET_MAX_MESSAGE_BYTES,
+        &limit_error,
+    )?
+    .map(|(bytes, _content_type)| bytes))
 }
 
 async fn send_noninteractive_messages<S>(
@@ -1043,6 +1047,26 @@ mod tests {
 
         let err = outgoing_message(vec![0xff], WebSocketMessageMode::Text).unwrap_err();
         assert!(err.to_string().contains("not valid UTF-8"));
+    }
+
+    #[test]
+    fn websocket_initial_message_rejects_oversized_file_before_reading() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large.bin");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(WEBSOCKET_MAX_MESSAGE_BYTES as u64 + 1)
+            .unwrap();
+        let body = format!("@{}", path.display());
+        let cli = Cli::try_parse_from(["fetch", "-d", &body, "ws://example.com"]).unwrap();
+
+        let err = websocket_initial_message(&cli).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "WebSocket initial message exceeds maximum of {WEBSOCKET_MAX_MESSAGE_BYTES} bytes"
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a bounded request-body materializer and use it for WebSocket initial messages and unary/raw gRPC request bodies.
- Prevent oversized `-d @file` or stdin inputs from being fully loaded into memory before existing protocol limits are enforced.
- Add regression tests for oversized file inputs on both paths.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features rejects_oversized_file_before_reading`
- `cargo test --all-features --lib`