### PR TITLE
Clarify forced HTTP version behavior in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 
 - `--grpc-list` and `--grpc-describe` provide grpcurl-style discovery using reflection or local descriptor files.
 - `--grpc` now automatically tries gRPC reflection when no local schema is supplied.
-- Plaintext loopback gRPC servers are supported via `h2c` for both calls and discovery.
+- Plaintext loopback gRPC servers are supported via `h2c` for calls and discovery; h2c is gRPC-only.
 - Formatted gRPC responses with `Content-Type: application/grpc+proto` stream through `FrameDecoder`, writing each complete message immediately while preserving trailers.
 - gRPC calls and reflection advertise `grpc-accept-encoding: gzip`; response frames with the compressed flag are decompressed with the response `grpc-encoding` before protobuf decoding, with unsupported encodings reported by name.
 - gRPC standard request headers, status extraction from headers/trailers, and full framed-body reads live under `src/grpc`; request execution and reflection should reuse those helpers instead of duplicating protocol handling.
@@ -105,7 +105,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - Rust TLS version options accept only TLS 1.2 and TLS 1.3; legacy TLS 1.0/1.1 values are rejected consistently for CLI flags, config, WebSocket, and inspection paths.
 - Rustls is built with `aws-lc-rs` and `prefer-post-quantum`; keep post-quantum key exchange preference enabled unless there is a concrete compatibility or provider reason to disable it.
 - TLS inspection keeps its custom verifier for certificate display and OCSP capture, but Rustls protocol-version selection and PEM/client-auth material parsing should stay centralized in `src/tls/mod.rs`.
-- Default HTTPS requests should preserve the old reqwest-style protocol preference by offering `h2` and `http/1.1` through ALPN, dispatching to hyper HTTP/2 when `h2` is negotiated and falling back to HTTP/1.1 otherwise. Explicit `--http 1`, `--http 2`, and `--http 3` remain forced protocol selections.
+- Default HTTPS requests should preserve the old reqwest-style protocol preference by offering `h2` and `http/1.1` through ALPN, dispatching to hyper HTTP/2 when `h2` is negotiated and falling back to HTTP/1.1 otherwise. Explicit `--http 1`, `--http 2`, and `--http 3` remain forced protocol selections, not version caps.
 - The custom transport should preserve reqwest's safe default retries for HTTP/2/3 protocol NACKs such as remote `REFUSED_STREAM`, remote `GOAWAY(NO_ERROR)`, and HTTP/3 connection timeout signals, but only when the request body can be replayed.
 - WebSocket terminal sessions use the interactive prompt by default and can be controlled with `--ws-interactive auto|on|off`; output-file/clipboard/retry flags are rejected because the WebSocket path streams through the message loop instead of the normal response pipeline.
 - WebSocket requests require HTTP/1.1 for the upgrade handshake; reject explicit `--http 2` and `--http 3` instead of silently performing an HTTP/1.1 upgrade.

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -151,6 +151,11 @@ fetch --unix ~/myapp.sock http://localhost/health
 
 Force a specific HTTP version.
 
+When `--http` is unset, HTTPS requests offer `h2` and then `http/1.1` through
+ALPN, using HTTP/2 when the server negotiates it and falling back to HTTP/1.1
+otherwise. Setting `--http 1`, `--http 2`, or `--http 3` forces that protocol;
+it does not set a version cap.
+
 ### HTTP/1.1
 
 ```sh
@@ -168,11 +173,13 @@ fetch --http 1 example.com
 fetch --http 2 example.com
 ```
 
-- Default behavior (HTTP/2 preferred with fallback)
+- Forces HTTP/2
 - Multiplexed streams
 - Header compression (HPACK)
 - Required for gRPC
-- Automatically uses h2c (HTTP/2 over cleartext) for gRPC requests with `http://` URLs, enabling plaintext HTTP/2 connections to local development servers without TLS
+- Plain `http://` URLs are only supported with forced HTTP/2 for gRPC requests,
+  where `fetch` uses h2c (HTTP/2 over cleartext) for local development servers
+  without TLS
 
 ### HTTP/3 (QUIC)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -456,13 +456,20 @@ fetch --ca-cert ca-cert.pem example.com
 
 ### `--http VERSION`
 
-Force specific HTTP version. Values: `1`, `2`, `3`.
+Force a specific HTTP protocol version. Values: `1`, `2`, `3`.
 
 - `1` - HTTP/1.1
-- `2` - HTTP/2 (default preference)
+- `2` - HTTP/2
 - `3` - HTTP/3 (QUIC)
 
-When `--http 2` is used with an `http://` URL for gRPC requests, `fetch` automatically uses h2c (HTTP/2 over cleartext) to connect without TLS.
+When `--http` is unset, HTTPS requests offer `h2` and then `http/1.1`
+through ALPN, using HTTP/2 when the server negotiates it and falling back to
+HTTP/1.1 otherwise.
+
+`--http 1`, `--http 2`, and `--http 3` force that protocol instead of setting
+a maximum version. `--http 2` with a plain `http://` URL is only supported for
+gRPC requests, where `fetch` uses h2c (HTTP/2 over cleartext) for local
+plaintext servers.
 
 ```sh
 fetch --http 1 example.com

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -358,13 +358,19 @@ retry-delay = 0.5
 **Type**: String
 **Values**: `1`, `2`, `3`
 
-Specify the highest allowed HTTP version.
+Force a specific HTTP protocol version.
+
+When unset, HTTPS requests offer `h2` and then `http/1.1` through ALPN, using
+HTTP/2 when the server negotiates it and falling back to HTTP/1.1 otherwise.
+Setting this option to `1`, `2`, or `3` forces that protocol; it does not set a
+version cap. Forced HTTP/2 with a plain `http://` URL is only supported for
+gRPC requests, where `fetch` uses h2c (HTTP/2 over cleartext).
 
 ```ini
 # Force HTTP/1.1
 http = 1
 
-# Allow HTTP/2 (default)
+# Force HTTP/2
 http = 2
 ```
 


### PR DESCRIPTION
## Summary
- Clarified that unset HTTP version uses ALPN with `h2` then `http/1.1`
- Stated that `--http 1|2|3` forces the selected protocol instead of setting a maximum
- Noted that h2c over plain `http://` is gRPC-only

## Testing
- Not run (not requested)