### PR TITLE
Fix WebSocket header handling and tighten update archive checks

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -1285,9 +1285,20 @@ fn has_unsafe_windows_archive_component(component: &str) -> bool {
         return true;
     }
 
-    let basename = component
+    let normalized = component.trim_end_matches([' ', '.']);
+    if normalized.len() != component.len() {
+        return true;
+    }
+    let raw_basename = normalized
         .split_once('.')
-        .map_or(component, |(base, _)| base);
+        .map_or(normalized, |(base, _)| base);
+    let basename = raw_basename.trim_end_matches([' ', '.']);
+    if basename.len() != raw_basename.len() {
+        return true;
+    }
+    if basename.is_empty() {
+        return true;
+    }
     let uppercase = basename.to_ascii_uppercase();
     matches!(uppercase.as_str(), "CON" | "PRN" | "AUX" | "NUL")
         || matches!(
@@ -2699,6 +2710,19 @@ mod tests {
             ("alternate data stream", "fetch.exe:ads", true),
             ("reserved device name", "CON", true),
             ("reserved device name with extension", "dir/NUL.txt", true),
+            (
+                "reserved device name with trailing dot",
+                "dir/COM1./fetch.exe",
+                true,
+            ),
+            (
+                "reserved device name with trailing space before extension",
+                "dir/NUL .txt",
+                true,
+            ),
+            ("all-dot windows component", "dir/.../fetch.exe", true),
+            ("trailing-dot component", "fetch.exe.", true),
+            ("trailing-space component", "fetch.exe ", true),
         ];
 
         for (name, filename, want_err) in tests {

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::error::Error as StdError;
 use std::future::Future;
 use std::io::{self, BufRead, Read, Write};
@@ -447,6 +448,7 @@ fn build_handshake_request(
         .into_client_request()
         .map_err(websocket_error)?;
     let headers = handshake_headers(cli, url, session)?;
+    let mut replaced_headers = HashSet::new();
     for (name, value) in &headers {
         let name = WsHeaderName::from_bytes(name.as_str().as_bytes()).map_err(|err| {
             FetchError::Message(format!("invalid header name '{}': {err}", name.as_str()))
@@ -457,7 +459,10 @@ fn build_handshake_request(
                 name.as_str()
             ))
         })?;
-        request.headers_mut().insert(name, value);
+        if replaced_headers.insert(name.clone()) {
+            request.headers_mut().remove(&name);
+        }
+        request.headers_mut().append(name, value);
     }
     Ok(request)
 }
@@ -901,6 +906,40 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("Bearer token")
         );
+    }
+
+    #[test]
+    fn websocket_request_preserves_duplicate_cli_headers_and_replaces_defaults() {
+        let cli = Cli::try_parse_from([
+            "fetch",
+            "-H",
+            "X-Test: one",
+            "-H",
+            "X-Test: two",
+            "-H",
+            "Host: vhost.example",
+            "ws://example.com/socket",
+        ])
+        .unwrap();
+        let request =
+            build_handshake_request(&cli, &Url::parse("ws://example.com/socket").unwrap(), None)
+                .unwrap();
+
+        let values = request
+            .headers()
+            .get_all("x-test")
+            .iter()
+            .map(|value| value.to_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(values, ["one", "two"]);
+
+        let hosts = request
+            .headers()
+            .get_all("host")
+            .iter()
+            .map(|value| value.to_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(hosts, ["vhost.example"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Preserve duplicate WebSocket handshake headers while still replacing generated defaults
- Harden Windows update archive path validation against trailing-space and trailing-dot normalization
- Add unit coverage for both behavior changes

## Testing
- `cargo test --all-features websocket_request_preserves_duplicate_cli_headers_and_replaces_defaults`
- `cargo test --all-features test_unpack_zip_artifact_path_traversal`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`