### PR TITLE
Refresh fetch tagline and project description

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,12 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Project Overview
 
-`fetch` is a modern HTTP(S) client CLI implemented as the Rust Cargo binary
-named `fetch`. It features automatic response formatting (JSON, XML, YAML,
-HTML, CSS, CSV, protobuf, msgpack), image rendering in terminals, gRPC support
-with reflection/discovery and JSON-to-protobuf conversion, and authentication
-(Basic, Digest, Bearer, AWS SigV4).
+`fetch` is a terminal-native API client implemented as the Rust Cargo binary
+named `fetch`. It covers requests, streams, and network debugging with
+automatic response formatting (JSON, XML, YAML, HTML, CSS, CSV, protobuf,
+msgpack), image rendering in terminals, gRPC support with reflection/discovery
+and JSON-to-protobuf conversion, WebSockets, DNS/TLS inspection, timing, and
+authentication (Basic, Digest, Bearer, AWS SigV4).
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # fetch
 
-A modern HTTP(S) client for the command line.
+A terminal API client for requests, streams, and network debugging.
 
 ![Example of fetch with an image and JSON responses](./assets/example.png)
 
-`fetch` is built for the parts of API work that usually require several
-separate tools: formatted HTTP responses, terminal image rendering, WebSockets,
-gRPC reflection and calls, DNS inspection, TLS certificate inspection, and
-request timing.
+`fetch` combines formatted HTTP responses, terminal image rendering,
+WebSockets, gRPC reflection and calls, DNS inspection, TLS certificate
+inspection, and request timing in one CLI.
 
 ## Features
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,7 +100,7 @@ impl PagerMode {
 #[derive(Debug, Parser)]
 #[command(
     name = "fetch",
-    about = "fetch is a modern HTTP(S) client for the command line",
+    about = "A terminal-native API client for HTTP, gRPC, WebSockets, and network debugging.",
     disable_help_flag = true,
     disable_version_flag = true
 )]


### PR DESCRIPTION
## Summary
- Replace the generic README hero tagline with a clearer positioning line
- Update the CLI `about` text to match the new terminal-native API client framing
- Refresh `AGENTS.md` project overview so repo guidance reflects the new copy

## Testing
- Not run (not requested)