### PR TITLE
Handle curl JSON defaults and cap update metadata

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -812,19 +812,23 @@ fn apply_proto_restriction(raw_url: &str, allowed_proto: &str) -> Result<String,
 
     let (allow_http, allow_https) = from_curl::parse_allowed_proto(allowed_proto);
     if let Some((scheme, _rest)) = raw_url.split_once("://") {
-        match scheme {
-            "http" if !allow_http => {
+        if scheme.eq_ignore_ascii_case("http") {
+            if !allow_http {
                 return Err(
                     format!("protocol 'http' not allowed by --proto {allowed_proto:?}").into(),
                 );
             }
-            "https" if !allow_https => {
+            return Ok(raw_url.to_string());
+        }
+        if scheme.eq_ignore_ascii_case("https") {
+            if !allow_https {
                 return Err(
                     format!("protocol 'https' not allowed by --proto {allowed_proto:?}").into(),
                 );
             }
-            _ => return Ok(raw_url.to_string()),
+            return Ok(raw_url.to_string());
         }
+        return Ok(raw_url.to_string());
     }
 
     if !allow_http && !allow_https {
@@ -1360,16 +1364,17 @@ mod tests {
     }
 
     #[test]
-    fn from_curl_proto_restriction_rejects_disallowed_scheme() {
-        let mut cli = Cli::try_parse_from([
-            "fetch",
-            "--from-curl",
+    fn from_curl_proto_restriction_rejects_disallowed_scheme_case_insensitively() {
+        for command in [
             "curl --proto '=https' http://example.com",
-        ])
-        .unwrap();
+            "curl --proto '=https' HTTP://example.com",
+            "curl --proto '=http' HTTPS://example.com",
+        ] {
+            let mut cli = Cli::try_parse_from(["fetch", "--from-curl", command]).unwrap();
 
-        let err = apply_from_curl(&mut cli).unwrap_err().to_string();
-        assert!(err.contains("not allowed by --proto"));
+            let err = apply_from_curl(&mut cli).unwrap_err().to_string();
+            assert!(err.contains("not allowed by --proto"), "{command}: {err}");
+        }
     }
 
     #[test]

--- a/src/cli/from_curl.rs
+++ b/src/cli/from_curl.rs
@@ -62,6 +62,7 @@ pub struct ParsedCurl {
     pub has_content_type: bool,
     pub has_accept: bool,
     pub allowed_proto: String,
+    json_defaults: bool,
 }
 
 pub fn parse(command: &str) -> Result<ParsedCurl, String> {
@@ -171,6 +172,23 @@ fn post_process(parsed: &mut ParsedCurl) -> Result<(), String> {
             parsed.method = "POST".to_string();
         } else if !parsed.upload_file.is_empty() {
             parsed.method = "PUT".to_string();
+        }
+    }
+
+    if parsed.json_defaults {
+        if !parsed.has_content_type {
+            parsed.headers.push(Header {
+                name: "Content-Type".to_string(),
+                value: "application/json".to_string(),
+            });
+            parsed.has_content_type = true;
+        }
+        if !parsed.has_accept {
+            parsed.headers.push(Header {
+                name: "Accept".to_string(),
+                value: "application/json".to_string(),
+            });
+            parsed.has_accept = true;
         }
     }
 
@@ -303,20 +321,7 @@ fn parse_long_flag(
                 is_raw: false,
                 is_urlencode: false,
             });
-            if !parsed.has_content_type {
-                parsed.headers.push(Header {
-                    name: "Content-Type".to_string(),
-                    value: "application/json".to_string(),
-                });
-                parsed.has_content_type = true;
-            }
-            if !parsed.has_accept {
-                parsed.headers.push(Header {
-                    name: "Accept".to_string(),
-                    value: "application/json".to_string(),
-                });
-                parsed.has_accept = true;
-            }
+            parsed.json_defaults = true;
             Ok(consumed)
         }
         "form" => {
@@ -1021,6 +1026,31 @@ mod tests {
                 .iter()
                 .any(|h| h.name == "Accept" && h.value == "application/json")
         );
+    }
+
+    #[test]
+    fn test_parse_json_custom_headers_suppress_defaults_regardless_of_order() {
+        for command in [
+            r#"curl --json '{"ok":true}' -H 'Accept: text/plain' -H 'Content-Type: application/custom' https://example.com"#,
+            r#"curl -H 'Accept: text/plain' -H 'Content-Type: application/custom' --json '{"ok":true}' https://example.com"#,
+        ] {
+            let parsed = parse(command).unwrap();
+            let content_types: Vec<_> = parsed
+                .headers
+                .iter()
+                .filter(|header| header.name.eq_ignore_ascii_case("content-type"))
+                .map(|header| header.value.as_str())
+                .collect();
+            let accepts: Vec<_> = parsed
+                .headers
+                .iter()
+                .filter(|header| header.name.eq_ignore_ascii_case("accept"))
+                .map(|header| header.value.as_str())
+                .collect();
+
+            assert_eq!(content_types, vec!["application/custom"], "{command}");
+            assert_eq!(accepts, vec!["text/plain"], "{command}");
+        }
     }
 
     #[test]

--- a/src/update/client.rs
+++ b/src/update/client.rs
@@ -13,6 +13,7 @@ use crate::error::FetchError;
 use crate::http::{client, transport};
 
 const INTERNAL_UPDATE_URL_ENV: &str = "FETCH_INTERNAL_UPDATE_URL";
+const MAX_UPDATE_RELEASE_METADATA_BYTES: u64 = 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 pub(super) struct Release {
@@ -45,7 +46,14 @@ pub(super) async fn latest_release(client: &UpdateClient<'_>) -> Result<Release,
         "{}/repos/ryanfowler/fetch/releases/latest",
         update_url().trim_end_matches('/')
     );
-    let response = update_get(client, &url).await?;
+    latest_release_from_url(client, &url).await
+}
+
+async fn latest_release_from_url(
+    client: &UpdateClient<'_>,
+    url: &str,
+) -> Result<Release, FetchError> {
+    let response = update_get_stream(client, url).await?;
     if !response.status().is_success() {
         return Err(format!(
             "unable to fetch the latest release: received status: {}",
@@ -53,19 +61,28 @@ pub(super) async fn latest_release(client: &UpdateClient<'_>) -> Result<Release,
         )
         .into());
     }
+
+    if let Some(len) = response.content_length()
+        && len > MAX_UPDATE_RELEASE_METADATA_BYTES
+    {
+        return Err(format!(
+            "unable to fetch the latest release: release metadata is too large: {len} bytes"
+        )
+        .into());
+    }
+
+    let response = response
+        .into_buffered_with_limit(
+            Some(MAX_UPDATE_RELEASE_METADATA_BYTES),
+            "unable to fetch the latest release: release metadata exceeded maximum allowed size",
+        )
+        .await?;
     let release: Release = serde_json::from_slice(response.body())
         .map_err(|err| FetchError::Message(format!("unable to fetch the latest release: {err}")))?;
     if release.tag_name.is_empty() {
         return Err("unable to fetch the latest release: no tag found".into());
     }
     Ok(release)
-}
-
-pub(super) async fn update_get(
-    client: &UpdateClient<'_>,
-    url: &str,
-) -> Result<UpdateResponse, FetchError> {
-    client.get(url).await
 }
 
 pub(super) async fn update_get_stream(
@@ -128,10 +145,6 @@ impl<'a> UpdateClient<'a> {
             allow_insecure_http: true,
             client: Mutex::new(None),
         }
-    }
-
-    async fn get(&self, raw_url: &str) -> Result<UpdateResponse, FetchError> {
-        self.get_stream(raw_url).await?.into_buffered().await
     }
 
     async fn get_stream(&self, raw_url: &str) -> Result<UpdateStreamingResponse, FetchError> {
@@ -282,15 +295,10 @@ fn is_update_redirect(status: StatusCode) -> bool {
 
 #[derive(Debug)]
 pub(super) struct UpdateResponse {
-    status: StatusCode,
     body: bytes::Bytes,
 }
 
 impl UpdateResponse {
-    pub(super) fn status(&self) -> StatusCode {
-        self.status
-    }
-
     pub(super) fn body(&self) -> &[u8] {
         &self.body
     }
@@ -314,18 +322,12 @@ impl UpdateStreamingResponse {
         content_length(self.headers())
     }
 
-    pub(super) async fn into_buffered(self) -> Result<UpdateResponse, FetchError> {
-        self.into_buffered_with_limit(None, "response body exceeded maximum allowed size")
-            .await
-    }
-
     pub(super) async fn into_buffered_with_limit(
         self,
         max_body_bytes: Option<u64>,
         limit_error: &'static str,
     ) -> Result<UpdateResponse, FetchError> {
         let budget = self.budget;
-        let status = self.response.status();
         let headers = self.response.headers().clone();
         let (mut body, _) = self.response.into_body_with_deadline();
         let capacity = content_length(&headers)
@@ -361,7 +363,6 @@ impl UpdateStreamingResponse {
             bytes.extend_from_slice(&data);
         }
         Ok(UpdateResponse {
-            status,
             body: bytes::Bytes::from(bytes),
         })
     }
@@ -436,13 +437,26 @@ mod tests {
         );
     }
 
+    async fn test_update_get_buffered(
+        client: &UpdateClient<'_>,
+        url: &str,
+    ) -> Result<(StatusCode, UpdateResponse), FetchError> {
+        let response = update_get_stream(client, url).await?;
+        let status = response.status();
+        let response = response
+            .into_buffered_with_limit(None, "response body exceeded maximum allowed size")
+            .await?;
+        Ok((status, response))
+    }
+
     #[tokio::test]
     async fn update_client_rejects_initial_http_by_default() {
         let client = UpdateClient::test(None);
 
-        let err = update_get(&client, "http://127.0.0.1:1/artifact")
-            .await
-            .unwrap_err();
+        let err = match update_get_stream(&client, "http://127.0.0.1:1/artifact").await {
+            Ok(_) => panic!("expected insecure update URL to be rejected"),
+            Err(err) => err,
+        };
 
         assert!(
             err.to_string()
@@ -459,11 +473,28 @@ mod tests {
         );
         let client = UpdateClient::test_allow_insecure_http(None);
 
-        let response = update_get(&client, &url).await.unwrap();
+        let (status, response) = test_update_get_buffered(&client, &url).await.unwrap();
         join.join().unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(response.body(), b"ok");
+    }
+
+    #[tokio::test]
+    async fn latest_release_rejects_metadata_content_length_above_limit() {
+        let too_large = MAX_UPDATE_RELEASE_METADATA_BYTES + 1;
+        let (url, join) =
+            start_artifact_response(vec![("Content-Length", too_large.to_string())], Vec::new());
+        let client = UpdateClient::test_allow_insecure_http(None);
+
+        let err = latest_release_from_url(&client, &url)
+            .await
+            .unwrap_err()
+            .to_string();
+        join.join().unwrap();
+
+        assert!(err.contains("release metadata is too large"), "{err}");
+        assert!(err.contains(&too_large.to_string()), "{err}");
     }
 
     #[tokio::test]
@@ -474,12 +505,13 @@ mod tests {
                 .unwrap();
         let client = UpdateClient::test_with_cli_allow_insecure_http(&cli, None);
 
-        let response = update_get(&client, "http://updates.example/artifact")
-            .await
-            .unwrap();
+        let (status, response) =
+            test_update_get_buffered(&client, "http://updates.example/artifact")
+                .await
+                .unwrap();
         let request_line = join.join().unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(response.body(), b"proxied update");
         assert!(
             request_line.starts_with("GET http://updates.example/artifact HTTP/1.1"),
@@ -493,7 +525,10 @@ mod tests {
             start_slow_redirect_response(Duration::from_millis(150), Duration::from_millis(150));
         let client = UpdateClient::test_allow_insecure_http(Some(Duration::from_millis(220)));
 
-        let err = update_get(&client, &url).await.unwrap_err();
+        let err = match update_get_stream(&client, &url).await {
+            Ok(_) => panic!("expected shared timeout budget to expire"),
+            Err(err) => err,
+        };
         let _ = join.join();
 
         assert!(


### PR DESCRIPTION
## Summary
- Apply `--json` default headers after parsing so explicit `Accept` and `Content-Type` overrides win regardless of option order
- Match `--proto` checks case-insensitively for curl-imported URLs
- Stream update release metadata through a 1 MiB limit before buffering and parsing
- Adjust update-client tests to cover the new buffering flow and metadata size guard

## Testing
- Added unit coverage for curl JSON header precedence and case-insensitive proto restriction handling
- Added unit coverage for rejecting oversized release metadata responses