### PR TITLE
Clarify fetch exit codes in troubleshooting docs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,15 +6,17 @@ This guide helps diagnose and fix common issues with `fetch`.
 
 `fetch` uses exit codes to indicate the result of a request:
 
-| Exit Code | Meaning                            |
-| --------- | ---------------------------------- |
-| 0         | Success (HTTP 2xx-3xx)             |
-| 4         | Client error (HTTP 4xx)            |
-| 5         | Server error (HTTP 5xx)            |
-| 6         | Other HTTP status or request error |
+| Exit Code | Meaning                              |
+| --------- | ------------------------------------ |
+| 0         | Success (HTTP 2xx-3xx)               |
+| 1         | Request, runtime, CLI, or gRPC error |
+| 4         | Client error (HTTP 4xx)              |
+| 5         | Server error (HTTP 5xx)              |
+| 6         | Other HTTP status                    |
 
-Unlike curl's default behavior, HTTP 4xx/5xx responses exit nonzero; use
-`--ignore-status` to ignore HTTP status when choosing the exit code.
+Unlike curl's default behavior, HTTP 4xx/5xx and other non-2xx/3xx responses
+exit nonzero; use `--ignore-status` to ignore HTTP status when choosing the
+exit code. gRPC status errors always exit 1.
 
 ### Ignore HTTP Status
 


### PR DESCRIPTION
## Summary
- Update the troubleshooting guide to document exit code `1` for request, runtime, CLI, and gRPC errors.
- Clarify that non-2xx/3xx responses exit nonzero, while gRPC status errors always exit `1`.
- Reword the exit code table for the current behavior.

## Testing
- Not run (not requested)