### PR TITLE
Include library unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
       - name: Rust unit tests
-        run: cargo test --locked --all-features --bins
+        run: cargo test --locked --all-features --lib --bins
 
   integration:
     name: integration (${{ matrix.os }})


### PR DESCRIPTION
## Summary
- Update the CI unit-test step to run `cargo test --locked --all-features --lib --bins`.
- This closes the coverage gap where `src/lib.rs` tests were skipped.

## Testing
- Not run (not requested)