### PR TITLE
Reject non-GET WebSocket methods

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -713,6 +713,11 @@ fn validate_websocket_exclusives(cli: &Cli) -> Result<(), FetchError> {
         )
         .into());
     }
+    if let Some(method) = cli.method.as_deref()
+        && !method.eq_ignore_ascii_case("GET")
+    {
+        return Err(format!("WebSocket requires GET; method {method} is not supported").into());
+    }
     let conflicting_flag = if cli.clobber {
         Some("clobber")
     } else if cli.copy {
@@ -1514,6 +1519,17 @@ mod tests {
         }
 
         let cli = Cli::try_parse_from(["fetch", "ws://example.com", "--http", "1"]).unwrap();
+        validate_websocket_exclusives(&cli).unwrap();
+    }
+
+    #[test]
+    fn websocket_rejects_non_get_methods() {
+        let cli = Cli::try_parse_from(["fetch", "ws://example.com", "--method", "POST"]).unwrap();
+        let err = validate_websocket_exclusives(&cli).unwrap_err().to_string();
+
+        assert_eq!(err, "WebSocket requires GET; method POST is not supported");
+
+        let cli = Cli::try_parse_from(["fetch", "ws://example.com", "--method", "GET"]).unwrap();
         validate_websocket_exclusives(&cli).unwrap();
     }
 

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -68,12 +68,6 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
 
     let method = effective_method(cli);
     let mut warnings = Vec::new();
-    if !cli.method().eq_ignore_ascii_case("GET") {
-        warnings.push(format!(
-            "WebSocket requires GET; ignoring method {}",
-            cli.method()
-        ));
-    }
     if cli.timing {
         warnings.push("--timing is not supported for WebSocket connections".to_string());
     }

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -323,15 +323,14 @@ fn websocket_noninteractive_go_cases() {
     assert!(!res.stderr.contains("--help"), "stderr:\n{}", res.stderr);
 
     let res = run_fetch(&[&ws_url, "--method", "POST", "--timing", "--dry-run"]);
-    assert_exit(&res, 0);
-    assert!(res.stderr.contains("GET / HTTP/1.1"));
+    assert_exit(&res, 1);
     assert!(
-        res.stderr.contains(
-            "warning: WebSocket requires GET; ignoring method POST\nwarning: --timing is not supported for WebSocket connections\n\n> GET / HTTP/1.1"
-        ),
+        res.stderr
+            .contains("WebSocket requires GET; method POST is not supported"),
         "{:?}",
         res.stderr
     );
+    assert!(!res.stderr.contains("GET / HTTP/1.1"), "{:?}", res.stderr);
 
     let res = run_fetch(&[
         &ws_url,
@@ -344,8 +343,13 @@ fn websocket_noninteractive_go_cases() {
         "--ws-interactive",
         "off",
     ]);
-    assert_exit(&res, 0);
-    assert!(res.stderr.contains("GET") || res.stderr.contains("method"));
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr
+            .contains("WebSocket requires GET; method POST is not supported"),
+        "{:?}",
+        res.stderr
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Reject explicit non-GET `--method` values during WebSocket validation instead of warning and continuing
- Remove the obsolete WebSocket method warning path in runtime execution
- Update WebSocket unit and integration coverage to assert the new error behavior

## Testing
- Unit tests added for WebSocket exclusives validation
- Integration tests updated and verified for the WebSocket dry-run and noninteractive cases
- `cargo fmt`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo test --all-features`, and the serialized integration suite all passed