### PR TITLE
Propagate multipart Content-Length errors

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1268,7 +1268,7 @@ mod tests {
 
         let body = crate::http::request_body(&cli).unwrap();
         assert_eq!(
-            crate::http::request_body_content_len(&body),
+            crate::http::request_body_content_len(&body).unwrap(),
             Some("streamed data".len() as u64)
         );
         assert!(crate::http::request_body_bytes(&body).is_none());

--- a/src/http/metadata.rs
+++ b/src/http/metadata.rs
@@ -106,7 +106,7 @@ pub(super) fn print_request_metadata(
     headers: &HeaderMap,
     body: &RequestBody,
     http_version: Option<HttpVersion>,
-) {
+) -> Result<(), FetchError> {
     let mut printer = core::Printer::stderr(cli.color.as_deref());
     let debug = cli.verbose >= 2;
     if debug {
@@ -123,7 +123,7 @@ pub(super) fn print_request_metadata(
     printer.push_str("\n");
     let mut lines = header_lines(headers);
     lines.retain(|(name, _)| !name.eq_ignore_ascii_case("host"));
-    if let Some(len) = inferred_request_body_content_len(headers, body) {
+    if let Some(len) = inferred_request_body_content_len(headers, body)? {
         lines.push(("content-length".to_string(), len.to_string()));
     }
     let host = headers
@@ -152,6 +152,7 @@ pub(super) fn print_request_metadata(
         printer.push_str("\n");
     }
     flush_stderr(printer);
+    Ok(())
 }
 
 pub(super) fn is_printable(bytes: &[u8]) -> bool {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -188,7 +188,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
             )?;
         }
         apply_builder_authorization_headers(&mut dry_run_headers, cli, None)?;
-        print_request_metadata(cli, &method, &url, &dry_run_headers, &body, http_version);
+        print_request_metadata(cli, &method, &url, &dry_run_headers, &body, http_version)?;
         print_dry_run_body(cli, &body)?;
         return Ok(0);
     }
@@ -235,7 +235,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                     &attempt_headers,
                     &request_body,
                     http_version,
-                );
+                )?;
             }
             if cli.verbose >= 3
                 && !cli.silent

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -18,6 +18,8 @@ pub enum MultipartError {
     FileIsDirectory(String),
     #[error("invalid multipart {kind}: value contains ASCII control character")]
     InvalidDispositionValue { kind: &'static str },
+    #[error("multipart body is too large to compute Content-Length")]
+    BodyTooLarge,
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }
@@ -149,22 +151,33 @@ impl Multipart {
     }
 
     pub fn content_len(&self) -> Result<u64, MultipartError> {
+        self.content_len_with_file_len(|path| Ok(std::fs::metadata(path)?.len()))
+    }
+
+    fn content_len_with_file_len(
+        &self,
+        mut file_len: impl FnMut(&Path) -> Result<u64, MultipartError>,
+    ) -> Result<u64, MultipartError> {
         let mut len = 0_u64;
         for field in &self.fields {
-            len += 2 + self.boundary.len() as u64 + 2;
+            add_len(&mut len, 2)?;
+            add_usize_len(&mut len, self.boundary.len())?;
+            add_len(&mut len, 2)?;
             match &field.value {
                 FieldValue::Text(value) => {
-                    len += text_header(&field.name).len() as u64;
-                    len += value.len() as u64;
+                    add_usize_len(&mut len, text_header(&field.name).len())?;
+                    add_usize_len(&mut len, value.len())?;
                 }
                 FieldValue::File(path) => {
-                    len += file_header(&field.name, path)?.len() as u64;
-                    len += std::fs::metadata(path)?.len();
+                    add_usize_len(&mut len, file_header(&field.name, path)?.len())?;
+                    add_len(&mut len, file_len(path)?)?;
                 }
             }
-            len += 2;
+            add_len(&mut len, 2)?;
         }
-        len += 2 + self.boundary.len() as u64 + 4;
+        add_len(&mut len, 2)?;
+        add_usize_len(&mut len, self.boundary.len())?;
+        add_len(&mut len, 4)?;
         Ok(len)
     }
 
@@ -175,6 +188,18 @@ impl Multipart {
             state: MultipartStreamState::Field,
         }
     }
+}
+
+fn add_len(len: &mut u64, amount: u64) -> Result<(), MultipartError> {
+    *len = len
+        .checked_add(amount)
+        .ok_or(MultipartError::BodyTooLarge)?;
+    Ok(())
+}
+
+fn add_usize_len(len: &mut u64, amount: usize) -> Result<(), MultipartError> {
+    let amount = u64::try_from(amount).map_err(|_| MultipartError::BodyTooLarge)?;
+    add_len(len, amount)
 }
 
 fn append_preview(out: &mut Vec<u8>, limit: usize, bytes: &[u8]) {
@@ -424,6 +449,38 @@ mod tests {
         assert!(body.contains("name=\"field\""));
         assert!(body.contains("value"));
         assert!(multipart.content_type().contains(&multipart.boundary));
+    }
+
+    #[test]
+    fn multipart_content_len_matches_open_body_len() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("payload.txt");
+        std::fs::write(&path, b"file payload").unwrap();
+        let multipart = Multipart::from_cli_fields(&[
+            "field=value".to_string(),
+            format!("file=@{}", path.display()),
+        ])
+        .unwrap()
+        .unwrap();
+        let body = multipart.open().unwrap();
+
+        assert_eq!(multipart.content_len().unwrap(), body.len() as u64);
+    }
+
+    #[test]
+    fn multipart_content_len_reports_body_too_large_on_overflow() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("payload.txt");
+        std::fs::write(&path, b"x").unwrap();
+        let multipart = Multipart::from_cli_fields(&[format!("file=@{}", path.display())])
+            .unwrap()
+            .unwrap();
+
+        let err = multipart
+            .content_len_with_file_len(|_| Ok(u64::MAX))
+            .unwrap_err();
+
+        assert!(matches!(err, MultipartError::BodyTooLarge));
     }
 
     #[test]

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -104,7 +104,7 @@ pub(super) fn build_request(
     cli: &Cli,
     authorization: RequestAuthorization<'_>,
 ) -> Result<RequestBuilder, FetchError> {
-    if let Some(len) = inferred_request_body_content_len(&headers, &body) {
+    if let Some(len) = inferred_request_body_content_len(&headers, &body)? {
         headers.insert(
             CONTENT_LENGTH,
             HeaderValue::from_str(&len.to_string())
@@ -484,37 +484,41 @@ pub(crate) fn request_body_bytes(body: &RequestBody) -> Option<&[u8]> {
     }
 }
 
-pub(crate) fn request_body_content_len(body: &RequestBody) -> Option<u64> {
-    match body.as_ref()? {
-        RequestBodyPayload {
+pub(crate) fn request_body_content_len(body: &RequestBody) -> Result<Option<u64>, FetchError> {
+    match body.as_ref() {
+        None => Ok(None),
+        Some(RequestBodyPayload {
             source: RequestBodySource::Bytes(bytes),
             ..
-        } => Some(bytes.len() as u64),
-        RequestBodyPayload {
+        }) => Ok(Some(bytes.len() as u64)),
+        Some(RequestBodyPayload {
             source: RequestBodySource::File { len, .. },
             ..
-        } => Some(*len),
-        RequestBodyPayload {
+        }) => Ok(Some(*len)),
+        Some(RequestBodyPayload {
             source: RequestBodySource::Multipart(multipart),
             ..
-        } => multipart.content_len().ok(),
-        RequestBodyPayload {
+        }) => multipart
+            .content_len()
+            .map(Some)
+            .map_err(|err| FetchError::Message(err.to_string())),
+        Some(RequestBodyPayload {
             source: RequestBodySource::Stdin,
             ..
-        } => None,
-        RequestBodyPayload {
+        }) => Ok(None),
+        Some(RequestBodyPayload {
             source: RequestBodySource::GrpcJsonStream { .. },
             ..
-        } => None,
+        }) => Ok(None),
     }
 }
 
 pub(super) fn inferred_request_body_content_len(
     headers: &HeaderMap,
     body: &RequestBody,
-) -> Option<u64> {
+) -> Result<Option<u64>, FetchError> {
     if headers.contains_key(CONTENT_LENGTH) || headers.contains_key(TRANSFER_ENCODING) {
-        return None;
+        return Ok(None);
     }
     request_body_content_len(body)
 }
@@ -1103,6 +1107,26 @@ mod tests {
             err,
             format!("file '{}' is a directory", dir.path().display())
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn request_body_content_len_propagates_multipart_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("evil\nname.txt");
+        std::fs::write(&path, b"payload").unwrap();
+        let multipart =
+            multipart::Multipart::from_cli_fields(&[format!("file=@{}", path.display())])
+                .unwrap()
+                .unwrap();
+        let body = Some(RequestBodyPayload {
+            source: RequestBodySource::Multipart(multipart),
+            content_type: None,
+        });
+
+        let err = request_body_content_len(&body).unwrap_err().to_string();
+
+        assert!(err.contains("invalid multipart filename"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- return errors when request body length inference fails instead of silently skipping `Content-Length`
- detect multipart length overflow and surface a dedicated `BodyTooLarge` error
- add tests for multipart length matching and overflow propagation

## Testing
- Added unit tests covering multipart length calculation and overflow handling
- Added a request-body unit test to verify multipart errors propagate through length inference