### PR TITLE
Centralize stderr status rendering through core::Printer

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -432,6 +432,32 @@ pub fn write_warning_separator_no_flush(printer: &mut Printer) {
     printer.push('\n');
 }
 
+pub fn write_status_msg_no_flush(printer: &mut Printer, msg: impl fmt::Display) {
+    printer.push_str(&msg.to_string());
+}
+
+pub fn write_status_line_no_flush(printer: &mut Printer, msg: impl fmt::Display) {
+    write_status_msg_no_flush(printer, msg);
+    printer.push('\n');
+}
+
+pub fn write_status_with_color(msg: impl fmt::Display, color: Option<&str>) {
+    let mut printer = Printer::stderr(color);
+    write_status_msg_no_flush(&mut printer, msg);
+    flush_stderr(printer);
+}
+
+pub fn write_status_line_with_color(msg: impl fmt::Display, color: Option<&str>) {
+    let mut printer = Printer::stderr(color);
+    write_status_line_no_flush(&mut printer, msg);
+    flush_stderr(printer);
+}
+
+pub fn flush_stderr(mut printer: Printer) {
+    let mut stderr = std::io::stderr();
+    let _ = printer.flush_to(&mut stderr);
+}
+
 impl std::io::Write for Printer {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.buf.extend_from_slice(buf);
@@ -676,6 +702,21 @@ mod tests {
         assert_eq!(
             printer.into_string().unwrap(),
             "warning: one\nwarning: two\n\nnext\n"
+        );
+    }
+
+    #[test]
+    fn status_helpers_write_plain_text_without_labels() {
+        let mut printer = Printer::new(false);
+        write_status_msg_no_flush(&mut printer, "Fetching latest release...\n");
+        write_status_line_no_flush(
+            &mut printer,
+            format_args!("Updated fetch: {} -> {}", "v1", "v2"),
+        );
+
+        assert_eq!(
+            printer.into_string().unwrap(),
+            "Fetching latest release...\nUpdated fetch: v1 -> v2\n"
         );
     }
 }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -56,7 +56,9 @@ pub(super) fn print_dry_run_body(cli: &Cli, body: &RequestBody) -> Result<(), Fe
         return Ok(());
     };
     if cli.verbose < 2 {
-        eprintln!();
+        let mut printer = core::Printer::stderr(cli.color.as_deref());
+        core::write_status_line_no_flush(&mut printer, "");
+        flush_stderr(printer);
     }
     let preview = dry_run_body_preview(body, DRY_RUN_BODY_PREVIEW_BYTES)?;
     if !is_printable(&preview.bytes) {

--- a/src/http/retry.rs
+++ b/src/http/retry.rs
@@ -429,10 +429,33 @@ pub(super) fn print_retry(
         return;
     }
 
-    let prefix = if cli.verbose >= 2 { "* " } else { "" };
-    eprintln!(
-        "{prefix}retry: attempt {next_attempt}/{total_attempts} in {} ({reason})",
-        format_delay(delay)
+    let mut printer = core::Printer::stderr(cli.color.as_deref());
+    write_retry_to(
+        &mut printer,
+        cli.verbose,
+        next_attempt,
+        total_attempts,
+        delay,
+        reason,
+    );
+    core::flush_stderr(printer);
+}
+
+fn write_retry_to(
+    printer: &mut core::Printer,
+    verbosity: u8,
+    next_attempt: usize,
+    total_attempts: usize,
+    delay: Duration,
+    reason: &str,
+) {
+    if verbosity >= 2 {
+        printer.write_info_prefix();
+    }
+    let delay = format_delay(delay);
+    core::write_status_line_no_flush(
+        printer,
+        format_args!("retry: attempt {next_attempt}/{total_attempts} in {delay} ({reason})"),
     );
 }
 
@@ -518,6 +541,42 @@ mod tests {
         assert_eq!(format_delay(Duration::from_millis(250)), "250ms");
         assert_eq!(format_delay(Duration::from_millis(2500)), "2.5s");
         assert_eq!(format_delay(Duration::from_secs(1)), "1.0s");
+    }
+
+    #[test]
+    fn retry_status_renders_through_printer() {
+        let mut printer = core::Printer::new(false);
+        write_retry_to(
+            &mut printer,
+            0,
+            2,
+            3,
+            Duration::from_millis(250),
+            "HTTP 503",
+        );
+
+        assert_eq!(
+            printer.into_string().unwrap(),
+            "retry: attempt 2/3 in 250ms (HTTP 503)\n"
+        );
+    }
+
+    #[test]
+    fn retry_debug_prefix_uses_printer_styling() {
+        let mut printer = core::Printer::new(true);
+        write_retry_to(
+            &mut printer,
+            2,
+            2,
+            3,
+            Duration::from_secs(1),
+            "connection failed",
+        );
+
+        assert_eq!(
+            printer.into_string().unwrap(),
+            "\x1b[2m* \x1b[0mretry: attempt 2/3 in 1.0s (connection failed)\n"
+        );
     }
 
     #[test]

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -36,7 +36,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
         lock_timeout,
     )?
     .ok_or_else(|| FetchError::Message("unable to acquire update lock".to_string()))?;
-    let result = update_inner(&client, cli.silent, cli.dry_run).await;
+    let result = update_inner(&client, cli.silent, cli.color.as_deref(), cli.dry_run).await;
     record_last_attempt_time(&cache_dir);
     result?;
     Ok(0)
@@ -45,6 +45,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
 async fn update_inner(
     client: &UpdateClient<'_>,
     silent: bool,
+    color: Option<&str>,
     dry_run: bool,
 ) -> Result<(), FetchError> {
     let exe_path = current_exe()?;
@@ -57,20 +58,24 @@ async fn update_inner(
     }
     let version = core::version();
 
-    write_msg(silent, "Fetching latest release...\n");
+    write_update_status(silent, color, "Fetching latest release...\n");
     let latest = latest_release(client).await?;
 
     if latest.tag_name == version {
-        if !silent {
-            eprintln!("Already using the latest version ({}).", latest.tag_name);
-        }
+        write_update_status_line(
+            silent,
+            color,
+            format_args!("Already using the latest version ({}).", latest.tag_name),
+        );
         return Ok(());
     }
 
     if dry_run {
-        if !silent {
-            eprintln!("Update available: {version} -> {}", latest.tag_name);
-        }
+        write_update_status_line(
+            silent,
+            color,
+            format_args!("Update available: {version} -> {}", latest.tag_name),
+        );
         return Ok(());
     }
 
@@ -81,9 +86,11 @@ async fn update_inner(
             goarch()
         ))
     })?;
-    if !silent {
-        eprintln!("Downloading {}\n", latest.tag_name);
-    }
+    write_update_status(
+        silent,
+        color,
+        format_args!("Downloading {}\n\n", latest.tag_name),
+    );
 
     let checksum = download_checksum(client, release_artifact.checksum_url).await?;
 
@@ -105,27 +112,45 @@ async fn update_inner(
     let replace_result = self_replace(&exe_path, &src);
     replace_result?;
 
-    write_update_success(silent, version, &latest.tag_name);
+    write_update_success(silent, color, version, &latest.tag_name);
     Ok(())
 }
 
-fn write_update_success(silent: bool, old_version: &str, new_version: &str) {
+fn write_update_success(silent: bool, color: Option<&str>, old_version: &str, new_version: &str) {
     if silent {
         return;
     }
-    eprintln!("Updated fetch: {old_version} -> {new_version}");
+    let mut printer = core::Printer::stderr(color);
+    write_update_success_to(&mut printer, old_version, new_version);
+    core::flush_stderr(printer);
+}
 
+fn write_update_success_to(printer: &mut core::Printer, old_version: &str, new_version: &str) {
+    core::write_status_line_no_flush(
+        printer,
+        format_args!("Updated fetch: {old_version} -> {new_version}"),
+    );
     let compare_ref = changelog_compare_ref(old_version);
     if !compare_ref.is_empty() {
-        eprintln!(
-            "\nChangelog: https://github.com/ryanfowler/fetch/compare/{compare_ref}...{new_version}"
+        printer.push('\n');
+        core::write_status_line_no_flush(
+            printer,
+            format_args!(
+                "Changelog: https://github.com/ryanfowler/fetch/compare/{compare_ref}...{new_version}"
+            ),
         );
     }
 }
 
-fn write_msg(silent: bool, message: &str) {
+fn write_update_status(silent: bool, color: Option<&str>, message: impl std::fmt::Display) {
     if !silent {
-        eprint!("{message}");
+        core::write_status_with_color(message, color);
+    }
+}
+
+fn write_update_status_line(silent: bool, color: Option<&str>, message: impl std::fmt::Display) {
+    if !silent {
+        core::write_status_line_with_color(message, color);
     }
 }
 
@@ -378,5 +403,16 @@ mod tests {
         for (input, want) in tests {
             assert_eq!(is_version_tag(input), want, "is_version_tag({input:?})");
         }
+    }
+
+    #[test]
+    fn update_success_renders_through_printer() {
+        let mut printer = core::Printer::new(false);
+        write_update_success_to(&mut printer, "v1.2.3", "v1.2.4");
+
+        assert_eq!(
+            printer.into_string().unwrap(),
+            "Updated fetch: v1.2.3 -> v1.2.4\n\nChangelog: https://github.com/ryanfowler/fetch/compare/v1.2.3...v1.2.4\n"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add shared `core::Printer` helpers for plain status lines and flushed stderr output
- Route update progress, update completion, retry messages, and the dry-run separator through the central printer path
- Add unit coverage for the new status helpers and the migrated retry/update rendering

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --all-features --test cli --test formatting --test grpc --test http --test network --test terminal --test update --test websocket -- --test-threads=1`