### PR TITLE
Warn when `-J` falls back from Content-Disposition

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -187,7 +187,9 @@ fetch -O example.com/path/to/file.txt  # Creates ./file.txt
 
 ### `-J, --remote-header-name`
 
-Use filename from `Content-Disposition` header. Requires `-O`.
+Use filename from `Content-Disposition` header. Requires `-O`. If the response
+does not include a usable header filename, fetch warns and falls back to the URL
+filename.
 
 ```sh
 fetch -O -J example.com/download

--- a/docs/output-formatting.md
+++ b/docs/output-formatting.md
@@ -317,7 +317,8 @@ fetch -O example.com/files/document.pdf
 
 ### `-J, --remote-header-name`
 
-Use filename from `Content-Disposition` header:
+Use filename from `Content-Disposition` header. If no usable header filename is
+available, fetch warns and falls back to the URL filename:
 
 ```sh
 fetch -O -J example.com/download

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -61,7 +61,7 @@ pub(super) async fn finish_response(
         ));
     }
 
-    let output_path = output::resolve_output_path(
+    let resolved_output = output::resolve_output_path(
         cli.output.as_deref(),
         cli.remote_name,
         cli.remote_header_name,
@@ -69,7 +69,10 @@ pub(super) async fn finish_response(
         &response_headers,
     )
     .map_err(|err| FetchError::Message(err.to_string()))?;
-    if let Some(path) = output_path {
+    if let Some(warning) = &resolved_output.warning {
+        write_warning(cli, warning);
+    }
+    if let Some(path) = resolved_output.path {
         let progress = if cli.silent {
             output::WriteProgress::disabled()
         } else {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -37,6 +37,12 @@ pub enum OutputError {
     Io(#[from] std::io::Error),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct ResolvedOutputPath {
+    pub path: Option<String>,
+    pub warning: Option<String>,
+}
+
 #[derive(Clone)]
 pub struct WriteProgress {
     printer: Option<ProgressPrinter>,
@@ -86,32 +92,59 @@ pub fn resolve_output_path(
     remote_header_name: bool,
     url: &Url,
     headers: &HeaderMap,
-) -> Result<Option<String>, OutputError> {
+) -> Result<ResolvedOutputPath, OutputError> {
     if let Some(path) = output {
         if path == "-" {
-            return Ok(None);
+            return Ok(ResolvedOutputPath {
+                path: None,
+                warning: None,
+            });
         }
-        return Ok(Some(path.to_string()));
+        return Ok(ResolvedOutputPath {
+            path: Some(path.to_string()),
+            warning: None,
+        });
     }
     if !remote_name {
-        return Ok(None);
+        return Ok(ResolvedOutputPath {
+            path: None,
+            warning: None,
+        });
     }
 
-    if remote_header_name
-        && let Some(filename) = content_disposition_filename(headers)
-        && let Ok(filename) = sanitize_filename(&filename)
-    {
-        return Ok(Some(filename));
+    let mut content_disposition_not_used = false;
+    if remote_header_name {
+        if let Some(filename) = content_disposition_filename(headers)
+            && let Ok(filename) = sanitize_filename(&filename)
+        {
+            return Ok(ResolvedOutputPath {
+                path: Some(filename),
+                warning: None,
+            });
+        }
+        content_disposition_not_used = true;
     }
 
     if let Some(filename) = filename_from_url_path(url) {
-        return Ok(Some(filename));
+        return Ok(ResolvedOutputPath {
+            path: Some(filename),
+            warning: content_disposition_not_used.then(|| {
+                "Content-Disposition filename was not usable; falling back to URL filename"
+                    .to_string()
+            }),
+        });
     }
 
     if let Some(host) = url.host_str()
         && !host.is_empty()
     {
-        return Ok(Some(host.to_string()));
+        return Ok(ResolvedOutputPath {
+            path: Some(host.to_string()),
+            warning: content_disposition_not_used.then(|| {
+                "Content-Disposition filename was not usable; falling back to host filename"
+                    .to_string()
+            }),
+        });
     }
 
     Err(OutputError::UnableToInferFileName)
@@ -887,11 +920,12 @@ mod tests {
         let url = Url::parse("http://example.com/dir/path_to_file.txt?ignored=yes").unwrap();
         let headers = HeaderMap::new();
 
-        let path = resolve_output_path(None, true, false, &url, &headers)
-            .unwrap()
-            .unwrap();
+        let resolved = resolve_output_path(None, true, false, &url, &headers).unwrap();
+
+        let path = resolved.path.unwrap();
 
         assert_eq!(path, "path_to_file.txt");
+        assert_eq!(resolved.warning, None);
     }
 
     #[test]
@@ -903,11 +937,12 @@ mod tests {
             r#"attachment; filename="cd-filename.txt""#.parse().unwrap(),
         );
 
-        let path = resolve_output_path(None, true, false, &url, &headers)
-            .unwrap()
-            .unwrap();
+        let resolved = resolve_output_path(None, true, false, &url, &headers).unwrap();
+
+        let path = resolved.path.unwrap();
 
         assert_eq!(path, "url-filename.txt");
+        assert_eq!(resolved.warning, None);
     }
 
     #[test]
@@ -919,11 +954,12 @@ mod tests {
             r#"attachment; filename="cd-filename.txt""#.parse().unwrap(),
         );
 
-        let path = resolve_output_path(None, true, true, &url, &headers)
-            .unwrap()
-            .unwrap();
+        let resolved = resolve_output_path(None, true, true, &url, &headers).unwrap();
+
+        let path = resolved.path.unwrap();
 
         assert_eq!(path, "cd-filename.txt");
+        assert_eq!(resolved.warning, None);
     }
 
     #[test]
@@ -937,11 +973,12 @@ mod tests {
                 .unwrap(),
         );
 
-        let path = resolve_output_path(None, true, true, &url, &headers)
-            .unwrap()
-            .unwrap();
+        let resolved = resolve_output_path(None, true, true, &url, &headers).unwrap();
+
+        let path = resolved.path.unwrap();
 
         assert_eq!(path, "malicious.txt");
+        assert_eq!(resolved.warning, None);
     }
 
     #[test]
@@ -953,11 +990,12 @@ mod tests {
             r#"attachment; filename="dir/subdir\\evil.txt""#.parse().unwrap(),
         );
 
-        let path = resolve_output_path(None, true, true, &url, &headers)
-            .unwrap()
-            .unwrap();
+        let resolved = resolve_output_path(None, true, true, &url, &headers).unwrap();
+
+        let path = resolved.path.unwrap();
 
         assert_eq!(path, "evil.txt");
+        assert_eq!(resolved.warning, None);
     }
 
     #[test]
@@ -969,11 +1007,29 @@ mod tests {
             r#"attachment; filename="..""#.parse().unwrap(),
         );
 
-        let path = resolve_output_path(None, true, true, &url, &headers)
-            .unwrap()
-            .unwrap();
+        let resolved = resolve_output_path(None, true, true, &url, &headers).unwrap();
+
+        let path = resolved.path.unwrap();
 
         assert_eq!(path, "fallback.txt");
+        assert_eq!(
+            resolved.warning.as_deref(),
+            Some("Content-Disposition filename was not usable; falling back to URL filename")
+        );
+    }
+
+    #[test]
+    fn remote_header_name_falls_back_to_url_when_content_disposition_missing() {
+        let url = Url::parse("http://example.com/fallback.txt").unwrap();
+        let headers = HeaderMap::new();
+
+        let resolved = resolve_output_path(None, true, true, &url, &headers).unwrap();
+
+        assert_eq!(resolved.path.as_deref(), Some("fallback.txt"));
+        assert_eq!(
+            resolved.warning.as_deref(),
+            Some("Content-Disposition filename was not usable; falling back to URL filename")
+        );
     }
 
     #[test]
@@ -981,11 +1037,26 @@ mod tests {
         let url = Url::parse("http://example.com/").unwrap();
         let headers = HeaderMap::new();
 
-        let path = resolve_output_path(None, true, false, &url, &headers)
-            .unwrap()
-            .unwrap();
+        let resolved = resolve_output_path(None, true, false, &url, &headers).unwrap();
+
+        let path = resolved.path.unwrap();
 
         assert_eq!(path, "example.com");
+        assert_eq!(resolved.warning, None);
+    }
+
+    #[test]
+    fn remote_header_name_falls_back_to_hostname_when_url_filename_missing() {
+        let url = Url::parse("http://example.com/").unwrap();
+        let headers = HeaderMap::new();
+
+        let resolved = resolve_output_path(None, true, true, &url, &headers).unwrap();
+
+        assert_eq!(resolved.path.as_deref(), Some("example.com"));
+        assert_eq!(
+            resolved.warning.as_deref(),
+            Some("Content-Disposition filename was not usable; falling back to host filename")
+        );
     }
 
     #[test]
@@ -993,9 +1064,10 @@ mod tests {
         let url = Url::parse("http://example.com/file.txt").unwrap();
         let headers = HeaderMap::new();
 
-        let path = resolve_output_path(Some("-"), false, false, &url, &headers).unwrap();
+        let resolved = resolve_output_path(Some("-"), false, false, &url, &headers).unwrap();
 
-        assert_eq!(path, None);
+        assert_eq!(resolved.path, None);
+        assert_eq!(resolved.warning, None);
     }
 
     #[test]

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -1049,6 +1049,9 @@ fn output_file_modes_match_go_harness() {
             "Content-Disposition",
             "attachment; filename=\"from-header.txt\"",
         ),
+        "/missing-header.txt" => TestResponse::ok("missing-header-body"),
+        "/invalid-header.txt" => TestResponse::ok("invalid-header-body")
+            .header("Content-Disposition", "attachment; filename=\"..\""),
         "/traversal" => TestResponse::ok("bad")
             .header("Content-Disposition", "attachment; filename=\"../bad.txt\""),
         _ => TestResponse::ok("body"),
@@ -1083,6 +1086,60 @@ fn output_file_modes_match_go_harness() {
     assert_eq!(
         fs::read_to_string(dir.path().join("from-header.txt")).unwrap(),
         "header-body"
+    );
+    assert!(
+        !res.stderr
+            .contains("Content-Disposition filename was not usable"),
+        "stderr:\n{}",
+        res.stderr
+    );
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            cwd: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        },
+        &[
+            &format!("{}/missing-header.txt", server.url),
+            "--remote-name",
+            "--remote-header-name",
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_eq!(
+        fs::read_to_string(dir.path().join("missing-header.txt")).unwrap(),
+        "missing-header-body"
+    );
+    assert!(
+        res.stderr.contains(
+            "warning: Content-Disposition filename was not usable; falling back to URL filename"
+        ),
+        "stderr:\n{}",
+        res.stderr
+    );
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            cwd: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        },
+        &[
+            &format!("{}/invalid-header.txt", server.url),
+            "--remote-name",
+            "--remote-header-name",
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_eq!(
+        fs::read_to_string(dir.path().join("invalid-header.txt")).unwrap(),
+        "invalid-header-body"
+    );
+    assert!(
+        res.stderr.contains(
+            "warning: Content-Disposition filename was not usable; falling back to URL filename"
+        ),
+        "stderr:\n{}",
+        res.stderr
     );
 
     let out = dir.path().join("explicit.txt");


### PR DESCRIPTION
## Summary
- Emit a warning when `--remote-header-name` is requested but no usable `Content-Disposition` filename is available
- Keep the fallback behavior intact, using the URL path or host filename as before
- Update docs and add unit/integration coverage for missing and invalid header cases

## Testing
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --all-features --test cli --test formatting --test grpc --test http --test network --test terminal --test update --test websocket -- --test-threads=1`
- Focused unit and HTTP integration tests for `-O -J` fallback behavior