### PR TITLE
Fix piped formatting examples in docs

### DIFF
--- a/docs/output-formatting.md
+++ b/docs/output-formatting.md
@@ -398,13 +398,13 @@ fetch --format off example.com/api | jq '.users[0]'
 ### Save Pretty JSON
 
 ```sh
-fetch example.com/api | tee response.json
+fetch --format on example.com/api | tee response.json
 ```
 
 ### Force Colors in Pipe
 
 ```sh
-fetch --color on example.com/api | less -R
+fetch --format on --color on example.com/api | less -R
 ```
 
 ### Raw Binary Download


### PR DESCRIPTION
## Summary
- Update the output-formatting docs to show `--format on` when piping pretty JSON or forcing color output
- Keep the examples aligned with fetch's actual behavior in non-terminal pipelines

## Testing
- Not run (not requested)