### PR TITLE
[codex] fix image rendering edge cases

### DIFF
--- a/src/image/decode.rs
+++ b/src/image/decode.rs
@@ -15,12 +15,42 @@ pub enum DecodeMode {
     External,
 }
 
+#[derive(Debug)]
+pub(crate) struct DecodedImage {
+    image: DynamicImage,
+    orientation_applied: bool,
+}
+
+impl DecodedImage {
+    pub(crate) fn needs_orientation(image: DynamicImage) -> Self {
+        Self {
+            image,
+            orientation_applied: false,
+        }
+    }
+
+    pub(crate) fn already_oriented(image: DynamicImage) -> Self {
+        Self {
+            image,
+            orientation_applied: true,
+        }
+    }
+
+    pub(crate) fn orientation_applied(&self) -> bool {
+        self.orientation_applied
+    }
+
+    pub(crate) fn into_image(self) -> DynamicImage {
+        self.image
+    }
+}
+
 pub(crate) fn decode_image(
     bytes: &[u8],
     decode_mode: DecodeMode,
-) -> Result<DynamicImage, ImageError> {
+) -> Result<DecodedImage, ImageError> {
     match decode_image_std(bytes) {
-        Ok(img) => Ok(img),
+        Ok(img) => Ok(DecodedImage::needs_orientation(img)),
         Err(err) if decode_mode == DecodeMode::BuiltIn => Err(err),
         Err(err) => match decode_with_adaptors(bytes) {
             Ok(img) => Ok(img),

--- a/src/image/external.rs
+++ b/src/image/external.rs
@@ -1,14 +1,15 @@
 use std::env;
 use std::io::{ErrorKind, Read};
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use ::image::DynamicImage;
+use crate::duration::format_go_duration;
 
 use super::ImageError;
-use super::decode::decode_image_std;
+use super::decode::{DecodedImage, decode_image_std};
+use super::orientation::orient_image;
 
 const TEMP_IMAGE_DIR_CREATE_ATTEMPTS: u32 = 100;
 const IMAGE_PATH_ARG: &str = "IMAGE_PATH";
@@ -20,6 +21,7 @@ struct Adaptor {
     name: &'static str,
     args: &'static [&'static str],
     env: &'static [(&'static str, &'static str)],
+    orientation_applied: bool,
 }
 
 const ADAPTORS: &[Adaptor] = &[
@@ -27,11 +29,13 @@ const ADAPTORS: &[Adaptor] = &[
         name: "vips",
         args: &["copy", IMAGE_PATH_ARG, ".jpeg"],
         env: &[("VIPS_MAX_MEM", "512MB")],
+        orientation_applied: false,
     },
     Adaptor {
         name: "magick",
         args: &[IMAGE_PATH_ARG, "-flatten", "-auto-orient", "jpeg:-"],
         env: &[("MAGICK_MEMORY_LIMIT", "512MiB")],
+        orientation_applied: true,
     },
     Adaptor {
         name: "ffmpeg",
@@ -53,23 +57,24 @@ const ADAPTORS: &[Adaptor] = &[
             "pipe:1",
         ],
         env: &[],
+        orientation_applied: true,
     },
 ];
 
-pub(crate) fn decode_with_adaptors(bytes: &[u8]) -> Result<DynamicImage, ImageError> {
+pub(crate) fn decode_with_adaptors(bytes: &[u8]) -> Result<DecodedImage, ImageError> {
     let dir = TempImageDir::create()?;
     let image_path = dir.path.join("fetch-temp-image");
     write_temp_image_file(&image_path, bytes)?;
 
     for adaptor in ADAPTORS {
-        if let Ok(img) = decode_adaptor(&image_path, *adaptor) {
-            return Ok(img);
+        if let Ok(decoded) = decode_adaptor(&image_path, *adaptor) {
+            return Ok(decoded);
         }
     }
     Err(ImageError::Message("unable to decode image".to_string()))
 }
 
-fn decode_adaptor(path: &Path, adaptor: Adaptor) -> Result<DynamicImage, ImageError> {
+fn decode_adaptor(path: &Path, adaptor: Adaptor) -> Result<DecodedImage, ImageError> {
     let mut cmd = Command::new(adaptor.name);
     for arg in adaptor.args {
         if *arg == IMAGE_PATH_ARG {
@@ -94,16 +99,32 @@ fn decode_adaptor(path: &Path, adaptor: Adaptor) -> Result<DynamicImage, ImageEr
             adaptor.name, ADAPTOR_STDOUT_CAP
         )));
     }
-    decode_image_std(&output.stdout)
+    let img = decode_image_std(&output.stdout)?;
+    let img = if adaptor.orientation_applied {
+        img
+    } else {
+        orient_image(&output.stdout, img)
+    };
+    Ok(DecodedImage::already_oriented(img))
 }
 
+#[derive(Debug)]
 struct AdaptorOutput {
     status: ExitStatus,
     stdout: Vec<u8>,
     stdout_truncated: bool,
 }
 
-fn run_adaptor(mut cmd: Command, name: &str) -> Result<AdaptorOutput, ImageError> {
+fn run_adaptor(cmd: Command, name: &str) -> Result<AdaptorOutput, ImageError> {
+    run_adaptor_with_timeout(cmd, name, ADAPTOR_TIMEOUT)
+}
+
+fn run_adaptor_with_timeout(
+    mut cmd: Command,
+    name: &str,
+    timeout: Duration,
+) -> Result<AdaptorOutput, ImageError> {
+    prepare_adaptor_command(&mut cmd);
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
@@ -113,19 +134,20 @@ fn run_adaptor(mut cmd: Command, name: &str) -> Result<AdaptorOutput, ImageError
         .take()
         .ok_or_else(|| ImageError::Message(format!("{name} stdout unavailable")))?;
     let stdout_reader = thread::spawn(move || read_capped(stdout, ADAPTOR_STDOUT_CAP));
-    let deadline = Instant::now() + ADAPTOR_TIMEOUT;
+    let deadline = Instant::now() + timeout;
 
     let status = loop {
         if let Some(status) = child.try_wait()? {
             break status;
         }
         if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = stdout_reader.join();
+            terminate_adaptor(&mut child);
+            if stdout_reader.is_finished() {
+                let _ = stdout_reader.join();
+            }
             return Err(ImageError::Message(format!(
-                "{name} timed out after {} seconds",
-                ADAPTOR_TIMEOUT.as_secs()
+                "{name} timed out after {}",
+                format_go_duration(timeout)
             )));
         }
         thread::sleep(Duration::from_millis(10));
@@ -140,6 +162,35 @@ fn run_adaptor(mut cmd: Command, name: &str) -> Result<AdaptorOutput, ImageError
         stdout_truncated,
     })
 }
+
+#[cfg(unix)]
+fn prepare_adaptor_command(cmd: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    cmd.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn prepare_adaptor_command(_cmd: &mut Command) {}
+
+fn terminate_adaptor(child: &mut Child) {
+    kill_adaptor_process_group(child);
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(unix)]
+fn kill_adaptor_process_group(child: &Child) {
+    if let Ok(pid) = i32::try_from(child.id()) {
+        // The adapter is spawned as a process-group leader, so this also catches helpers it starts.
+        unsafe {
+            libc::kill(-pid, libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_adaptor_process_group(_child: &Child) {}
 
 fn read_capped<R: Read>(mut reader: R, cap: usize) -> std::io::Result<(Vec<u8>, bool)> {
     let mut out = Vec::new();
@@ -282,5 +333,24 @@ mod tests {
         let (out, truncated) = read_capped(Cursor::new(b"abc"), 4).unwrap();
         assert_eq!(out, b"abc");
         assert!(!truncated);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn adaptor_timeout_does_not_wait_for_inherited_stdout() {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "sleep 5 >&1 & sleep 5"]);
+        let started_at = Instant::now();
+
+        let err = run_adaptor_with_timeout(command, "fake-adaptor", Duration::from_millis(100))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("fake-adaptor timed out after"), "{err}");
+        assert!(
+            started_at.elapsed() < Duration::from_secs(2),
+            "adapter timeout took {:?}",
+            started_at.elapsed()
+        );
     }
 }

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -41,7 +41,7 @@ fn render_with_options(
     decode_mode: DecodeMode,
     options: RenderOptions,
 ) -> Result<Vec<u8>, ImageError> {
-    let img = orient_image(bytes, decode_image(bytes, decode_mode)?);
+    let img = oriented_decoded_image(bytes, decode_image(bytes, decode_mode)?);
     if img.width() == 0 || img.height() == 0 {
         return Ok(Vec::new());
     }
@@ -57,10 +57,19 @@ fn render_with_options(
     }
 }
 
+fn oriented_decoded_image(bytes: &[u8], decoded: decode::DecodedImage) -> ::image::DynamicImage {
+    if decoded.orientation_applied() {
+        decoded.into_image()
+    } else {
+        orient_image(bytes, decoded.into_image())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::decode::DecodedImage;
     use super::terminal::{Protocol, RenderOptions, TerminalSize};
-    use super::{DecodeMode, render_with_options};
+    use super::{DecodeMode, oriented_decoded_image, render_with_options};
     use ::image::codecs::png::PngEncoder;
     use ::image::{ColorType, DynamicImage, ImageEncoder, Rgba, RgbaImage};
 
@@ -105,7 +114,68 @@ mod tests {
         .unwrap();
         assert_eq!(
             String::from_utf8(out).unwrap(),
-            "\x1b[48;2;255;0;0m\x1b[38;2;0;0;255m▄\x1b[0m\n\x1b[0m"
+            "\x1b[48;2;255;0;0m\x1b[38;2;0;0;255m▄\x1b[0m\n"
         );
+    }
+
+    #[test]
+    fn built_in_decode_applies_input_orientation_once() {
+        let img = DynamicImage::ImageRgba8({
+            let mut img = RgbaImage::new(2, 1);
+            img.put_pixel(0, 0, Rgba([1, 0, 0, 255]));
+            img.put_pixel(1, 0, Rgba([2, 0, 0, 255]));
+            img
+        });
+
+        let oriented = oriented_decoded_image(
+            &jpeg_with_orientation(6),
+            DecodedImage::needs_orientation(img),
+        )
+        .to_rgba8();
+
+        assert_eq!(oriented.dimensions(), (1, 2));
+        assert_eq!(oriented.get_pixel(0, 0)[0], 1);
+        assert_eq!(oriented.get_pixel(0, 1)[0], 2);
+    }
+
+    #[test]
+    fn external_decode_does_not_apply_input_orientation_twice() {
+        let already_oriented = DynamicImage::ImageRgba8({
+            let mut img = RgbaImage::new(1, 2);
+            img.put_pixel(0, 0, Rgba([1, 0, 0, 255]));
+            img.put_pixel(0, 1, Rgba([2, 0, 0, 255]));
+            img
+        });
+
+        let got = oriented_decoded_image(
+            &jpeg_with_orientation(6),
+            DecodedImage::already_oriented(already_oriented),
+        )
+        .to_rgba8();
+
+        assert_eq!(got.dimensions(), (1, 2));
+        assert_eq!(got.get_pixel(0, 0)[0], 1);
+        assert_eq!(got.get_pixel(0, 1)[0], 2);
+    }
+
+    fn jpeg_with_orientation(orientation: u16) -> Vec<u8> {
+        let mut app1 = Vec::new();
+        app1.extend_from_slice(b"Exif\0\0");
+        app1.extend_from_slice(&0x4d4d_u16.to_be_bytes());
+        app1.extend_from_slice(&42_u16.to_be_bytes());
+        app1.extend_from_slice(&8_u32.to_be_bytes());
+        app1.extend_from_slice(&1_u16.to_be_bytes());
+        app1.extend_from_slice(&0x0112_u16.to_be_bytes());
+        app1.extend_from_slice(&3_u16.to_be_bytes());
+        app1.extend_from_slice(&1_u32.to_be_bytes());
+        app1.extend_from_slice(&orientation.to_be_bytes());
+        app1.extend_from_slice(&0_u16.to_be_bytes());
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&0xffd8_u16.to_be_bytes());
+        bytes.extend_from_slice(&0xffe1_u16.to_be_bytes());
+        bytes.extend_from_slice(&u16::try_from(app1.len() + 2).unwrap().to_be_bytes());
+        bytes.extend_from_slice(&app1);
+        bytes
     }
 }

--- a/src/image/render.rs
+++ b/src/image/render.rs
@@ -15,10 +15,11 @@ pub(crate) fn write_blocks(
 ) -> Vec<u8> {
     let (cols, rows) = image_block_output_dimensions(img, term_width, term_height);
     let target_width = cols.max(1);
-    let target_height = (rows * 2).max(1);
+    let target_height = rows.saturating_mul(2).max(1);
     let dst = resize_image(img, target_width, target_height);
 
     let mut out = String::new();
+    let mut ansi = AnsiState::default();
     for row in 0..rows {
         let top_y = row * 2;
         let bottom_y = top_y + 1;
@@ -29,11 +30,11 @@ pub(crate) fn write_blocks(
             } else {
                 None
             };
-            write_block(&mut out, top, bottom, true_color);
+            write_block(&mut out, &mut ansi, top, bottom, true_color);
         }
+        ansi.reset(&mut out);
         out.push('\n');
     }
-    out.push_str("\x1b[0m");
     out.into_bytes()
 }
 
@@ -43,15 +44,20 @@ fn image_block_output_dimensions(
     term_height: u32,
 ) -> (u32, u32) {
     let cols = term_width.max(1);
-    let rows = (2 * term_height * 4 / 5).max(1);
+    let rows = scaled_u32(term_height, 8, 5).max(1);
     let (width, height) = img.dimensions();
+    if width == 0 || height == 0 {
+        return (1, 1);
+    }
     if width <= cols && height <= rows {
         return (width.max(1), (height / 2 + height % 2).max(1));
     }
-    if cols.saturating_mul(height) <= width.saturating_mul(rows) {
-        return (cols, ((height * cols) / width / 2).max(1));
+    if product_u64(cols, height) <= product_u64(width, rows) {
+        let height_pixels = product_u64(height, cols) / u64::from(width);
+        return (cols, u64_to_u32(height_pixels / 2).max(1));
     }
-    (((width * rows) / height).max(1), (rows / 2).max(1))
+    let scaled_width = product_u64(width, rows) / u64::from(height);
+    (u64_to_u32(scaled_width).max(1), (rows / 2).max(1))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,27 +80,75 @@ fn pixel_to_color(pixel: Rgba<u8>) -> Option<RgbColor> {
 
 fn write_block(
     out: &mut String,
+    ansi: &mut AnsiState,
     top: Option<RgbColor>,
     bottom: Option<RgbColor>,
     true_color: bool,
 ) {
     match (top, bottom) {
-        (None, None) => out.push(' '),
+        (None, None) => {
+            ansi.clear_fg(out);
+            ansi.clear_bg(out);
+            out.push(' ');
+        }
         (Some(top), None) => {
-            ansi_fg(out, top, true_color);
+            ansi.clear_bg(out);
+            ansi.set_fg(out, top, true_color);
             out.push('▀');
-            out.push_str("\x1b[0m");
         }
         (None, Some(bottom)) => {
-            ansi_fg(out, bottom, true_color);
+            ansi.clear_bg(out);
+            ansi.set_fg(out, bottom, true_color);
             out.push('▄');
-            out.push_str("\x1b[0m");
         }
         (Some(top), Some(bottom)) => {
-            ansi_bg(out, top, true_color);
-            ansi_fg(out, bottom, true_color);
+            ansi.set_bg(out, top, true_color);
+            ansi.set_fg(out, bottom, true_color);
             out.push('▄');
+        }
+    }
+}
+
+#[derive(Default)]
+struct AnsiState {
+    fg: Option<RgbColor>,
+    bg: Option<RgbColor>,
+}
+
+impl AnsiState {
+    fn set_fg(&mut self, out: &mut String, color: RgbColor, true_color: bool) {
+        if self.fg == Some(color) {
+            return;
+        }
+        ansi_fg(out, color, true_color);
+        self.fg = Some(color);
+    }
+
+    fn set_bg(&mut self, out: &mut String, color: RgbColor, true_color: bool) {
+        if self.bg == Some(color) {
+            return;
+        }
+        ansi_bg(out, color, true_color);
+        self.bg = Some(color);
+    }
+
+    fn clear_fg(&mut self, out: &mut String) {
+        if self.fg.take().is_some() {
+            out.push_str("\x1b[39m");
+        }
+    }
+
+    fn clear_bg(&mut self, out: &mut String) {
+        if self.bg.take().is_some() {
+            out.push_str("\x1b[49m");
+        }
+    }
+
+    fn reset(&mut self, out: &mut String) {
+        if self.fg.is_some() || self.bg.is_some() {
             out.push_str("\x1b[0m");
+            self.fg = None;
+            self.bg = None;
         }
     }
 }
@@ -206,12 +260,25 @@ fn bool_to_int(value: bool) -> u8 {
     u8::from(value)
 }
 
+fn scaled_u32(value: u32, numerator: u64, denominator: u64) -> u32 {
+    let scaled = u64::from(value).saturating_mul(numerator) / denominator.max(1);
+    u64_to_u32(scaled)
+}
+
+fn product_u64(left: u32, right: u32) -> u64 {
+    u64::from(left) * u64::from(right)
+}
+
+fn u64_to_u32(value: u64) -> u32 {
+    value.min(u64::from(u32::MAX)) as u32
+}
+
 fn resize_for_term(img: &DynamicImage, term_width_px: u32, term_height_px: u32) -> DynamicImage {
     if term_width_px == 0 || term_height_px == 0 {
         return img.clone();
     }
 
-    let term_height_px = (term_height_px * 4 / 5).max(1);
+    let term_height_px = scaled_u32(term_height_px, 4, 5).max(1);
     let (width, height) = img.dimensions();
     if width <= term_width_px && height <= term_height_px {
         return img.clone();
@@ -284,7 +351,21 @@ mod tests {
     #[test]
     fn write_blocks_uses_foreground_and_background_colors() {
         let out = String::from_utf8(write_blocks(&img_1x2(), 1, 1, true)).unwrap();
-        assert_eq!(out, "\x1b[48;2;255;0;0m\x1b[38;2;0;0;255m▄\x1b[0m\n\x1b[0m");
+        assert_eq!(out, "\x1b[48;2;255;0;0m\x1b[38;2;0;0;255m▄\x1b[0m\n");
+    }
+
+    #[test]
+    fn image_dimension_math_handles_extreme_terminal_sizes() {
+        let img = DynamicImage::ImageRgba8(RgbaImage::new(8192, 8192));
+
+        assert_eq!(image_block_output_dimensions(&img, u32::MAX, 1), (1, 1));
+        assert_eq!(
+            image_block_output_dimensions(&img, u32::MAX, u32::MAX),
+            (8192, 4096)
+        );
+
+        let resized = resize_for_term(&img, u32::MAX, u32::MAX);
+        assert_eq!(resized.dimensions(), (8192, 8192));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Prevent double EXIF orientation when images are decoded through external adapters.
- Bound external image adapter cleanup so timeout paths do not wait indefinitely on inherited stdout handles.
- Harden terminal image dimension math against overflow with extreme terminal sizes.
- Reduce block image ANSI output churn by tracking foreground/background state instead of resetting every cell.

## Why

The image renderer had a few correctness and robustness edge cases: external decoders could return already-oriented pixels while fetch applied the original EXIF orientation again, adapter timeout cleanup could block if a descendant kept stdout open, and terminal sizing math used direct `u32` multiplication. Block rendering was also emitting avoidable ANSI reset sequences per cell.

## Validation

- `cargo fmt --check`
- `cargo test --locked --all-features image::`
- `cargo test --locked --all-features --test terminal image`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
