### PR TITLE
Reserve capacity for split gRPC frames

### DIFF
--- a/src/grpc/framing.rs
+++ b/src/grpc/framing.rs
@@ -123,7 +123,7 @@ impl FrameDecoder {
                     });
                 } else {
                     self.current = Some(PartialFrame {
-                        data: Vec::new(),
+                        data: Vec::with_capacity(length),
                         len: length,
                         compressed,
                     });


### PR DESCRIPTION
## Summary
- Initialize split gRPC frame buffers with `Vec::with_capacity(length)` after validating the frame length.
- Avoid repeated reallocations and copies when large messages arrive in chunks.

## Testing
- Unit tests cover the existing framing and split-frame behavior.
- Not run (not requested).