### PR TITLE
Fix from-curl proto schemeless URL handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -812,7 +812,11 @@ fn apply_proto_restriction(raw_url: &str, allowed_proto: &str) -> Result<String,
     }
 
     let (allow_http, allow_https) = from_curl::parse_allowed_proto(allowed_proto);
-    if let Some((scheme, _rest)) = raw_url.split_once("://") {
+    if crate::http::has_authority_scheme(raw_url) {
+        let scheme = raw_url
+            .split_once(':')
+            .map(|(scheme, _rest)| scheme)
+            .unwrap_or_default();
         if scheme.eq_ignore_ascii_case("http") {
             if !allow_http {
                 return Err(
@@ -1401,6 +1405,18 @@ mod tests {
             (
                 "curl --proto '=http' example.com/path",
                 "http://example.com/path",
+            ),
+            (
+                "curl --proto '=http' example.com/path://still",
+                "http://example.com/path://still",
+            ),
+            (
+                "curl --proto '=http' example.com/path?next=https://other",
+                "http://example.com/path?next=https://other",
+            ),
+            (
+                "curl --proto '=http' example.com/path#next=https://other",
+                "http://example.com/path#next=https://other",
             ),
         ] {
             let mut cli = Cli::try_parse_from(["fetch", "--from-curl", command]).unwrap();

--- a/src/http/metadata.rs
+++ b/src/http/metadata.rs
@@ -255,7 +255,7 @@ pub(crate) fn normalize_url(raw: &str) -> Result<Url, FetchError> {
     }
 }
 
-fn has_authority_scheme(raw: &str) -> bool {
+pub(crate) fn has_authority_scheme(raw: &str) -> bool {
     let Some(colon) = raw.find(':') else {
         return false;
     };

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -68,7 +68,8 @@ mod retry;
 pub(crate) mod transport;
 
 pub(crate) use metadata::{
-    apply_headers, apply_query, load_session, normalize_url, request_target, save_session,
+    apply_headers, apply_query, has_authority_scheme, load_session, normalize_url, request_target,
+    save_session,
 };
 pub(crate) use request::{
     RequestBody, RequestBodyPayload, apply_aws_sigv4, apply_builder_authorization_headers,


### PR DESCRIPTION
## Summary

Fix `--from-curl --proto` handling for schemeless URLs that contain `://` later in the path, query, or fragment.

The previous check used a loose `split_once("://")`, which could mistake text after the authority position for an explicit URL scheme. This meant a command such as `curl --proto '=http' example.com/path://still` could bypass the intended schemeless defaulting path and later normalize as HTTPS.

This change reuses the HTTP URL authority-scheme detector so `--from-curl --proto` only treats a URL as explicitly schemed when the scheme appears before `/`, `?`, or `#` and is followed by `//`. Regression coverage now covers `://` in the path, query, and fragment.

## Validation

- `cargo fmt`
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- `cargo test --locked --all-features from_curl_proto`
- `cargo test --locked --all-features authority_scheme_detection_requires_valid_leading_scheme`