### PR TITLE
Fix from-curl JSON example quoting

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -663,7 +663,7 @@ Cannot be combined with other request-specifying flags (URL, `--method`, `--head
 fetch --from-curl 'curl https://example.com'
 
 # POST with JSON
-fetch --from-curl 'curl -X POST -H "Content-Type: application/json" -d {"key":"value"} https://example.com'
+fetch --from-curl "curl -X POST -H 'Content-Type: application/json' -d '{\"key\":\"value\"}' https://example.com"
 
 # With authentication
 fetch --from-curl 'curl -u user:pass https://example.com'


### PR DESCRIPTION
## Summary
- Update the `--from-curl` JSON example in the CLI reference so the shell quoting is valid
- Use single quotes around the header and escaped JSON payload inside the outer double-quoted example

## Testing
- Not run (not requested)