### PR TITLE
Infer POST for body flags when `--method` is omitted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,9 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - `--from-curl` should only no-op curl flags that already match fetch defaults or curl presentation-only progress flags. Unsupported semantic flags such as `-n`/`--netrc`, `-f`/`--fail`, `-N`/`--no-buffer`, `--proto-default`, and `--proto-redir` return clear diagnostics instead of being ignored.
 - `--from-curl -d @file` and `-d @-` use the native streaming request body source when they are the single non-`-G` data value. Composite curl data bodies and `--data-urlencode @file` still materialize for curl-compatible concatenation/encoding, but cap the generated body at 16 MiB with a clear diagnostic.
 - The HTTP/2/3 environment-proxy guard implements `NO_PROXY` matching for hosts, domains, IP literals, CIDR ranges, and `*` so env proxies do not incorrectly block direct private-network requests.
+- Body-producing flags (`--data`, `--json`, `--xml`, `--form`,
+  `--multipart`, and `--edit`) infer `POST` when `--method` is omitted.
+  Explicit methods still win, including `-m GET` with a body.
 
 Retryable requests use replayable request bodies so retries and 307/308 redirects can resend data without holding unrelated state.
 Multipart `-F` request bodies are produced with a stable boundary so redirected requests preserve the original body shape.

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ fetch picsum.photos/1024/1024
 
 ```sh
 # POST JSON and format the response automatically
-fetch -m POST -j '{"name":"Ada"}' https://httpbin.org/post
+fetch -j '{"name":"Ada"}' https://httpbin.org/post
 
 # Reuse cookies across requests with a named session
-fetch --session api -m POST -j '{"user":"me"}' https://example.com/login
+fetch --session api -j '{"user":"me"}' https://example.com/login
 fetch --session api https://example.com/dashboard
 
 # Convert a curl command into a fetch request

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -564,7 +564,7 @@ fetch -vvv example.com  # DNS + TLS details with direction prefixes
 Preview the request without sending:
 
 ```sh
-fetch --dry-run -m POST -j '{"test": true}' example.com
+fetch --dry-run -j '{"test": true}' example.com
 ```
 
 ### Testing Connectivity

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,7 +22,8 @@ fetch http://example.com   # Force HTTP
 
 ### `-m, --method METHOD`
 
-Specify the HTTP method. Default: `GET`.
+Specify the HTTP method. Default: `GET`, or `POST` when a request-body flag is
+used and `--method` is omitted.
 
 **Alias**: `-X`
 
@@ -52,7 +53,10 @@ fetch -q page=1 -q limit=50 example.com
 
 ## Request Body Options
 
-Body options are mutually exclusive - only one can be used per request.
+Payload source options are mutually exclusive - only one of `--data`, `--json`,
+`--xml`, `--form`, or `--multipart` can be used per request. These options, and
+`--edit`, default the request method to `POST` when `--method` is omitted; use
+`-m`/`--method` to send the body with another method.
 
 ### `-d, --data [@]VALUE`
 
@@ -61,7 +65,7 @@ Send a raw request body. Content-Type is auto-detected when using file reference
 ```sh
 fetch -d 'Hello, world!' -m PUT example.com
 fetch -d @data.txt -m PUT example.com
-fetch -d @- -m PUT example.com < data.txt
+fetch -d @- example.com < data.txt
 ```
 
 ### `-j, --json [@]VALUE`
@@ -69,8 +73,8 @@ fetch -d @- -m PUT example.com < data.txt
 Send a JSON request body. Sets `Content-Type: application/json`.
 
 ```sh
-fetch -j '{"hello": "world"}' -m POST example.com
-fetch -j @data.json -m POST example.com
+fetch -j '{"hello": "world"}' example.com
+fetch -j @data.json example.com
 ```
 
 ### `-x, --xml [@]VALUE`
@@ -78,7 +82,7 @@ fetch -j @data.json -m POST example.com
 Send an XML request body. Sets `Content-Type: application/xml`.
 
 ```sh
-fetch -x '<Tag>value</Tag>' -m PUT example.com
+fetch -x '<Tag>value</Tag>' example.com
 fetch -x @data.xml -m PUT example.com
 ```
 
@@ -87,7 +91,7 @@ fetch -x @data.xml -m PUT example.com
 Send a URL-encoded form body. Can be used multiple times.
 
 ```sh
-fetch -f username=john -f password=secret -m POST example.com/login
+fetch -f username=john -f password=secret example.com/login
 ```
 
 ### `-F, --multipart NAME=[@]VALUE`
@@ -95,7 +99,7 @@ fetch -f username=john -f password=secret -m POST example.com/login
 Send a multipart form body. Use `@` prefix for file uploads. Can be used multiple times.
 
 ```sh
-fetch -F hello=world -F file=@document.pdf -m POST example.com/upload
+fetch -F hello=world -F file=@document.pdf example.com/upload
 ```
 
 ### `-e, --edit`
@@ -103,7 +107,7 @@ fetch -F hello=world -F file=@document.pdf -m POST example.com/upload
 Open an editor to modify the request body before sending. Uses `VISUAL` or `EDITOR` environment variables.
 
 ```sh
-fetch --edit -m PUT example.com
+fetch --edit example.com
 ```
 
 ## Authentication
@@ -718,7 +722,7 @@ fetch --complete fish > ~/.config/fish/completions/fetch.fish
 Print request information without sending. When used with `--update`, checks for the latest version without installing.
 
 ```sh
-fetch --dry-run -m POST -j '{"test": true}' example.com
+fetch --dry-run -j '{"test": true}' example.com
 fetch --update --dry-run
 ```
 
@@ -743,6 +747,6 @@ Many options support file references with the `@` prefix:
 - `@~/path` - Home directory expansion
 
 ```sh
-fetch -j @data.json -m POST example.com
-echo '{"test": true}' | fetch -j @- -m POST example.com
+fetch -j @data.json example.com
+echo '{"test": true}' | fetch -j @- example.com
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -221,7 +221,7 @@ This is useful for diagnosing latency issues, verifying TLS configuration, and u
 Preview the exact request that would be sent without actually making the HTTP call:
 
 ```sh
-fetch --dry-run -vv -j '{"hello":"world"}' -m POST httpbin.org/post
+fetch --dry-run -vv -j '{"hello":"world"}' httpbin.org/post
 ```
 
 ```
@@ -252,7 +252,7 @@ fetch -X DELETE httpbin.org/delete
 The `-j` flag sets the request body and automatically adds `Content-Type: application/json`:
 
 ```sh
-fetch -j '{"name": "test", "value": 42}' -m POST httpbin.org/post
+fetch -j '{"name": "test", "value": 42}' httpbin.org/post
 ```
 
 ### Adding Headers and Query Parameters
@@ -269,7 +269,7 @@ Query parameters are URL-encoded and appended to the URL automatically.
 ### Sending Form Data
 
 ```sh
-fetch -f name=test -f value=42 -m POST httpbin.org/post
+fetch -f name=test -f value=42 httpbin.org/post
 ```
 
 See [Request Bodies](request-bodies.md) for multipart forms and file uploads.
@@ -315,7 +315,7 @@ Sessions let you persist cookies across multiple requests. This is useful for in
 
 ```sh
 # Log in - cookies are saved to the "myapi" session
-fetch -S myapi -j '{"user":"me","pass":"secret"}' -m POST httpbin.org/cookies/set/token/abc123
+fetch -S myapi -j '{"user":"me","pass":"secret"}' httpbin.org/cookies/set/token/abc123
 
 # Subsequent requests automatically include the saved cookies
 fetch -S myapi httpbin.org/cookies

--- a/docs/request-bodies.md
+++ b/docs/request-bodies.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Request body options are **mutually exclusive** - you can only use one per request:
+Payload source options are **mutually exclusive** - you can only use one per request:
 
 | Option            | Content-Type                        | Use Case               |
 | ----------------- | ----------------------------------- | ---------------------- |
@@ -13,6 +13,10 @@ Request body options are **mutually exclusive** - you can only use one per reque
 | `-x, --xml`       | `application/xml`                   | XML/SOAP APIs          |
 | `-f, --form`      | `application/x-www-form-urlencoded` | Simple forms           |
 | `-F, --multipart` | `multipart/form-data`               | File uploads           |
+
+When no method is specified, these options default the method to `POST`.
+`--edit` also defaults to `POST` when composing a body. Use `-m`/`--method` to
+send a body with another method, such as `PUT`.
 
 ## Raw Data
 
@@ -28,14 +32,14 @@ fetch -d 'Hello, world!' -m PUT example.com/resource
 
 ```sh
 fetch -d @data.txt -m PUT example.com/resource
-fetch -d @payload.bin -m POST example.com/upload
+fetch -d @payload.bin example.com/upload
 ```
 
 ### From Stdin
 
 ```sh
 echo 'Request body' | fetch -d @- -m PUT example.com/resource
-cat data.json | fetch -d @- -m POST example.com/api
+cat data.json | fetch -d @- example.com/api
 ```
 
 ### Content-Type Detection
@@ -60,7 +64,7 @@ Multipart file parts use the same policy. Some examples are:
 Override with a header:
 
 ```sh
-fetch -d @data.bin -H "Content-Type: application/custom" -m POST example.com
+fetch -d @data.bin -H "Content-Type: application/custom" example.com
 ```
 
 ## JSON Bodies
@@ -70,22 +74,22 @@ The `-j` or `--json` flag sends JSON data and sets `Content-Type: application/js
 ### Inline JSON
 
 ```sh
-fetch -j '{"name": "test", "value": 42}' -m POST example.com/api
+fetch -j '{"name": "test", "value": 42}' example.com/api
 ```
 
 ### From File
 
 ```sh
-fetch -j @payload.json -m POST example.com/api
+fetch -j @payload.json example.com/api
 ```
 
 ### From Stdin
 
 ```sh
-echo '{"key": "value"}' | fetch -j @- -m POST example.com/api
+echo '{"key": "value"}' | fetch -j @- example.com/api
 
 # Build JSON dynamically
-jq -n '{name: "test", time: now}' | fetch -j @- -m POST example.com/api
+jq -n '{name: "test", time: now}' | fetch -j @- example.com/api
 ```
 
 ### Nested JSON
@@ -100,7 +104,7 @@ fetch -j '{
     "theme": "dark",
     "notifications": true
   }
-}' -m POST example.com/api/users
+}' example.com/api/users
 ```
 
 ## XML Bodies
@@ -110,13 +114,13 @@ The `-x` or `--xml` flag sends XML data and sets `Content-Type: application/xml`
 ### Inline XML
 
 ```sh
-fetch -x '<user><name>John</name></user>' -m POST example.com/api
+fetch -x '<user><name>John</name></user>' example.com/api
 ```
 
 ### From File
 
 ```sh
-fetch -x @request.xml -m POST example.com/soap/endpoint
+fetch -x @request.xml example.com/soap/endpoint
 ```
 
 ### SOAP Example
@@ -129,7 +133,7 @@ fetch -x '<?xml version="1.0"?>
       <UserId>123</UserId>
     </GetUser>
   </soap:Body>
-</soap:Envelope>' -m POST example.com/soap
+</soap:Envelope>' example.com/soap
 ```
 
 ## URL-Encoded Forms
@@ -139,7 +143,7 @@ The `-f` or `--form` flag sends URL-encoded form data. Use multiple times for mu
 ### Basic Form
 
 ```sh
-fetch -f username=john -f password=secret -m POST example.com/login
+fetch -f username=john -f password=secret example.com/login
 ```
 
 ### With Special Characters
@@ -147,7 +151,7 @@ fetch -f username=john -f password=secret -m POST example.com/login
 Values are automatically URL-encoded:
 
 ```sh
-fetch -f "message=Hello World!" -f "email=user@example.com" -m POST example.com/contact
+fetch -f "message=Hello World!" -f "email=user@example.com" example.com/contact
 ```
 
 ### Generated Content-Type
@@ -169,7 +173,7 @@ The `-F` or `--multipart` flag sends multipart form data, typically used for fil
 ### Text Fields
 
 ```sh
-fetch -F name=John -F email=john@example.com -m POST example.com/users
+fetch -F name=John -F email=john@example.com example.com/users
 ```
 
 ### File Uploads
@@ -177,8 +181,8 @@ fetch -F name=John -F email=john@example.com -m POST example.com/users
 Use `@` prefix to upload files:
 
 ```sh
-fetch -F file=@document.pdf -m POST example.com/upload
-fetch -F avatar=@photo.jpg -F name=John -m POST example.com/profile
+fetch -F file=@document.pdf example.com/upload
+fetch -F avatar=@photo.jpg -F name=John example.com/profile
 ```
 
 When uploading a file by path, only the file's base name is sent in the multipart `filename` parameter.
@@ -186,7 +190,7 @@ When uploading a file by path, only the file's base name is sent in the multipar
 ### Multiple Files
 
 ```sh
-fetch -F "files=@doc1.pdf" -F "files=@doc2.pdf" -m POST example.com/upload
+fetch -F "files=@doc1.pdf" -F "files=@doc2.pdf" example.com/upload
 ```
 
 ### Mixed Content
@@ -197,7 +201,7 @@ fetch \
   -F "description=A sample upload" \
   -F "file=@document.pdf" \
   -F "thumbnail=@preview.png" \
-  -m POST example.com/documents
+  example.com/documents
 ```
 
 ### Home Directory Expansion
@@ -205,7 +209,7 @@ fetch \
 The `~` is expanded to your home directory:
 
 ```sh
-fetch -F config=@~/config.json -m POST example.com/settings
+fetch -F config=@~/config.json example.com/settings
 ```
 
 ## Editor Integration
@@ -216,7 +220,7 @@ When the request has a recognized Content-Type, the temporary edit file uses the
 ### Basic Usage
 
 ```sh
-fetch --edit -m PUT example.com/resource
+fetch --edit example.com/resource
 ```
 
 ### With Initial Content
@@ -224,7 +228,7 @@ fetch --edit -m PUT example.com/resource
 Combine with other body options to edit before sending:
 
 ```sh
-fetch -j '{"name": "template"}' --edit -m POST example.com/api
+fetch -j '{"name": "template"}' --edit example.com/api
 ```
 
 ### Editor Selection
@@ -236,7 +240,7 @@ The editor is selected in this order:
 3. Well-known editors (`vim`, `nano`, etc.)
 
 ```sh
-EDITOR=code fetch --edit -m POST example.com/api
+EDITOR=code fetch --edit example.com/api
 ```
 
 ## File Reference Syntax
@@ -254,13 +258,13 @@ Body options that accept `[@]VALUE` support these formats:
 
 ```sh
 # Literal value
-fetch -j '{"inline": true}' -m POST example.com
+fetch -j '{"inline": true}' example.com
 
 # From file
-fetch -j @data.json -m POST example.com
+fetch -j @data.json example.com
 
 # From stdin
-cat data.json | fetch -j @- -m POST example.com
+cat data.json | fetch -j @- example.com
 
 # Home directory
 fetch -d @~/Documents/data.txt -m PUT example.com
@@ -268,14 +272,16 @@ fetch -d @~/Documents/data.txt -m PUT example.com
 
 ## Method Inference
 
-When a request body is provided without specifying a method, the default is still GET. Always specify the method explicitly for clarity:
+When a request body flag is provided without `--method`, `fetch` uses `POST`.
+An explicit method always wins, so use `-m PUT`, `-m PATCH`, or even `-m GET`
+when a body must be sent with a different method.
 
 ```sh
-# Explicit POST
-fetch -j '{"data": true}' -m POST example.com
+# Inferred POST
+fetch -j '{"data": true}' example.com
 
-# Don't rely on implicit behavior
-fetch -j '{"data": true}' example.com  # Still uses GET!
+# Explicit override
+fetch -m PUT -j '{"data": true}' example.com
 ```
 
 ## Large Files
@@ -287,7 +293,7 @@ For large file uploads, consider:
 3. **Progress**: Use `-v` to see request/response headers
 
 ```sh
-fetch -F "large=@bigfile.zip" --timeout 300 -v -m POST example.com/upload
+fetch -F "large=@bigfile.zip" --timeout 300 -v example.com/upload
 ```
 
 ## Examples
@@ -299,13 +305,13 @@ fetch -j '{
   "title": "New Post",
   "content": "Hello, World!",
   "published": true
-}' -m POST example.com/api/posts
+}' example.com/api/posts
 ```
 
 ### Form Login
 
 ```sh
-fetch -f username=admin -f password=secret -m POST example.com/login
+fetch -f username=admin -f password=secret example.com/login
 ```
 
 ### File Upload with Metadata
@@ -315,7 +321,7 @@ fetch \
   -F "file=@report.pdf" \
   -F "title=Monthly Report" \
   -F "tags=finance,monthly" \
-  -m POST example.com/documents
+  example.com/documents
 ```
 
 ### GraphQL Query
@@ -323,7 +329,7 @@ fetch \
 ```sh
 fetch -j '{
   "query": "{ user(id: 1) { name email } }"
-}' -m POST example.com/graphql
+}' example.com/graphql
 ```
 
 ### Webhook Payload
@@ -331,7 +337,7 @@ fetch -j '{
 ```sh
 fetch -j @webhook-payload.json \
   -H "X-Webhook-Secret: $WEBHOOK_SECRET" \
-  -m POST example.com/webhooks/receive
+  example.com/webhooks/receive
 ```
 
 ## See Also

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,7 +63,7 @@ Shows:
 Preview the request without sending:
 
 ```sh
-fetch --dry-run -m POST -j '{"test": true}' example.com
+fetch --dry-run -j '{"test": true}' example.com
 ```
 
 Shows:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -325,7 +325,7 @@ pub struct Cli {
         long = "method",
         short_alias = 'X',
         value_name = "METHOD",
-        help = "HTTP method to use [default: GET]"
+        help = "HTTP method to use [default: GET; body=POST]"
     )]
     pub method: Option<String>,
 
@@ -621,9 +621,9 @@ mod tests {
         );
         assert!(help.contains("--pager <MODE>                Control pager use [auto, on, off]"));
         assert!(help.contains("--sort-headers                Sort displayed headers by name"));
-        assert!(
-            help.contains("-m, --method <METHOD>             HTTP method to use [default: GET]")
-        );
+        assert!(help.contains(
+            "-m, --method <METHOD>             HTTP method to use [default: GET; body=POST]"
+        ));
         assert!(
             help.contains("--ws-interactive <MODE>       WebSocket prompt mode [auto, on, off]")
         );

--- a/src/http/metadata.rs
+++ b/src/http/metadata.rs
@@ -42,11 +42,22 @@ pub(super) fn write_warning_before_output(cli: &Cli, message: &str) {
 }
 
 pub(super) fn effective_method(cli: &Cli) -> &str {
-    if cli.grpc && cli.method.is_none() {
+    if cli.method.is_some() {
+        cli.method()
+    } else if cli.grpc || has_request_body_flag(cli) {
         "POST"
     } else {
         cli.method()
     }
+}
+
+fn has_request_body_flag(cli: &Cli) -> bool {
+    cli.data.is_some()
+        || cli.json.is_some()
+        || cli.xml.is_some()
+        || !cli.form.is_empty()
+        || !cli.multipart.is_empty()
+        || cli.edit
 }
 
 pub(super) fn effective_http_version(
@@ -523,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn method_defaults_and_custom_method_parse_like_go() {
+    fn method_defaults_infer_post_for_body_flags() {
         let cli = Cli::try_parse_from(["fetch", "https://example.com"]).unwrap();
         assert_eq!(cli.method(), "GET");
         assert_eq!(effective_method(&cli), "GET");
@@ -531,6 +542,29 @@ mod tests {
         let cli = Cli::try_parse_from(["fetch", "--method", "PUT", "https://example.com"]).unwrap();
         assert_eq!(cli.method(), "PUT");
         assert_eq!(effective_method(&cli), "PUT");
+
+        let cli = Cli::try_parse_from([
+            "fetch",
+            "--method",
+            "GET",
+            "--json",
+            "{}",
+            "https://example.com",
+        ])
+        .unwrap();
+        assert_eq!(effective_method(&cli), "GET");
+
+        for args in [
+            vec!["fetch", "--data", "body", "https://example.com"],
+            vec!["fetch", "--json", "{}", "https://example.com"],
+            vec!["fetch", "--xml", "<x/>", "https://example.com"],
+            vec!["fetch", "--form", "a=b", "https://example.com"],
+            vec!["fetch", "--multipart", "a=b", "https://example.com"],
+            vec!["fetch", "--edit", "https://example.com"],
+        ] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            assert_eq!(effective_method(&cli), "POST");
+        }
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -185,14 +185,14 @@ fn dry_run_prints_effective_request_without_network() {
     let res = run_fetch(&["-j", r#"{"key":"val1"}"#, "localhost:3000", "--dry-run"]);
     assert_exit(&res, 0);
     assert!(res.stdout.is_empty());
-    assert!(res.stderr.contains("GET / HTTP/1.1\n"));
+    assert!(res.stderr.contains("POST / HTTP/1.1\n"));
     assert!(res.stderr.contains("accept: application/json, */*;q=0.5"));
     assert!(res.stderr.contains("accept-encoding: gzip, br, zstd\n"));
     assert!(res.stderr.contains("content-length: 14\n"));
     assert!(res.stderr.contains("content-type: application/json\n"));
     assert!(res.stderr.contains("host: localhost:3000\n"));
     assert!(res.stderr.contains("\n\n{\"key\":\"val1\"}"));
-    assert!(!res.stderr.contains("> GET"));
+    assert!(!res.stderr.contains("> POST"));
 
     let res = run_fetch(&[
         "-j",

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -35,19 +35,21 @@ fn request_construction_and_data_sources() {
     let res = run_fetch(&[&server.url, "--data", "hello"]);
     assert_exit(&res, 0);
     let req = wait_for_requests(&server, 1).remove(0);
-    assert_eq!(req.method, "GET");
+    assert_eq!(req.method, "POST");
     assert_eq!(req.body_string(), "hello");
     assert_eq!(req.header("content-type"), "text/plain; charset=utf-8");
 
     let res = run_fetch(&[&server.url, "--json", r#"{"key":"val"}"#]);
     assert_exit(&res, 0);
     let req = wait_for_requests(&server, 2).remove(1);
+    assert_eq!(req.method, "POST");
     assert_eq!(req.body_string(), r#"{"key":"val"}"#);
     assert_eq!(req.header("content-type"), "application/json");
 
     let res = run_fetch(&[&server.url, "--xml", "<Tag></Tag>"]);
     assert_exit(&res, 0);
     let req = wait_for_requests(&server, 3).remove(2);
+    assert_eq!(req.method, "POST");
     assert_eq!(req.body_string(), "<Tag></Tag>");
     assert_eq!(req.header("content-type"), "application/xml");
 
@@ -56,12 +58,14 @@ fn request_construction_and_data_sources() {
     let res = run_fetch(&[&server.url, "--data", &format!("@{}", file.display())]);
     assert_exit(&res, 0);
     let req = wait_for_requests(&server, 4).remove(3);
+    assert_eq!(req.method, "POST");
     assert_eq!(req.body_string(), "temp file data");
     assert_eq!(req.header("content-length"), "14");
 
     let res = run_fetch(&[&server.url, "--data", "hello", "-H", "Content-Length: 5"]);
     assert_exit(&res, 0);
     let req = wait_for_requests(&server, 5).remove(4);
+    assert_eq!(req.method, "POST");
     assert_eq!(req.body_string(), "hello");
     assert_eq!(req.header("content-length"), "5");
 
@@ -74,9 +78,16 @@ fn request_construction_and_data_sources() {
     ]);
     assert_exit(&res, 0);
     let req = wait_for_requests(&server, 6).remove(5);
+    assert_eq!(req.method, "POST");
     assert_eq!(req.body_string(), "chunked body");
     assert_eq!(req.header("transfer-encoding"), "chunked");
     assert!(req.header("content-length").is_empty());
+
+    let res = run_fetch(&[&server.url, "--method", "GET", "--json", r#"{"key":"val"}"#]);
+    assert_exit(&res, 0);
+    let req = wait_for_requests(&server, 7).remove(6);
+    assert_eq!(req.method, "GET");
+    assert_eq!(req.body_string(), r#"{"key":"val"}"#);
 }
 
 #[cfg(unix)]
@@ -1214,6 +1225,8 @@ fn request_construction_host_header_form_and_http_version() {
     });
     let res = run_fetch(&[&form_server.url, "-f", "key1=val1", "-f", "key2=val2"]);
     assert_exit(&res, 0);
+    let req = wait_for_requests(&form_server, 1).remove(0);
+    assert_eq!(req.method, "POST");
 
     let res = run_fetch(&[&server.url, "--http", "1"]);
     assert_exit(&res, 0);
@@ -1450,7 +1463,8 @@ fn from_curl_individual_go_cases() {
 #[test]
 fn edit_request_body_matches_go_harness() {
     let server = TestServer::start(|req| {
-        if req.body_string() == r#"{"edited":true}"#
+        if req.method == "POST"
+            && req.body_string() == r#"{"edited":true}"#
             && req.header("content-type") == "application/json"
         {
             TestResponse::ok("ok")


### PR DESCRIPTION
## Summary
- Make body-producing flags default the request method to `POST` when `--method` is not set.
- Keep explicit methods authoritative, including `-m GET` with a body.
- Update help text, README/docs, AGENTS notes, and request-method tests to match the new behavior.

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features`