### PR TITLE
Fix WebSocket spacing and Ctrl-C shutdown behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.claude
 /.zig-cache
 /bin
+/local-test-servers
 /scratch
 /target

--- a/src/app.rs
+++ b/src/app.rs
@@ -40,15 +40,20 @@ pub async fn main_entry() -> i32 {
                 1
             }
         },
-        message = shutdown_signal_message() => {
-            write_runtime_error_with_color(FetchError::Runtime(message), signal_color.as_deref());
-            1
+        signal = shutdown_signal() => {
+            match signal {
+                ShutdownSignal::Interrupt => 0,
+                ShutdownSignal::Terminate(message) => {
+                    write_runtime_error_with_color(FetchError::Runtime(message), signal_color.as_deref());
+                    1
+                }
+            }
         }
     }
 }
 
 #[cfg(unix)]
-async fn shutdown_signal_message() -> String {
+async fn shutdown_signal() -> ShutdownSignal {
     use tokio::signal::unix::{SignalKind, signal};
 
     let mut interrupt = signal(SignalKind::interrupt()).ok();
@@ -56,9 +61,9 @@ async fn shutdown_signal_message() -> String {
     let mut terminate = signal(SignalKind::terminate()).ok();
 
     tokio::select! {
-        _ = recv_signal(&mut interrupt) => "received signal: interrupt".to_string(),
-        _ = recv_signal(&mut hangup) => "received signal: hangup".to_string(),
-        _ = recv_signal(&mut terminate) => "received signal: terminated".to_string(),
+        _ = recv_signal(&mut interrupt) => ShutdownSignal::Interrupt,
+        _ = recv_signal(&mut hangup) => ShutdownSignal::Terminate("received signal: hangup".to_string()),
+        _ = recv_signal(&mut terminate) => ShutdownSignal::Terminate("received signal: terminated".to_string()),
     }
 }
 
@@ -72,9 +77,14 @@ async fn recv_signal(signal: &mut Option<tokio::signal::unix::Signal>) {
 }
 
 #[cfg(not(unix))]
-async fn shutdown_signal_message() -> String {
+async fn shutdown_signal() -> ShutdownSignal {
     let _ = tokio::signal::ctrl_c().await;
-    "received signal: interrupt".to_string()
+    ShutdownSignal::Interrupt
+}
+
+enum ShutdownSignal {
+    Interrupt,
+    Terminate(String),
 }
 
 fn handle_parse_error(err: clap::Error, color: Option<&str>) -> i32 {

--- a/src/websocket/interactive.rs
+++ b/src/websocket/interactive.rs
@@ -17,6 +17,7 @@ const MIN_ROWS: usize = 5;
 const READ_BUF_SIZE: usize = 256;
 const STDIN_CHAN_BUF: usize = 64;
 const MAX_MESSAGES: usize = 10_000;
+const STATUS_GAP_ROWS: usize = 1;
 
 #[derive(Debug, Default)]
 pub struct LineEditor {
@@ -445,12 +446,12 @@ impl InteractiveMode {
 
     pub fn message_row_count(&self, msg: &MessageEntry) -> Result<usize, FetchError> {
         let Some(data) = msg.data.as_deref() else {
-            return Ok(2);
+            return Ok(1);
         };
         let arrow = msg.arrow.unwrap_or("←");
         let prefix_width = display_width(&format!("{arrow} "));
         let width = self.cols.saturating_sub(prefix_width).max(1);
-        Ok(wrap_display_lines(&self.format_message(data)?, width).len() + 1)
+        Ok(wrap_display_lines(&self.format_message(data)?, width).len())
     }
 
     pub fn format_message(&self, data: &[u8]) -> Result<String, FetchError> {
@@ -613,13 +614,12 @@ impl InteractiveMode {
             }
             write!(out, "{line}")?;
         }
-        self.write_message_spacer(out)
+        Ok(())
     }
 
     fn write_binary<W: Write>(&mut self, out: &mut W, len: usize) -> io::Result<()> {
         self.write_physical_line(out)?;
-        write!(out, "\x1b[2m← [binary {len} bytes]\x1b[0m")?;
-        self.write_message_spacer(out)
+        write!(out, "\x1b[2m← [binary {len} bytes]\x1b[0m")
     }
 
     fn write_physical_line<W: Write>(&mut self, out: &mut W) -> io::Result<()> {
@@ -634,15 +634,8 @@ impl InteractiveMode {
         Ok(())
     }
 
-    fn write_message_spacer<W: Write>(&mut self, out: &mut W) -> io::Result<()> {
-        if self.next_row <= self.scroll_end() {
-            self.write_physical_line(out)?;
-        }
-        Ok(())
-    }
-
     fn scroll_end(&self) -> usize {
-        self.rows.saturating_sub(3).max(1)
+        self.rows.saturating_sub(3 + STATUS_GAP_ROWS).max(1)
     }
 
     fn truncate_messages(&mut self) {
@@ -1350,13 +1343,13 @@ mod tests {
         let mode = InteractiveMode::new(7, false);
 
         let msg = MessageEntry::text("←", b"abcdef");
-        assert_eq!(mode.message_row_count(&msg).unwrap(), 3);
+        assert_eq!(mode.message_row_count(&msg).unwrap(), 2);
 
         let msg = MessageEntry::text("←", b"ab\ncd");
-        assert_eq!(mode.message_row_count(&msg).unwrap(), 3);
+        assert_eq!(mode.message_row_count(&msg).unwrap(), 2);
 
         let msg = MessageEntry::binary(10);
-        assert_eq!(mode.message_row_count(&msg).unwrap(), 2);
+        assert_eq!(mode.message_row_count(&msg).unwrap(), 1);
     }
 
     #[test]
@@ -1456,7 +1449,7 @@ mod tests {
         mode.setup_screen(&mut out, 8, 10, 1).unwrap();
         let out = String::from_utf8(out).unwrap();
 
-        assert!(out.contains("\x1b[1;5r"), "{out:?}");
+        assert!(out.contains("\x1b[1;4r"), "{out:?}");
         assert!(out.contains("\x1b[6;1H\x1b[2K\x1b[90mconnected\x1b[0m"));
         assert!(out.contains("\x1b[8;1H\x1b[2K\x1b[90m──────────\x1b[0m"));
         assert!(out.contains("\x1b[7;1H\x1b[2K\x1b[1m❯ \x1b[0m"));
@@ -1473,8 +1466,8 @@ mod tests {
         mode.setup_screen(&mut out, 8, 10, 7).unwrap();
         let out = String::from_utf8(out).unwrap();
 
-        assert!(out.contains("\x1b[8;1H\n\n\n\n"), "{out:?}");
-        assert_eq!(mode.next_row(), 4);
+        assert!(out.contains("\x1b[8;1H\n\n\n\n\n"), "{out:?}");
+        assert_eq!(mode.next_row(), 3);
     }
 
     #[test]

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -176,7 +176,7 @@ fn image_rendering_pty_go_cases() {
 
 #[cfg(unix)]
 #[test]
-fn request_ctrl_c_reports_signal_go_case() {
+fn request_ctrl_c_exits_successfully() {
     let (started_tx, started_rx) = mpsc::channel();
     let release = Arc::new(AtomicUsize::new(0));
     let release_for_handler = Arc::clone(&release);
@@ -215,15 +215,12 @@ fn request_ctrl_c_reports_signal_go_case() {
         .expect("wait fetch after SIGINT");
     release.store(1, Ordering::SeqCst);
     let output = child.wait_with_output().expect("collect signal output");
-    assert_eq!(status.code(), Some(1));
+    assert_eq!(status.code(), Some(0));
     assert!(
         output.stdout.is_empty(),
         "stdout = {:?}, want empty",
         String::from_utf8_lossy(&output.stdout)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("received signal: interrupt"),
-        "stderr = {stderr:?}, want signal error"
-    );
+    assert!(stderr.is_empty(), "stderr = {stderr:?}, want empty");
 }

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -602,6 +602,54 @@ fn websocket_flushes_noninteractive_stdout_while_socket_stays_open() {
     server.join().expect("join hold-open websocket server");
 }
 
+#[cfg(unix)]
+#[test]
+fn websocket_noninteractive_ctrl_c_exits_successfully() {
+    let (ws_url, shutdown, server) = start_ws_hold_open_push_server(b"message before interrupt");
+    let mut cmd = Command::new(fetch_bin());
+    cmd.args([&ws_url, "--format", "off", "--ws-interactive", "off"]);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.env("NO_COLOR", "");
+    cmd.env("HTTP_PROXY", "");
+    cmd.env("HTTPS_PROXY", "");
+    cmd.env("ALL_PROXY", "");
+    cmd.env("NO_PROXY", "*");
+
+    let mut child = cmd.spawn().expect("spawn websocket ctrl-c fetch");
+    let _stdin = child.stdin.take().expect("child stdin");
+    let stdout = start_read_capture(child.stdout.take().expect("child stdout"));
+    let stderr = start_read_capture(child.stderr.take().expect("child stderr"));
+
+    stdout.wait_for("message before interrupt\n", Duration::from_secs(5));
+    let rc = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGINT) };
+    assert_eq!(rc, 0, "failed to send SIGINT");
+    let status = wait_child(&mut child, Duration::from_secs(5))
+        .unwrap_or_else(|| {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "fetch did not exit after SIGINT; stdout:\n{}\nstderr:\n{}",
+                stdout.output(),
+                stderr.output()
+            )
+        })
+        .expect("wait websocket ctrl-c fetch");
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "fetch exited with {status}; stdout:\n{}\nstderr:\n{}",
+        stdout.output(),
+        stderr.output()
+    );
+    assert!(stderr.output().is_empty(), "stderr:\n{}", stderr.output());
+    let _ = shutdown.send(());
+    stdout.close();
+    stderr.close();
+    server.join().expect("join hold-open websocket server");
+}
+
 #[test]
 fn websocket_receives_json_text_binary_and_query_handshake() {
     let ws_url = start_ws_push_server(|req| {


### PR DESCRIPTION
## Summary
- Remove the extra spacer row after interactive WebSocket messages so wrapping and scrolling stay consistent.
- Reserve a blank line above the status/input area for clearer separation in interactive mode.
- Treat Ctrl-C as a successful exit instead of a runtime error, including WebSocket non-interactive mode.
- Add regression coverage for the updated interactive layout and Ctrl-C behavior.

## Testing
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- `cargo test --locked --all-features --test websocket -- --test-threads=1`
- Focused unit and integration tests for WebSocket interactive rendering and Ctrl-C handling passed.