### PR TITLE
Bound dry-run request body previews

### DIFF
--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -77,6 +77,50 @@ impl Multipart {
         Ok(out)
     }
 
+    pub fn preview(&self, limit: usize) -> Result<(Vec<u8>, bool), MultipartError> {
+        let total_len = self.content_len()?;
+        let truncated = total_len > u64::try_from(limit).unwrap_or(u64::MAX);
+        let capacity = usize::try_from(total_len).unwrap_or(usize::MAX).min(limit);
+        let mut out = Vec::with_capacity(capacity);
+
+        for field in &self.fields {
+            append_preview(&mut out, limit, b"--");
+            append_preview(&mut out, limit, self.boundary.as_bytes());
+            append_preview(&mut out, limit, b"\r\n");
+            if out.len() >= limit {
+                return Ok((out, truncated));
+            }
+
+            match &field.value {
+                FieldValue::Text(value) => {
+                    append_preview(&mut out, limit, text_header(&field.name).as_bytes());
+                    append_preview(&mut out, limit, value.as_bytes());
+                    append_preview(&mut out, limit, b"\r\n");
+                }
+                FieldValue::File(path) => {
+                    append_preview(&mut out, limit, file_header(&field.name, path)?.as_bytes());
+                    if out.len() < limit {
+                        let remaining = limit - out.len();
+                        let mut file = std::fs::File::open(path)?;
+                        Read::by_ref(&mut file)
+                            .take(u64::try_from(remaining).unwrap_or(u64::MAX))
+                            .read_to_end(&mut out)?;
+                    }
+                    append_preview(&mut out, limit, b"\r\n");
+                }
+            }
+
+            if out.len() >= limit {
+                return Ok((out, truncated));
+            }
+        }
+
+        append_preview(&mut out, limit, b"--");
+        append_preview(&mut out, limit, self.boundary.as_bytes());
+        append_preview(&mut out, limit, b"--\r\n");
+        Ok((out, truncated))
+    }
+
     pub fn write_to<W: Write>(&self, mut out: W) -> Result<(), MultipartError> {
         for field in &self.fields {
             out.write_all(b"--")?;
@@ -131,6 +175,11 @@ impl Multipart {
             state: MultipartStreamState::Field,
         }
     }
+}
+
+fn append_preview(out: &mut Vec<u8>, limit: usize, bytes: &[u8]) {
+    let remaining = limit.saturating_sub(out.len());
+    out.extend_from_slice(&bytes[..bytes.len().min(remaining)]);
 }
 
 fn random_boundary() -> String {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -5,6 +5,8 @@ use std::io::Cursor;
 pub(crate) type RequestBody = Option<RequestBodyPayload>;
 pub(crate) type MaterializedRequestBody = Option<(Vec<u8>, Option<String>)>;
 
+const DRY_RUN_BODY_PREVIEW_BYTES: usize = 1024;
+
 #[derive(Debug, Clone)]
 pub(crate) struct RequestBodyPayload {
     pub(super) source: RequestBodySource,
@@ -56,47 +58,22 @@ pub(super) fn print_dry_run_body(cli: &Cli, body: &RequestBody) -> Result<(), Fe
     if cli.verbose < 2 {
         eprintln!();
     }
-    if let Some(materialized) = materialize_dry_run_body(body)? {
-        return print_materialized_dry_run_body(cli, materialized);
-    }
-    let preview = request_body_preview(body)?;
-    if is_printable(&preview) {
-        write_request_body_to_stderr(body)?;
-    } else {
+    let preview = dry_run_body_preview(body, DRY_RUN_BODY_PREVIEW_BYTES)?;
+    if !is_printable(&preview.bytes) {
         print_dry_run_binary_warning(cli);
+        if preview.truncated {
+            print_dry_run_truncation_warning(cli, DRY_RUN_BODY_PREVIEW_BYTES);
+        }
+        return Ok(());
     }
-    Ok(())
-}
 
-enum DryRunMaterializedBody {
-    Bytes(Vec<u8>),
-    BinaryWarning,
-}
-
-fn materialize_dry_run_body(
-    body: &RequestBodyPayload,
-) -> Result<Option<DryRunMaterializedBody>, FetchError> {
-    if !matches!(
-        body.source,
-        RequestBodySource::Stdin | RequestBodySource::GrpcJsonStream { .. }
-    ) {
-        return Ok(None);
-    }
-    let bytes = request_body_source_to_bytes(body.source.clone())?;
-    Ok(Some(if is_printable(&bytes) {
-        DryRunMaterializedBody::Bytes(bytes)
-    } else {
-        DryRunMaterializedBody::BinaryWarning
-    }))
-}
-
-fn print_materialized_dry_run_body(
-    cli: &Cli,
-    body: DryRunMaterializedBody,
-) -> Result<(), FetchError> {
-    match body {
-        DryRunMaterializedBody::Bytes(bytes) => std::io::stderr().write_all(&bytes)?,
-        DryRunMaterializedBody::BinaryWarning => print_dry_run_binary_warning(cli),
+    let mut stderr = std::io::stderr();
+    stderr.write_all(&preview.bytes)?;
+    if preview.truncated {
+        if !preview.bytes.ends_with(b"\n") {
+            stderr.write_all(b"\n")?;
+        }
+        print_dry_run_truncation_warning(cli, DRY_RUN_BODY_PREVIEW_BYTES);
     }
     Ok(())
 }
@@ -104,6 +81,15 @@ fn print_materialized_dry_run_body(
 fn print_dry_run_binary_warning(cli: &Cli) {
     let mut printer = core::Printer::stderr(cli.color.as_deref());
     core::write_warning_msg_no_flush(&mut printer, "the request body appears to be binary");
+    flush_stderr(printer);
+}
+
+fn print_dry_run_truncation_warning(cli: &Cli, limit: usize) {
+    let mut printer = core::Printer::stderr(cli.color.as_deref());
+    core::write_warning_msg_no_flush(
+        &mut printer,
+        format!("the request body preview was truncated after {limit} bytes"),
+    );
     flush_stderr(printer);
 }
 
@@ -732,63 +718,77 @@ impl Write for LimitedBytesWriter<'_> {
     }
 }
 
-pub(crate) fn request_body_preview(body: &RequestBodyPayload) -> Result<Vec<u8>, FetchError> {
-    match &body.source {
-        RequestBodySource::Bytes(bytes) => Ok(bytes.slice(..bytes.len().min(1024)).to_vec()),
-        RequestBodySource::File { path, .. } => read_file_prefix(path, 1024),
-        RequestBodySource::Stdin => Ok(Vec::new()),
-        RequestBodySource::Multipart(multipart) => {
-            let mut out = Vec::new();
-            let mut writer = PrefixWriter {
-                out: &mut out,
-                limit: 1024,
-            };
-            multipart
-                .write_to(&mut writer)
-                .map_err(|err| FetchError::Message(err.to_string()))?;
-            Ok(out)
-        }
-        RequestBodySource::GrpcJsonStream { .. } => {
-            request_body_source_to_bytes(body.source.clone())
-                .map(|bytes| bytes.into_iter().take(1024).collect())
-        }
-    }
+struct DryRunBodyPreview {
+    bytes: Vec<u8>,
+    truncated: bool,
 }
 
-pub(super) fn write_request_body_to_stderr(body: &RequestBodyPayload) -> Result<(), FetchError> {
-    let mut stderr = std::io::stderr();
-    match &body.source {
-        RequestBodySource::Bytes(bytes) => stderr.write_all(bytes)?,
-        RequestBodySource::File { path, .. } => {
-            let mut file = std::fs::File::open(path)?;
-            std::io::copy(&mut file, &mut stderr)?;
-        }
-        RequestBodySource::Stdin => {}
-        RequestBodySource::Multipart(multipart) => multipart
-            .write_to(&mut stderr)
-            .map_err(|err| FetchError::Message(err.to_string()))?,
-        RequestBodySource::GrpcJsonStream { .. } => {
-            stderr.write_all(&request_body_source_to_bytes(body.source.clone())?)?
-        }
-    }
-    Ok(())
-}
-
-pub(super) struct PrefixWriter<'a> {
-    out: &'a mut Vec<u8>,
+fn dry_run_body_preview(
+    body: &RequestBodyPayload,
     limit: usize,
+) -> Result<DryRunBodyPreview, FetchError> {
+    dry_run_source_preview(&body.source, limit)
 }
 
-impl Write for PrefixWriter<'_> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let remaining = self.limit.saturating_sub(self.out.len());
-        self.out.extend_from_slice(&buf[..buf.len().min(remaining)]);
-        Ok(buf.len())
+fn dry_run_source_preview(
+    source: &RequestBodySource,
+    limit: usize,
+) -> Result<DryRunBodyPreview, FetchError> {
+    match source {
+        RequestBodySource::Bytes(bytes) => Ok(DryRunBodyPreview {
+            bytes: bytes.slice(..bytes.len().min(limit)).to_vec(),
+            truncated: bytes.len() > limit,
+        }),
+        RequestBodySource::File { path, len } => Ok(DryRunBodyPreview {
+            bytes: read_file_prefix(path, limit)?,
+            truncated: *len > u64::try_from(limit).unwrap_or(u64::MAX),
+        }),
+        RequestBodySource::Stdin => read_prefix_preview(std::io::stdin().lock(), limit),
+        RequestBodySource::Multipart(multipart) => {
+            let (bytes, truncated) = multipart
+                .preview(limit)
+                .map_err(|err| FetchError::Message(err.to_string()))?;
+            Ok(DryRunBodyPreview { bytes, truncated })
+        }
+        RequestBodySource::GrpcJsonStream { source, desc } => {
+            grpc_json_stream_dry_run_preview(source, desc, limit)
+        }
     }
+}
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
+fn read_prefix_preview<R: Read>(reader: R, limit: usize) -> Result<DryRunBodyPreview, FetchError> {
+    let read_limit = u64::try_from(limit).unwrap_or(u64::MAX).saturating_add(1);
+    let mut limited = reader.take(read_limit);
+    let mut bytes = Vec::new();
+    limited.read_to_end(&mut bytes)?;
+    let truncated = bytes.len() > limit;
+    bytes.truncate(limit);
+    Ok(DryRunBodyPreview { bytes, truncated })
+}
+
+fn grpc_json_stream_dry_run_preview(
+    source: &RequestBodySource,
+    desc: &prost_reflect::MessageDescriptor,
+    limit: usize,
+) -> Result<DryRunBodyPreview, FetchError> {
+    let input = dry_run_source_preview(source, limit)?;
+    if input.truncated {
+        return Ok(DryRunBodyPreview {
+            bytes: vec![0],
+            truncated: true,
+        });
     }
+    let framed = proto::stream_json_to_grpc_frames(&input.bytes, desc)
+        .map_err(|err| FetchError::Message(err.to_string()))?;
+    Ok(DryRunBodyPreview {
+        bytes: framed.iter().copied().take(limit).collect(),
+        truncated: framed.len() > limit,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn request_body_preview(body: &RequestBodyPayload) -> Result<Vec<u8>, FetchError> {
+    dry_run_body_preview(body, DRY_RUN_BODY_PREVIEW_BYTES).map(|preview| preview.bytes)
 }
 
 pub(super) fn apply_body_content_type(headers: &mut HeaderMap, body: &RequestBody) {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -240,6 +240,77 @@ fn dry_run_prints_effective_request_without_network() {
 }
 
 #[test]
+fn dry_run_truncates_large_file_body_preview() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("large.txt");
+    let tail = "FILE_TAIL_SHOULD_NOT_APPEAR";
+    fs::write(&path, format!("{}{}", "a".repeat(2048), tail)).unwrap();
+
+    let data_arg = format!("@{}", path.display());
+    let res = run_fetch(&["localhost:3000", "--data", &data_arg, "--dry-run"]);
+
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(res.stderr.contains(&"a".repeat(1024)));
+    assert!(res.stderr.contains("truncated after 1024 bytes"));
+    assert!(!res.stderr.contains(tail), "stderr:\n{}", res.stderr);
+    assert!(
+        res.stderr.len() < 1800,
+        "dry-run body preview was not bounded:\n{}",
+        res.stderr
+    );
+}
+
+#[test]
+fn dry_run_truncates_large_stdin_body_preview() {
+    let tail = "STDIN_TAIL_SHOULD_NOT_APPEAR";
+    let res = run_fetch_opts(
+        FetchOpts {
+            stdin: Some(format!("{}{}", "s".repeat(2048), tail)),
+            ..Default::default()
+        },
+        &["localhost:3000", "--data", "@-", "--dry-run"],
+    );
+
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(res.stderr.contains(&"s".repeat(1024)));
+    assert!(res.stderr.contains("truncated after 1024 bytes"));
+    assert!(!res.stderr.contains(tail), "stderr:\n{}", res.stderr);
+    assert!(
+        res.stderr.len() < 1800,
+        "dry-run stdin preview was not bounded:\n{}",
+        res.stderr
+    );
+}
+
+#[test]
+fn dry_run_truncates_multipart_file_body_preview() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("part.txt");
+    let tail = "MULTIPART_TAIL_SHOULD_NOT_APPEAR";
+    fs::write(&path, format!("{}{}", "m".repeat(2048), tail)).unwrap();
+
+    let field = format!("file=@{}", path.display());
+    let res = run_fetch(&["localhost:3000", "--multipart", &field, "--dry-run"]);
+
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(res.stderr.contains("multipart/form-data; boundary="));
+    assert!(
+        res.stderr
+            .contains("Content-Disposition: form-data; name=\"file\"; filename=\"part.txt\"")
+    );
+    assert!(res.stderr.contains("truncated after 1024 bytes"));
+    assert!(!res.stderr.contains(tail), "stderr:\n{}", res.stderr);
+    assert!(
+        res.stderr.len() < 1900,
+        "dry-run multipart preview was not bounded:\n{}",
+        res.stderr
+    );
+}
+
+#[test]
 fn default_scheme_loopback_and_presentation_flags() {
     let server = TestServer::start(|req| {
         if req.path != "/?probe=1" && req.path != "/" {


### PR DESCRIPTION
## Summary
- Added a bounded dry-run preview path that prints at most 1024 bytes and emits a truncation warning when the preview is cut off.
- Removed the old dry-run behavior that could fully materialize stdin, gRPC, file, and multipart bodies just to inspect them.
- Added multipart preview support that reads file parts only as far as needed for the preview cap.
- Added regression coverage for large `@file`, `@-`, and multipart file bodies.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test cli --test formatting --test grpc --test http --test network --test terminal --test update --test websocket -- --test-threads=1`