### PR TITLE
Document the output model and clarify binary warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ fetch httpbin.org/json
 fetch picsum.photos/1024/1024
 ```
 
+## Output Model
+
+`fetch` keeps response bodies and metadata separate: the body is written to
+stdout, while status lines, headers, progress, timing, warnings, and errors are
+written to stderr. This makes commands like `fetch example.com/api | jq .` work
+without mixing diagnostics into the pipe.
+
+When stdout is a terminal, supported response bodies are formatted and may open
+in `less -FIRX`; use `--pager off` to write directly. When stdout is redirected
+or piped, formatting turns off by default; use `--format on` to force formatted
+output in a pipe. Binary-looking responses are not printed to a terminal unless
+you explicitly choose an output path with `-o file`, force raw stdout with
+`-o - > file`, or disable terminal image rendering with `--image off`.
+
 ## Examples
 
 ### Everyday API Work

--- a/docs/output-formatting.md
+++ b/docs/output-formatting.md
@@ -358,13 +358,15 @@ The pager uses these flags: `less -FIRX`
 When stdout is a terminal, `fetch` checks if the response appears to be binary data. If so, it displays a warning instead of corrupting your terminal:
 
 ```
-warning: the response body appears to be binary
+warning: the response body appears to be binary (content type: application/octet-stream)
 ```
 
 To force output:
 
 ```sh
+fetch -o file.dat example.com/binary.dat
 fetch -o - example.com/binary.dat > file.dat
+fetch --image off example.com/image.png
 ```
 
 ## Configuration

--- a/src/http/response/formatters.rs
+++ b/src/http/response/formatters.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use super::stdout::{StdoutBody, response_header_content_type};
+use super::stdout::{StdoutBody, response_header_content_type, response_header_content_type_label};
 use super::stream::{MAX_BUFFERED_RESPONSE_BYTES, StdoutStreamFormatter, StreamedOutput};
 
 pub(super) fn should_stream_formatted_sse_stdout(
@@ -386,6 +386,7 @@ pub(super) fn format_stdout_bytes_with_terminal(
         return Ok(StdoutBody {
             bytes: bytes.to_vec(),
             content_type,
+            content_type_label: response_header_content_type_label(headers),
         });
     }
 
@@ -494,6 +495,7 @@ pub(super) fn format_stdout_bytes_with_terminal(
     Ok(StdoutBody {
         bytes,
         content_type,
+        content_type_label: response_header_content_type_label(headers),
     })
 }
 

--- a/src/http/response/stdout.rs
+++ b/src/http/response/stdout.rs
@@ -1,17 +1,15 @@
 use super::*;
 
-pub(super) const BINARY_RESPONSE_WARNING: &str =
-    "the response body appears to be binary\n\nTo output to the terminal anyway, use '--output -'";
-
 pub(super) struct StdoutBody {
     pub(super) bytes: Vec<u8>,
     pub(super) content_type: ContentType,
+    pub(super) content_type_label: String,
 }
 
 pub(super) fn write_stdout_bytes(cli: &Cli, body: &StdoutBody) -> Result<(), FetchError> {
     let stdout_is_terminal = core::stdio().stdout_is_terminal();
     if should_warn_for_terminal_binary_stdout(cli, &body.bytes, stdout_is_terminal) {
-        write_warning(cli, BINARY_RESPONSE_WARNING);
+        write_warning(cli, &binary_response_warning(&body.content_type_label));
         return Ok(());
     }
 
@@ -104,6 +102,24 @@ pub(super) fn response_header_content_type(headers: &HeaderMap) -> ContentType {
     content_type::get_content_type(content_type).0
 }
 
+pub(super) fn response_header_content_type_label(headers: &HeaderMap) -> String {
+    headers
+        .get(http::header::CONTENT_TYPE)
+        .map(|value| {
+            value
+                .to_str()
+                .unwrap_or("<invalid content-type>")
+                .to_owned()
+        })
+        .unwrap_or_else(|| "<none>".to_owned())
+}
+
+pub(super) fn binary_response_warning(content_type: &str) -> String {
+    format!(
+        "the response body appears to be binary (content type: {content_type})\n\nUse '-o file' to save it, '-o - > file' to redirect raw bytes, or '--image off' to disable terminal image rendering."
+    )
+}
+
 pub(super) fn terminal_binary_stdout_guard_enabled(cli: &Cli, stdout_is_terminal: bool) -> bool {
     stdout_is_terminal && cli.output.as_deref() != Some("-")
 }
@@ -147,6 +163,15 @@ mod tests {
             b"abc\0def",
             true
         ));
+    }
+
+    #[test]
+    fn binary_response_warning_includes_content_type_and_alternatives() {
+        let warning = binary_response_warning("application/octet-stream");
+        assert!(warning.contains("content type: application/octet-stream"));
+        assert!(warning.contains("-o file"));
+        assert!(warning.contains("-o - > file"));
+        assert!(warning.contains("--image off"));
     }
 
     #[test]

--- a/src/http/response/stream.rs
+++ b/src/http/response/stream.rs
@@ -1,7 +1,8 @@
 use super::*;
 
 use super::stdout::{
-    BINARY_RESPONSE_WARNING, StdoutStreamTarget, terminal_binary_stdout_guard_enabled,
+    StdoutStreamTarget, binary_response_warning, response_header_content_type_label,
+    terminal_binary_stdout_guard_enabled,
 };
 
 pub(super) const MAX_BUFFERED_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
@@ -110,8 +111,14 @@ pub(super) async fn stream_response_to_stdout(
     let mut reader = decoded_async_response_reader(reader, compression, &response_headers)?;
     let mut capture = copy.then(clipboard::Capture::default);
     let bytes_written = if terminal_binary_stdout_guard_enabled(cli, stdout_is_terminal) {
-        stream_response_to_stdout_with_binary_check(cli, &mut reader, target, capture.as_mut())
-            .await?
+        stream_response_to_stdout_with_binary_check(
+            cli,
+            &response_headers,
+            &mut reader,
+            target,
+            capture.as_mut(),
+        )
+        .await?
     } else {
         copy_async_reader_to_stdout_target(&mut reader, target, &[], capture.as_mut()).await?
     };
@@ -315,6 +322,7 @@ fn async_response_reader(response: Response) -> (AsyncReadBox, ResponseTrailers)
 
 async fn stream_response_to_stdout_with_binary_check(
     cli: &Cli,
+    response_headers: &HeaderMap,
     reader: &mut AsyncReadBox,
     target: StdoutStreamTarget,
     mut capture: Option<&mut clipboard::Capture>,
@@ -327,7 +335,10 @@ async fn stream_response_to_stdout_with_binary_check(
 
     let first_chunk = &first_chunk[..n];
     if !is_printable(first_chunk) {
-        write_warning(cli, BINARY_RESPONSE_WARNING);
+        write_warning(
+            cli,
+            &binary_response_warning(&response_header_content_type_label(response_headers)),
+        );
         if let Some(capture) = capture.as_mut() {
             capture.push(first_chunk);
         }

--- a/tests/support/terminal.rs
+++ b/tests/support/terminal.rs
@@ -172,7 +172,9 @@ pub(crate) fn run_fetch_pty_with_fake_less(
 pub(crate) fn run_binary_pty_with_fake_less(
     extra_args: &[&str],
 ) -> (String, Option<String>, Option<String>) {
-    let server = TestServer::start(|_| TestResponse::ok(b"abc\0def".to_vec()));
+    let server = TestServer::start(|_| {
+        TestResponse::ok(b"abc\0def".to_vec()).header("Content-Type", "application/octet-stream")
+    });
     let dir = TempDir::new().unwrap();
     install_fake_less(dir.path());
     let less_args = dir.path().join("less.args");

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -14,6 +14,22 @@ use support::terminal::{
     run_fetch_with_fake_less, run_image_pty_with_fake_less, run_image_render_pty,
 };
 
+fn assert_binary_warning_output(output: &str) {
+    assert!(
+        output.contains(
+            "the response body appears to be binary (content type: application/octet-stream)"
+        ),
+        "{output:?}"
+    );
+    assert!(
+        output.contains("\x1b[1m\x1b[33mwarning\x1b[0m: "),
+        "{output:?}"
+    );
+    assert!(output.contains("-o file"), "{output:?}");
+    assert!(output.contains("-o - > file"), "{output:?}");
+    assert!(output.contains("--image off"), "{output:?}");
+}
+
 #[cfg(unix)]
 #[test]
 fn terminal_stdout_uses_less_pager_by_default() {
@@ -39,18 +55,7 @@ fn pager_off_writes_terminal_stdout_directly() {
 fn terminal_stdout_warns_instead_of_printing_binary_response() {
     let (output, less_args, less_input) = run_binary_pty_with_fake_less(&[]);
 
-    assert!(
-        output.contains("the response body appears to be binary"),
-        "{output:?}"
-    );
-    assert!(
-        output.contains("\x1b[1m\x1b[33mwarning\x1b[0m: "),
-        "{output:?}"
-    );
-    assert!(
-        output.contains("To output to the terminal anyway, use '--output -'"),
-        "{output:?}"
-    );
+    assert_binary_warning_output(&output);
     assert!(!output.contains("abc\0def"), "{output:?}");
     assert!(less_args.is_none(), "pager was invoked: {less_args:?}");
     assert!(less_input.is_none(), "pager received input: {less_input:?}");
@@ -61,18 +66,7 @@ fn terminal_stdout_warns_instead_of_printing_binary_response() {
 fn terminal_stdout_format_off_warns_instead_of_streaming_binary_response() {
     let (output, less_args, less_input) = run_binary_pty_with_fake_less(&["--format", "off"]);
 
-    assert!(
-        output.contains("the response body appears to be binary"),
-        "{output:?}"
-    );
-    assert!(
-        output.contains("\x1b[1m\x1b[33mwarning\x1b[0m: "),
-        "{output:?}"
-    );
-    assert!(
-        output.contains("To output to the terminal anyway, use '--output -'"),
-        "{output:?}"
-    );
+    assert_binary_warning_output(&output);
     assert!(!output.contains("abc\0def"), "{output:?}");
     assert!(less_args.is_none(), "pager was invoked: {less_args:?}");
     assert!(less_input.is_none(), "pager received input: {less_input:?}");


### PR DESCRIPTION
## Summary
- Add a short Output Model section near the README quick start to explain stdout/stderr separation, paging, formatting, and binary safeguards
- Improve binary-response warnings to include the detected content type and exact alternatives
- Update docs and terminal tests to cover the new warning text

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features --lib`
- `cargo test --all-features --test terminal binary_response`
- `cargo test --all-features --test cli --test formatting --test grpc --test http --test network --test terminal --test update --test websocket -- --test-threads=1`