### PR TITLE
Correct silent mode docs to say only errors are shown

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,7 +166,7 @@ pager = on
 **Type**: Boolean
 **Default**: `false`
 
-Suppress verbose output. Only warnings and errors are written to stderr.
+Suppress verbose output. Only errors are written to stderr.
 
 ```ini
 # Enable silent mode


### PR DESCRIPTION
## Summary
- Update the `silent` configuration docs to match implementation and CLI help.
- Remove the stale mention of warnings from the `docs/configuration.md` entry.

## Testing
- Not run (not requested)