### PR TITLE
Refactor shared file lock handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - **src/cli** - Command-line argument parsing, shell completion, and `--from-curl` support.
 - **src/config** - INI-format config file parsing with host-specific overrides.
 - **src/core.rs** - Shared printer, color, format, and terminal utilities.
+- **src/fileutil.rs** - Atomic file replacement and shared cross-platform advisory file locks.
 - **src/dns** - DNS-over-HTTPS, UDP DNS, system resolver fallback, and `--inspect-dns`.
 - **src/format** - Response body formatters for JSON, XML, YAML, HTML, CSS, CSV, Markdown, msgpack, protobuf, SSE, NDJSON, gRPC, and images.
 - **src/grpc** - gRPC framing, reflection, status handling, and protobuf request/response support.
@@ -143,6 +144,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - Clipboard command execution is bounded while stdin is written and while waiting for exit; `--copy` kills a clipboard backend that does not finish within the short wait timeout and reports a warning instead of hanging indefinitely.
 - Named session saves take a per-session advisory lock, reload the latest JSON, and merge only local cookie creates/updates/deletes before atomic replacement so concurrent `--session` invocations preserve distinct cookie changes. Session saves use a short bounded lock wait and report a warning instead of hanging indefinitely when another process keeps the session lock.
 - Explicit self-updates use a bounded update-lock wait capped by the request timeout or the fixed update-lock timeout; background auto-update checks keep using nonblocking lock acquisition.
+- Session and update lock acquisition should go through `fileutil::FileLock` so cross-platform open/retry/flock/LockFileEx/unlock behavior stays centralized while call sites own their timeout diagnostics.
 - Self-update release metadata, artifact, checksum, and redirect-target URLs require HTTPS by default; only internal update/test overrides such as an `http://` `FETCH_INTERNAL_UPDATE_URL` may use HTTP for local fixtures.
 - Output-file downloads keep `*.download` temp files behind a drop guard so cancellation paths such as Ctrl-C clean up partial files; Unix atomic installs also sync the parent directory after rename/link updates for stronger crash durability.
 - Self-updates stream release artifacts while calculating SHA-256 on the fly: `.tar.gz`/`.tgz` artifacts unpack directly into the update temp directory through a bounded reader, while `.zip` artifacts stream to a temp archive file first because zip extraction needs seekable input. Non-Windows replacement copies the new executable into the target directory before calling `fileutil::atomic_replace_file` so Unix parent-directory syncs are preserved.

--- a/src/fileutil.rs
+++ b/src/fileutil.rs
@@ -1,5 +1,7 @@
 use std::io;
 use std::path::Path;
+use std::thread;
+use std::time::{Duration, Instant};
 
 #[cfg(windows)]
 use std::iter;
@@ -23,6 +25,87 @@ pub fn atomic_write_new_file(
     target_path: impl AsRef<Path>,
 ) -> io::Result<()> {
     atomic_write_new_file_impl(temp_path.as_ref(), target_path.as_ref())
+}
+
+#[derive(Debug)]
+pub struct FileLock {
+    file: std::fs::File,
+}
+
+impl FileLock {
+    pub fn try_acquire(path: impl AsRef<Path>) -> io::Result<Option<Self>> {
+        let file = open_lock_file(path.as_ref())?;
+        if try_lock_file(&file)? {
+            Ok(Some(Self { file }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn acquire_with_timeout<E, F, G>(
+        path: impl AsRef<Path>,
+        timeout: Duration,
+        on_contention: F,
+        timeout_error: G,
+    ) -> Result<Self, E>
+    where
+        E: From<io::Error>,
+        F: FnMut(),
+        G: FnOnce(Duration) -> E,
+    {
+        acquire_lock_with_timeout(path.as_ref(), timeout, on_contention, timeout_error)
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        let _ = unlock_file(&self.file);
+    }
+}
+
+fn acquire_lock_with_timeout<E, F, G>(
+    path: &Path,
+    timeout: Duration,
+    mut on_contention: F,
+    timeout_error: G,
+) -> Result<FileLock, E>
+where
+    E: From<io::Error>,
+    F: FnMut(),
+    G: FnOnce(Duration) -> E,
+{
+    let file = open_lock_file(path).map_err(E::from)?;
+    let started_at = Instant::now();
+
+    for attempt in 0.. {
+        if try_lock_file(&file).map_err(E::from)? {
+            return Ok(FileLock { file });
+        }
+        if started_at.elapsed() >= timeout {
+            return Err(timeout_error(timeout));
+        }
+
+        if attempt == 0 {
+            on_contention();
+        }
+        let multiplier = (attempt + 1).min(10) as u64;
+        let sleep = Duration::from_millis(multiplier * 50);
+        let remaining = timeout.saturating_sub(started_at.elapsed());
+        thread::sleep(sleep.min(remaining));
+    }
+
+    unreachable!("file lock acquisition loop is unbounded by the iterator")
+}
+
+fn open_lock_file(path: &Path) -> io::Result<std::fs::File> {
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
 }
 
 #[cfg(not(windows))]
@@ -81,9 +164,188 @@ fn sync_parent_dir(path: &Path) -> io::Result<()> {
     std::fs::File::open(dir)?.sync_all()
 }
 
+#[cfg(unix)]
+fn try_lock_file(file: &std::fs::File) -> io::Result<bool> {
+    use std::os::fd::AsRawFd;
+
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc == 0 {
+        return Ok(true);
+    }
+
+    let err = io::Error::last_os_error();
+    if err.raw_os_error() == Some(libc::EWOULDBLOCK) || err.raw_os_error() == Some(libc::EAGAIN) {
+        Ok(false)
+    } else {
+        Err(err)
+    }
+}
+
+#[cfg(unix)]
+fn unlock_file(file: &std::fs::File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(windows)]
+fn try_lock_file(file: &std::fs::File) -> io::Result<bool> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::ERROR_LOCK_VIOLATION;
+    use windows_sys::Win32::Storage::FileSystem::{
+        LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
+    };
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let mut overlapped = OVERLAPPED::default();
+    // SAFETY: the file handle is valid for this File and overlapped points to writable storage.
+    let ok = unsafe {
+        LockFileEx(
+            file.as_raw_handle(),
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            u32::MAX,
+            u32::MAX,
+            &mut overlapped,
+        )
+    };
+    if ok != 0 {
+        return Ok(true);
+    }
+
+    let err = io::Error::last_os_error();
+    if err.raw_os_error() == Some(ERROR_LOCK_VIOLATION as i32) {
+        Ok(false)
+    } else {
+        Err(err)
+    }
+}
+
+#[cfg(windows)]
+fn unlock_file(file: &std::fs::File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::UnlockFileEx;
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let mut overlapped = OVERLAPPED::default();
+    // SAFETY: the file handle is valid for this File and overlapped points to writable storage.
+    let ok = unsafe { UnlockFileEx(file.as_raw_handle(), 0, u32::MAX, u32::MAX, &mut overlapped) };
+    if ok != 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn try_lock_file(_file: &std::fs::File) -> io::Result<bool> {
+    Ok(true)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn unlock_file(_file: &std::fs::File) -> io::Result<()> {
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn file_lock_try_acquire_returns_none_when_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("held.lock");
+        let _held = FileLock::try_acquire(&path).unwrap().unwrap();
+
+        assert!(FileLock::try_acquire(&path).unwrap().is_none());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn file_lock_acquire_with_timeout_returns_mapped_timeout_when_held() {
+        #[derive(Debug, PartialEq, Eq)]
+        enum TestError {
+            Io(String),
+            Timeout(Duration),
+        }
+
+        impl From<io::Error> for TestError {
+            fn from(err: io::Error) -> Self {
+                Self::Io(err.to_string())
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("held.lock");
+        let _held = FileLock::try_acquire(&path).unwrap().unwrap();
+        let started_at = Instant::now();
+
+        let err = FileLock::acquire_with_timeout(
+            &path,
+            Duration::from_millis(10),
+            || {},
+            TestError::Timeout,
+        )
+        .unwrap_err();
+
+        assert_eq!(err, TestError::Timeout(Duration::from_millis(10)));
+        assert!(started_at.elapsed() < Duration::from_secs(1));
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn file_lock_acquire_with_timeout_calls_contention_hook_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("held.lock");
+        let _held = FileLock::try_acquire(&path).unwrap().unwrap();
+        let mut contentions = 0;
+
+        let result: Result<FileLock, io::Error> = FileLock::acquire_with_timeout(
+            &path,
+            Duration::from_millis(10),
+            || {
+                contentions += 1;
+            },
+            |timeout| io::Error::new(io::ErrorKind::TimedOut, format!("{timeout:?}")),
+        );
+
+        assert!(result.is_err());
+        assert_eq!(contentions, 1);
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn file_lock_acquire_with_timeout_waits_until_lock_is_released() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("held.lock");
+        let held = FileLock::try_acquire(&path).unwrap().unwrap();
+        let path_for_waiter = path.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        let join = std::thread::spawn(move || {
+            FileLock::acquire_with_timeout(
+                path_for_waiter,
+                Duration::from_secs(2),
+                || {
+                    let _ = tx.send(());
+                },
+                |timeout| io::Error::new(io::ErrorKind::TimedOut, format!("{timeout:?}")),
+            )
+        });
+
+        rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        drop(held);
+        let waited_lock = join.join().unwrap().unwrap();
+        drop(waited_lock);
+
+        assert!(FileLock::try_acquire(&path).unwrap().is_some());
+    }
 
     #[test]
     fn test_atomic_replace_file_replaces_existing_file() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,8 +2,7 @@ use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
-use std::thread;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
 use cookie::{Cookie as RawCookie, SameSite};
@@ -14,6 +13,8 @@ use thiserror::Error;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 use url::Url;
+
+use crate::fileutil::FileLock;
 
 #[derive(Debug, Error)]
 pub enum SessionError {
@@ -506,45 +507,22 @@ fn session_cookie_map(
         .collect()
 }
 
-struct SessionLock {
-    file: std::fs::File,
-}
-
-impl Drop for SessionLock {
-    fn drop(&mut self) {
-        let _ = unlock_session_file(&self.file);
-    }
-}
-
-fn acquire_session_lock(path: &Path) -> Result<SessionLock, SessionError> {
+fn acquire_session_lock(path: &Path) -> Result<FileLock, SessionError> {
     acquire_session_lock_with_timeout(path, SESSION_LOCK_WAIT_TIMEOUT)
 }
 
 fn acquire_session_lock_with_timeout(
     path: &Path,
     timeout: Duration,
-) -> Result<SessionLock, SessionError> {
+) -> Result<FileLock, SessionError> {
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
     create_sessions_dir(dir)?;
-    let file = open_session_lock_file(&session_lock_path(path))?;
-    let started_at = Instant::now();
-
-    for attempt in 0.. {
-        if try_lock_session_file(&file)? {
-            return Ok(SessionLock { file });
-        }
-        if started_at.elapsed() >= timeout {
-            return Err(SessionError::LockTimeout(
-                crate::duration::format_go_duration(timeout),
-            ));
-        }
-        let multiplier = (attempt + 1).min(10) as u64;
-        let sleep = Duration::from_millis(multiplier * 50);
-        let remaining = timeout.saturating_sub(started_at.elapsed());
-        thread::sleep(sleep.min(remaining));
-    }
-
-    unreachable!("session lock acquisition loop is unbounded by the iterator")
+    FileLock::acquire_with_timeout(
+        session_lock_path(path),
+        timeout,
+        || {},
+        |timeout| SessionError::LockTimeout(crate::duration::format_go_duration(timeout)),
+    )
 }
 
 fn session_lock_path(path: &Path) -> PathBuf {
@@ -553,105 +531,6 @@ fn session_lock_path(path: &Path) -> PathBuf {
         .map(|name| name.to_string_lossy())
         .unwrap_or_else(|| "session.json".into());
     path.with_file_name(format!(".{name}.lock"))
-}
-
-fn open_session_lock_file(path: &Path) -> Result<std::fs::File, SessionError> {
-    let mut options = std::fs::OpenOptions::new();
-    options.create(true).read(true).write(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    Ok(options.open(path)?)
-}
-
-#[cfg(unix)]
-fn try_lock_session_file(file: &std::fs::File) -> Result<bool, SessionError> {
-    use std::os::fd::AsRawFd;
-
-    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-    if rc == 0 {
-        return Ok(true);
-    }
-
-    let err = std::io::Error::last_os_error();
-    if err.raw_os_error() == Some(libc::EWOULDBLOCK) || err.raw_os_error() == Some(libc::EAGAIN) {
-        Ok(false)
-    } else {
-        Err(err.into())
-    }
-}
-
-#[cfg(unix)]
-fn unlock_session_file(file: &std::fs::File) -> Result<(), SessionError> {
-    use std::os::fd::AsRawFd;
-
-    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
-    if rc == 0 {
-        Ok(())
-    } else {
-        Err(std::io::Error::last_os_error().into())
-    }
-}
-
-#[cfg(windows)]
-fn try_lock_session_file(file: &std::fs::File) -> Result<bool, SessionError> {
-    use std::os::windows::io::AsRawHandle;
-    use windows_sys::Win32::Foundation::ERROR_LOCK_VIOLATION;
-    use windows_sys::Win32::Storage::FileSystem::{
-        LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
-    };
-    use windows_sys::Win32::System::IO::OVERLAPPED;
-
-    let mut overlapped = OVERLAPPED::default();
-    // SAFETY: the file handle is valid for this File and overlapped points to writable storage.
-    let ok = unsafe {
-        LockFileEx(
-            file.as_raw_handle(),
-            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
-            0,
-            u32::MAX,
-            u32::MAX,
-            &mut overlapped,
-        )
-    };
-    if ok != 0 {
-        return Ok(true);
-    }
-
-    let err = std::io::Error::last_os_error();
-    if err.raw_os_error() == Some(ERROR_LOCK_VIOLATION as i32) {
-        Ok(false)
-    } else {
-        Err(err.into())
-    }
-}
-
-#[cfg(windows)]
-fn unlock_session_file(file: &std::fs::File) -> Result<(), SessionError> {
-    use std::os::windows::io::AsRawHandle;
-    use windows_sys::Win32::Storage::FileSystem::UnlockFileEx;
-    use windows_sys::Win32::System::IO::OVERLAPPED;
-
-    let mut overlapped = OVERLAPPED::default();
-    // SAFETY: the file handle is valid for this File and overlapped points to writable storage.
-    let ok = unsafe { UnlockFileEx(file.as_raw_handle(), 0, u32::MAX, u32::MAX, &mut overlapped) };
-    if ok != 0 {
-        Ok(())
-    } else {
-        Err(std::io::Error::last_os_error().into())
-    }
-}
-
-#[cfg(not(any(unix, windows)))]
-fn try_lock_session_file(_file: &std::fs::File) -> Result<bool, SessionError> {
-    Ok(true)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn unlock_session_file(_file: &std::fs::File) -> Result<(), SessionError> {
-    Ok(())
 }
 
 fn atomic_write(path: &Path, data: &[u8]) -> Result<(), SessionError> {
@@ -702,6 +581,7 @@ fn is_false(value: &bool) -> bool {
 mod tests {
     use super::*;
     use std::sync::{Mutex, MutexGuard};
+    use std::time::Instant;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,7 +1,6 @@
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use flate2::read::GzDecoder;
@@ -19,6 +18,7 @@ use crate::cli::Cli;
 use crate::core;
 use crate::duration::{TimeoutBudget, duration_from_seconds, format_go_duration};
 use crate::error::{FetchError, write_warning_with_separator_with_color};
+use crate::fileutil::FileLock;
 use crate::http::{client, transport};
 use crate::output::progress::{self, BarCounter, ProgressPrinter, SpinnerCounter};
 
@@ -1762,22 +1762,12 @@ fn update_last_attempt_time(dir: &Path, now: SystemTime) -> Result<(), FetchErro
     Ok(())
 }
 
-struct UpdateLock {
-    file: std::fs::File,
-}
-
-impl Drop for UpdateLock {
-    fn drop(&mut self) {
-        let _ = unlock_file(&self.file);
-    }
-}
-
 fn acquire_update_lock(
     dir: &Path,
     block: bool,
     silent: bool,
     color: Option<&str>,
-) -> Result<Option<UpdateLock>, FetchError> {
+) -> Result<Option<FileLock>, FetchError> {
     acquire_update_lock_with_timeout(dir, block, silent, color, UPDATE_LOCK_WAIT_TIMEOUT)
 }
 
@@ -1787,32 +1777,24 @@ fn acquire_update_lock_with_timeout(
     silent: bool,
     color: Option<&str>,
     timeout: Duration,
-) -> Result<Option<UpdateLock>, FetchError> {
+) -> Result<Option<FileLock>, FetchError> {
     std::fs::create_dir_all(dir)?;
-    let file = open_lock_file(&dir.join(".update-lock"))?;
-    let started_at = Instant::now();
-
-    for attempt in 0.. {
-        if try_lock_file(&file)? {
-            return Ok(Some(UpdateLock { file }));
-        }
-        if !block {
-            return Ok(None);
-        }
-        if started_at.elapsed() >= timeout {
-            return Err(update_lock_timeout_error(timeout));
-        }
-
-        if attempt == 0 && !silent {
-            write_warning_with_separator_with_color("waiting on lock to begin updating", color);
-        }
-        let multiplier = (attempt + 1).min(10) as u64;
-        let sleep = Duration::from_millis(multiplier * 50);
-        let remaining = timeout.saturating_sub(started_at.elapsed());
-        thread::sleep(sleep.min(remaining));
+    let path = dir.join(".update-lock");
+    if !block {
+        return FileLock::try_acquire(path).map_err(FetchError::from);
     }
 
-    unreachable!("update lock acquisition loop is unbounded by the iterator")
+    FileLock::acquire_with_timeout(
+        path,
+        timeout,
+        || {
+            if !silent {
+                write_warning_with_separator_with_color("waiting on lock to begin updating", color);
+            }
+        },
+        update_lock_timeout_error,
+    )
+    .map(Some)
 }
 
 fn update_lock_wait_timeout(request_timeout: Option<Duration>) -> Duration {
@@ -1826,105 +1808,6 @@ fn update_lock_timeout_error(timeout: Duration) -> FetchError {
         "timed out waiting for update lock after {}",
         format_go_duration(timeout)
     ))
-}
-
-fn open_lock_file(path: &Path) -> Result<std::fs::File, FetchError> {
-    let mut options = std::fs::OpenOptions::new();
-    options.create(true).read(true).write(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    Ok(options.open(path)?)
-}
-
-#[cfg(unix)]
-fn try_lock_file(file: &std::fs::File) -> Result<bool, FetchError> {
-    use std::os::fd::AsRawFd;
-
-    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-    if rc == 0 {
-        return Ok(true);
-    }
-
-    let err = std::io::Error::last_os_error();
-    if err.raw_os_error() == Some(libc::EWOULDBLOCK) || err.raw_os_error() == Some(libc::EAGAIN) {
-        Ok(false)
-    } else {
-        Err(err.into())
-    }
-}
-
-#[cfg(unix)]
-fn unlock_file(file: &std::fs::File) -> Result<(), FetchError> {
-    use std::os::fd::AsRawFd;
-
-    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
-    if rc == 0 {
-        Ok(())
-    } else {
-        Err(std::io::Error::last_os_error().into())
-    }
-}
-
-#[cfg(windows)]
-fn try_lock_file(file: &std::fs::File) -> Result<bool, FetchError> {
-    use std::os::windows::io::AsRawHandle;
-    use windows_sys::Win32::Foundation::ERROR_LOCK_VIOLATION;
-    use windows_sys::Win32::Storage::FileSystem::{
-        LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
-    };
-    use windows_sys::Win32::System::IO::OVERLAPPED;
-
-    let mut overlapped = OVERLAPPED::default();
-    // SAFETY: the file handle is valid for this File and overlapped points to writable storage.
-    let ok = unsafe {
-        LockFileEx(
-            file.as_raw_handle(),
-            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
-            0,
-            u32::MAX,
-            u32::MAX,
-            &mut overlapped,
-        )
-    };
-    if ok != 0 {
-        return Ok(true);
-    }
-
-    let err = std::io::Error::last_os_error();
-    if err.raw_os_error() == Some(ERROR_LOCK_VIOLATION as i32) {
-        Ok(false)
-    } else {
-        Err(err.into())
-    }
-}
-
-#[cfg(windows)]
-fn unlock_file(file: &std::fs::File) -> Result<(), FetchError> {
-    use std::os::windows::io::AsRawHandle;
-    use windows_sys::Win32::Storage::FileSystem::UnlockFileEx;
-    use windows_sys::Win32::System::IO::OVERLAPPED;
-
-    let mut overlapped = OVERLAPPED::default();
-    // SAFETY: the file handle is valid for this File and overlapped points to writable storage.
-    let ok = unsafe { UnlockFileEx(file.as_raw_handle(), 0, u32::MAX, u32::MAX, &mut overlapped) };
-    if ok != 0 {
-        Ok(())
-    } else {
-        Err(std::io::Error::last_os_error().into())
-    }
-}
-
-#[cfg(not(any(unix, windows)))]
-fn try_lock_file(_file: &std::fs::File) -> Result<bool, FetchError> {
-    Ok(true)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn unlock_file(_file: &std::fs::File) -> Result<(), FetchError> {
-    Ok(())
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Centralize cross-platform advisory lock open/retry/unlock logic in `src/fileutil.rs` with a reusable `FileLock` helper
- Switch session and update lock paths to use the shared helper while preserving their existing timeout and warning behavior
- Add regression tests for nonblocking acquisition, timeout mapping, contention hooks, and successful blocking acquisition after release
- Update `AGENTS.md` to document the shared lock owner

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test cli --test formatting --test grpc --test http --test network --test terminal --test update --test websocket -- --test-threads=1`