### PR TITLE
Add update documentation for manual and automatic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ fetch --compress off -o archive.tar.gz https://example.com/archive.tar.gz
 - **[WebSocket](docs/websocket.md)** - Bidirectional WebSocket connections
 - **[gRPC](docs/grpc.md)** - Making gRPC requests with Protocol Buffers
 - **[Advanced Features](docs/advanced-features.md)** - DNS, proxies, TLS, HTTP versions, and more
+- **[Updates](docs/updates.md)** - Manual updates, auto-update behavior, verification, and update files
 - **[Troubleshooting](docs/troubleshooting.md)** - Common issues, debugging, and exit codes
 
 ## License

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -737,6 +737,8 @@ Print build information. Use `-v --buildinfo` to include dependency details.
 ### `--update`
 
 Update fetch binary in place. Use with `--dry-run` to check for updates without installing.
+See [Updates](updates.md) for release source, verification, permissions,
+background auto-update behavior, and cache/lock files.
 
 ### `--complete SHELL`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,8 @@ option = host_specific_value
 **Default**: `false` (disabled)
 
 Enable or disable automatic updates, or set the minimum interval between update checks.
+See [Updates](updates.md) for background update behavior, cache files, locking,
+verification, and timeout/proxy behavior.
 
 ```ini
 # Enable auto-update with default 24-hour interval
@@ -741,3 +743,4 @@ Validation errors may include:
 - [CLI Reference](cli-reference.md) - All command-line options
 - [Authentication](authentication.md) - Detailed authentication setup
 - [Advanced Features](advanced-features.md) - DNS, proxies, and TLS configuration
+- [Updates](updates.md) - Manual and automatic update behavior

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -330,11 +330,20 @@ Update `fetch` to the latest version:
 fetch --update
 ```
 
+Check for an available update without installing it:
+
+```sh
+fetch --update --dry-run
+```
+
 Or enable automatic updates in your [configuration file](configuration.md):
 
 ```ini
 auto-update = true
 ```
+
+See [Updates](updates.md) for details about release source, checksum
+verification, permissions, background behavior, and cache files.
 
 ## Shell Completions
 
@@ -358,4 +367,5 @@ fetch --complete fish > ~/.config/fish/completions/fetch.fish
 - **[Authentication](authentication.md)** - Learn about authentication options
 - **[Request Bodies](request-bodies.md)** - Send JSON, XML, forms, and files
 - **[Output Formatting](output-formatting.md)** - Formatting and syntax highlighting details
+- **[Updates](updates.md)** - Keep `fetch` current
 - **[Image Rendering](image-rendering.md)** - Rendering images in the terminal

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,0 +1,168 @@
+# Updates
+
+`fetch` can update its own binary from the project's GitHub releases. Use
+`fetch --update` for an explicit update check, or set `auto-update` in the
+configuration file to run update checks in the background.
+
+## Manual Updates
+
+```sh
+fetch --update
+```
+
+`--update` checks the latest release, downloads the release artifact for the
+current operating system and CPU architecture, verifies it, and replaces the
+currently running `fetch` executable in place.
+
+The update command prints status to stderr. On success, it reports the old and
+new versions and, when possible, a GitHub compare URL for the changelog.
+
+## Dry Run
+
+Use `--dry-run` to check whether an update is available without downloading or
+installing the release artifact:
+
+```sh
+fetch --update --dry-run
+```
+
+Dry-run mode still performs the same executable permission preflight and latest
+release lookup as a normal update. If the latest release matches your current
+version, it reports that `fetch` is already up to date. If a newer release is
+available, it reports the version change and exits without downloading the
+archive or modifying the binary.
+
+## Update Source
+
+By default, self-updates read release metadata from:
+
+```text
+https://api.github.com/repos/ryanfowler/fetch/releases/latest
+```
+
+The release metadata points to the platform artifact and checksum sidecar on
+GitHub Releases. `fetch` selects an artifact named like:
+
+```text
+fetch-<version>-<os>-<arch>.tar.gz
+fetch-<version>-windows-<arch>.zip
+```
+
+The updater uses Go-style platform names for compatibility with the release
+artifacts, such as `darwin`, `linux`, `windows`, `amd64`, and `arm64`.
+
+The request URL argument is not used as an update source, and there is no
+configuration option for selecting an alternate update channel.
+
+Self-update URLs must use HTTPS. Redirects are followed, but redirect targets
+must also use HTTPS.
+
+## Verification
+
+Before replacing the executable, `fetch` downloads the matching
+`<artifact>.sha256` sidecar, parses the leading SHA-256 digest, hashes the
+downloaded artifact as it streams, and compares the two digests. A mismatch
+aborts the update before installation.
+
+The updater also bounds the release metadata, checksum file, artifact download,
+archive entry count, and unpacked data size, and refuses archive paths that
+would escape the temporary unpack directory.
+
+## Permissions
+
+Self-update replaces the executable returned by the operating system as the
+current `fetch` binary. The process must be able to write in that executable's
+directory.
+
+On Unix-like systems, `fetch` checks directory write access before contacting
+the update source. If `fetch` was installed into a root-owned or package-manager
+managed directory, run the update with appropriate permissions or update through
+the package manager instead. On Windows, replacement errors are reported if the
+binary cannot be moved into place.
+
+Temporary unpack directories are created under the system temp directory as
+`fetch-update-*` and are removed after the update attempt. On Unix-like systems,
+these directories are created with private `0700` permissions.
+
+## Automatic Updates
+
+Enable background update checks in the configuration file:
+
+```ini
+# Check at most once every 24 hours
+auto-update = true
+
+# Check at most once every 12 hours
+auto-update = 12h
+
+# Disable automatic updates
+auto-update = false
+```
+
+`true` uses a 24 hour interval. Custom intervals require units, including
+values such as `30m`, `1.5h`, `4h`, and `1d`. `false`, `off`, `no`, `never`,
+and `0` disable automatic updates.
+
+Automatic updates run after configuration has been loaded and validated, and
+only for normal request/inspection commands. Metadata commands such as
+`fetch --help`, `fetch --version`, and `fetch --buildinfo` do not start
+background updates.
+
+When an automatic update is due, `fetch` starts a detached child process with:
+
+```text
+--update --timeout=300 --silent
+```
+
+The parent command continues without waiting, and the child process has stdin,
+stdout, and stderr detached. The explicit config path from `--config` is passed
+to the child; otherwise the child uses normal config discovery. Background
+update failures are not reported by the parent command.
+
+## Cache and Lock Files
+
+Automatic update scheduling and update locking use the user cache directory:
+
+| Platform             | Directory                                        |
+| -------------------- | ------------------------------------------------ |
+| macOS                | `$HOME/Library/Caches/fetch`                     |
+| Linux and other Unix | `$XDG_CACHE_HOME/fetch`, or `$HOME/.cache/fetch` |
+| Windows              | `%LOCALAPPDATA%\fetch`                           |
+
+Files in this directory include:
+
+| File            | Purpose                                                                   |
+| --------------- | ------------------------------------------------------------------------- |
+| `metadata.json` | Stores the last update attempt timestamp for auto-update interval checks. |
+| `.update-lock`  | Advisory lock that prevents concurrent update attempts.                   |
+
+Manual and automatic update attempts both refresh `metadata.json`, including
+`fetch --update --dry-run`.
+
+Explicit `fetch --update` waits for the update lock, up to the shorter of the
+request timeout and 30 seconds. Background auto-update checks use a nonblocking
+lock attempt; if another update is running, the background check is skipped.
+
+## Proxy and Timeout Behavior
+
+Self-update downloads use the same HTTP transport as normal requests. Proxy
+configuration from `--proxy`, the configuration file, and standard proxy
+environment variables applies to update metadata, checksum, and artifact
+requests. `NO_PROXY` is honored by the transport.
+
+`--timeout` and `--connect-timeout` also apply to explicit update requests:
+
+```sh
+fetch --update --timeout 120 --connect-timeout 10
+```
+
+Each update network operation uses the configured timeout budget, and redirects
+share the budget of the request that encountered them. Automatic updates set
+`--timeout=300` for the child process so background checks cannot run
+indefinitely.
+
+## See Also
+
+- [Configuration](configuration.md) - Configure `auto-update`, proxies, and timeouts
+- [CLI Reference](cli-reference.md) - Command-line option reference
+- [Getting Started](getting-started.md) - Installation and first-run basics


### PR DESCRIPTION
## Summary
- Add a new updates guide covering manual `--update`, dry-run behavior, release sources, checksum verification, permissions, cache files, locks, and proxy/timeout handling
- Cross-link the new guide from the README, CLI reference, configuration docs, and getting started guide
- Document `--update --dry-run` as a way to check for available updates without installing

## Testing
- Not run (not requested)