### PR TITLE
Clarify Windows config file search order

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,10 +11,13 @@ This guide provides comprehensive documentation for configuring `fetch` using a 
 `fetch` searches for configuration files in the following order:
 
 1. **Specified path**: The file location specified with the `-c` or `--config` flag
-2. **Windows**: `%AppData%\fetch\config`
-3. **Unix-like systems**:
+2. **Default path candidates**:
    - `$XDG_CONFIG_HOME/fetch/config` (if `XDG_CONFIG_HOME` is set)
-   - `$HOME/.config/fetch/config` (fallback)
+   - `$HOME/.config/fetch/config` (if `HOME` is set)
+   - **Windows only**: `%AppData%\fetch\config` (fallback)
+
+On Windows, `fetch` still checks `XDG_CONFIG_HOME` and `HOME` first when those
+environment variables are present, then falls back to `%AppData%\fetch\config`.
 
 ### Configuration Precedence
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -321,8 +321,9 @@ fetch --grpc --proto-file service.proto \
 ### Config File Not Loading
 
 1. **Check location**:
-   - Windows: `%AppData%\fetch\config`
-   - macOS/Linux: `~/.config/fetch/config`
+   - `$XDG_CONFIG_HOME/fetch/config` if `XDG_CONFIG_HOME` is set
+   - `$HOME/.config/fetch/config` if `HOME` is set
+   - Windows fallback: `%AppData%\fetch\config`
 
 2. **Specify explicitly**:
 


### PR DESCRIPTION
## Summary
- Document the actual default config search order on Windows
- Note that `XDG_CONFIG_HOME` and `HOME` are checked before `%AppData%\fetch\config`
- Update the troubleshooting guide to match the loader behavior

## Testing
- Not run (not requested)