### PR TITLE
Clarify HTTP 4xx/5xx exit behavior in docs and help text

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -547,7 +547,8 @@ fetch -s example.com
 
 ### `--ignore-status`
 
-Don't use HTTP status code for exit code. Always exit 0 on successful request.
+HTTP 4xx/5xx responses exit nonzero by default; use `--ignore-status` to keep
+the exit code at 0 when the request completes.
 
 ```sh
 fetch --ignore-status example.com/not-found

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -570,7 +570,8 @@ query = sort=name
 **Type**: Boolean
 **Default**: `false`
 
-Don't determine exit code from HTTP status. Always exit with code 0.
+HTTP 4xx/5xx responses exit nonzero by default. Set `ignore-status = true` to
+ignore HTTP status when choosing the exit code.
 
 ```ini
 # Ignore HTTP status for exit code

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,9 +13,12 @@ This guide helps diagnose and fix common issues with `fetch`.
 | 5         | Server error (HTTP 5xx)            |
 | 6         | Other HTTP status or request error |
 
+Unlike curl's default behavior, HTTP 4xx/5xx responses exit nonzero; use
+`--ignore-status` to ignore HTTP status when choosing the exit code.
+
 ### Ignore HTTP Status
 
-To always exit 0 regardless of HTTP status:
+To always exit 0 for completed HTTP requests regardless of status:
 
 ```sh
 fetch --ignore-status example.com/not-found

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -282,7 +282,7 @@ pub struct Cli {
     #[arg(long, value_name = "VERSION", help = "HTTP version to use [1, 2, 3]")]
     pub http: Option<String>,
 
-    #[arg(long = "ignore-status", help = "Exit code unaffected by HTTP status")]
+    #[arg(long = "ignore-status", help = "Do not exit nonzero for HTTP 4xx/5xx")]
     pub ignore_status: bool,
 
     #[arg(

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -279,7 +279,7 @@ const FLAGS: &[Flag] = &[
         None,
         "ignore-status",
         "",
-        "Exit code unaffected by HTTP status",
+        "Do not exit nonzero for HTTP 4xx/5xx",
     ),
     Flag {
         short: None,


### PR DESCRIPTION
## Summary
- Clarify that HTTP 4xx/5xx responses exit nonzero by default
- Point users to `--ignore-status` in the CLI reference, troubleshooting guide, and config docs
- Update the `--ignore-status` help text and completion description to match the documented behavior

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features --test cli`