### PR TITLE
Warn on ignored request flags during inspect modes

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -51,6 +51,8 @@ fetch --inspect-dns example.com
 fetch --inspect-dns --dns-server https://1.1.1.1/dns-query example.com
 ```
 
+Request-only CLI flags warn that no HTTP request will be sent and those flags have no effect when used with `--inspect-dns`; config-file defaults do not trigger this warning.
+
 The output shows the resolver backend, A, AAAA, CNAME, TXT, MX, NS, SOA, SRV, CAA, SVCB, and HTTPS records when present, address count, record count, lookup duration, and per-record TTLs. UDP DNS inspection advertises EDNS(0) and retries truncated UDP responses over TCP; if TCP fallback cannot complete the lookup, `fetch` warns that the results are incomplete and exits with a non-zero status.
 
 ### Configuration File
@@ -264,7 +266,7 @@ Output includes:
 
 Expiry is color-coded: red if expired or less than 7 days remaining, yellow if less than 30 days, green otherwise.
 
-HTTP-only flags (e.g. `--data`, `--timing`, `--grpc`) are ignored with a warning when used with `--inspect-tls`.
+Request-only CLI flags (e.g. `--data`, `--timing`, `--grpc`) warn that no HTTP request will be sent and those flags have no effect when used with `--inspect-tls`; config-file defaults do not trigger this warning.
 
 `--dns-server` applies to TLS inspection too, so certificate diagnostics can use
 the same UDP or DNS-over-HTTPS resolver override as normal requests. When

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -388,7 +388,7 @@ fetch --dns-server https://1.1.1.1/dns-query example.com
 
 ### `--inspect-dns`
 
-Inspect DNS resolution for the URL hostname only (no HTTP request is made). Displays the resolver backend, A, AAAA, CNAME, TXT, MX, NS, SOA, SRV, CAA, SVCB, and HTTPS records when present, along with per-record TTLs, address count, record count, and lookup duration. UDP DNS inspection advertises EDNS(0) and retries truncated UDP responses over TCP; if TCP fallback cannot complete the lookup, `fetch` warns that the results are incomplete and exits with a non-zero status.
+Inspect DNS resolution for the URL hostname only (no HTTP request is made). Displays the resolver backend, A, AAAA, CNAME, TXT, MX, NS, SOA, SRV, CAA, SVCB, and HTTPS records when present, along with per-record TTLs, address count, record count, and lookup duration. UDP DNS inspection advertises EDNS(0) and retries truncated UDP responses over TCP; if TCP fallback cannot complete the lookup, `fetch` warns that the results are incomplete and exits with a non-zero status. Request-only CLI flags warn that no HTTP request will be sent and those flags have no effect; config-file defaults do not trigger this warning.
 
 ```sh
 fetch --inspect-dns example.com
@@ -445,7 +445,7 @@ fetch --min-tls 1.2 --max-tls 1.2 example.com
 
 ### `--inspect-tls`
 
-Inspect the TLS certificate chain by performing a TLS handshake only (no HTTP request is made). Displays the TLS version, cipher suite, ALPN protocol, full certificate chain with expiry status, Subject Alternative Names (SANs), and OCSP staple status. Requires an HTTPS URL. With `--http 3`, inspection uses a QUIC handshake and offers `h3` ALPN. HTTP-only flags (e.g. `--data`, `--timing`, `--grpc`) are ignored with a warning.
+Inspect the TLS certificate chain by performing a TLS handshake only (no HTTP request is made). Displays the TLS version, cipher suite, ALPN protocol, full certificate chain with expiry status, Subject Alternative Names (SANs), and OCSP staple status. Requires an HTTPS URL. With `--http 3`, inspection uses a QUIC handshake and offers `h3` ALPN. Request-only CLI flags (e.g. `--data`, `--timing`, `--grpc`) warn that no HTTP request will be sent and those flags have no effect; config-file defaults do not trigger this warning.
 
 ```sh
 fetch --inspect-tls example.com

--- a/src/app.rs
+++ b/src/app.rs
@@ -278,6 +278,13 @@ async fn run_inner(cli: &mut Cli) -> Result<i32, FetchError> {
     let direct_cli_sources = DirectCliSources::capture(cli);
 
     apply_from_curl(cli)?;
+    let direct_inspection_ignored_flags = if cli.inspect_dns {
+        crate::dns::inspect::ignored_inspection_flags(cli)
+    } else if cli.inspect_tls {
+        crate::tls::inspect::ignored_inspection_flags(cli)
+    } else {
+        Vec::new()
+    };
     let config_path = crate::config::apply(cli)?;
     crate::config::validate(cli)?;
     crate::cli::parse_http_version(cli.http.as_deref()).map_err(FetchError::Message)?;
@@ -307,11 +314,11 @@ async fn run_inner(cli: &mut Cli) -> Result<i32, FetchError> {
     }
 
     if cli.inspect_dns {
-        return crate::dns::inspect::execute(cli).await;
+        return crate::dns::inspect::execute(cli, &direct_inspection_ignored_flags).await;
     }
 
     if cli.inspect_tls {
-        return crate::tls::inspect::execute(cli).await;
+        return crate::tls::inspect::execute(cli, &direct_inspection_ignored_flags).await;
     }
 
     let is_websocket = cli

--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -151,13 +151,15 @@ enum ResolverTarget {
     Doh { label: String, url: Url },
 }
 
-pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
+pub async fn execute(cli: &Cli, ignored_flags: &[&'static str]) -> Result<i32, FetchError> {
     let request_start = Instant::now();
     let url = crate::http::normalize_url(cli.url.as_deref().expect("URL checked by app"))?;
-    let ignored = ignored_inspection_flags(cli);
-    if !ignored.is_empty() && !cli.silent {
+    if !ignored_flags.is_empty() && !cli.silent {
         write_warning_with_separator_with_color(
-            format!("--inspect-dns ignores: {}", ignored.join(", ")),
+            format!(
+                "No HTTP request will be sent; these flags have no effect: {}",
+                ignored_flags.join(", ")
+            ),
             cli.color.as_deref(),
         );
     }
@@ -1015,7 +1017,7 @@ fn hex_digit(byte: u8) -> Option<u8> {
     }
 }
 
-fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
+pub(crate) fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     let mut ignored = Vec::new();
     if cli.data.is_some() || cli.json.is_some() || cli.xml.is_some() {
         ignored.push("--data/--json/--xml");
@@ -1035,6 +1037,15 @@ fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     if cli.grpc_list {
         ignored.push("--grpc-list");
     }
+    if cli.proto_desc.is_some() {
+        ignored.push("--proto-desc");
+    }
+    if !cli.proto_files.is_empty() {
+        ignored.push("--proto-file");
+    }
+    if !cli.proto_imports.is_empty() {
+        ignored.push("--proto-import");
+    }
     if cli.output.is_some() {
         ignored.push("--output");
     }
@@ -1046,6 +1057,9 @@ fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     }
     if cli.copy {
         ignored.push("--copy");
+    }
+    if cli.clobber {
+        ignored.push("--clobber");
     }
     if cli.method.is_some() {
         ignored.push("--method");
@@ -1065,6 +1079,12 @@ fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     if cli.retry() > 0 {
         ignored.push("--retry");
     }
+    if cli.retry_delay.is_some() {
+        ignored.push("--retry-delay");
+    }
+    if cli.redirects.is_some() {
+        ignored.push("--redirects");
+    }
     if !cli.ranges.is_empty() {
         ignored.push("--range");
     }
@@ -1079,6 +1099,9 @@ fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     }
     if cli.unix.is_some() {
         ignored.push("--unix");
+    }
+    if cli.http.is_some() {
+        ignored.push("--http");
     }
     if cli.inspect_tls {
         ignored.push("--inspect-tls");
@@ -1113,8 +1136,29 @@ fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     if cli.insecure {
         ignored.push("--insecure");
     }
+    if cli.compress.is_some() || cli.no_encode {
+        ignored.push("--compress/--no-encode");
+    }
     if cli.format.is_some() {
         ignored.push("--format");
+    }
+    if cli.image.is_some() {
+        ignored.push("--image");
+    }
+    if cli.pager.is_some() {
+        ignored.push("--pager");
+    }
+    if cli.ignore_status {
+        ignored.push("--ignore-status");
+    }
+    if cli.sort_headers {
+        ignored.push("--sort-headers");
+    }
+    if cli.ws_interactive.is_some() {
+        ignored.push("--ws-interactive");
+    }
+    if cli.ws_message_mode.is_some() {
+        ignored.push("--ws-message-mode");
     }
     if cli.dry_run {
         ignored.push("--dry-run");
@@ -1588,17 +1632,41 @@ mod tests {
             "-d",
             "body",
             "--grpc",
+            "--proto-file",
+            "Cargo.toml",
+            "--proto-import",
+            ".",
             "--output",
             "out.txt",
             "--copy",
+            "--clobber",
+            "--compress",
+            "off",
+            "--http",
+            "2",
+            "--image",
+            "off",
+            "--pager",
+            "off",
+            "--ignore-status",
             "--timing",
             "--proxy",
             "http://proxy.test",
+            "--redirects",
+            "1",
+            "--retry-delay",
+            "0.1",
+            "--sort-headers",
             "--bearer",
             "token",
             "--insecure",
             "--format",
             "off",
+            "--ws-interactive",
+            "off",
+            "--ws-message-mode",
+            "text",
+            "--dry-run",
         ])
         .unwrap();
 
@@ -1607,13 +1675,27 @@ mod tests {
             [
                 "--data/--json/--xml",
                 "--grpc",
+                "--proto-file",
+                "--proto-import",
                 "--output",
                 "--copy",
+                "--clobber",
+                "--retry-delay",
+                "--redirects",
                 "--timing",
                 "--proxy",
+                "--http",
                 "--bearer",
                 "--insecure",
+                "--compress/--no-encode",
                 "--format",
+                "--image",
+                "--pager",
+                "--ignore-status",
+                "--sort-headers",
+                "--ws-interactive",
+                "--ws-message-mode",
+                "--dry-run",
             ]
         );
     }

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -19,14 +19,16 @@ use crate::core::{self, Printer, Sequence};
 use crate::duration::{TimeoutBudget, duration_from_seconds};
 use crate::error::{FetchError, write_warning_with_separator_with_color};
 
-pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
+pub async fn execute(cli: &Cli, ignored_flags: &[&'static str]) -> Result<i32, FetchError> {
     let request_start = Instant::now();
     let url = tls_url(cli.url.as_deref().expect("URL checked by app"))?;
     super::validate_client_auth_for_tls(cli.cert.as_deref(), cli.key.as_deref())?;
-    let ignored = ignored_inspection_flags(cli);
-    if !ignored.is_empty() && !cli.silent {
+    if !ignored_flags.is_empty() && !cli.silent {
         write_warning_with_separator_with_color(
-            format!("--inspect-tls ignores: {}", ignored.join(", ")),
+            format!(
+                "No HTTP request will be sent; these flags have no effect: {}",
+                ignored_flags.join(", ")
+            ),
             cli.color.as_deref(),
         );
     }
@@ -547,7 +549,7 @@ fn alpn_protocols(http_version: Option<HttpVersion>) -> &'static [&'static str] 
     }
 }
 
-fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
+pub(crate) fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     let mut ignored = Vec::new();
     if cli.data.is_some() || cli.json.is_some() || cli.xml.is_some() {
         ignored.push("--data/--json/--xml");
@@ -567,6 +569,15 @@ fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     if cli.grpc_list {
         ignored.push("--grpc-list");
     }
+    if cli.proto_desc.is_some() {
+        ignored.push("--proto-desc");
+    }
+    if !cli.proto_files.is_empty() {
+        ignored.push("--proto-file");
+    }
+    if !cli.proto_imports.is_empty() {
+        ignored.push("--proto-import");
+    }
     if cli.output.is_some() {
         ignored.push("--output");
     }
@@ -578,6 +589,9 @@ fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     }
     if cli.copy {
         ignored.push("--copy");
+    }
+    if cli.clobber {
+        ignored.push("--clobber");
     }
     if cli.method.is_some() {
         ignored.push("--method");
@@ -597,6 +611,12 @@ fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     if cli.retry() > 0 {
         ignored.push("--retry");
     }
+    if cli.retry_delay.is_some() {
+        ignored.push("--retry-delay");
+    }
+    if cli.redirects.is_some() {
+        ignored.push("--redirects");
+    }
     if !cli.ranges.is_empty() {
         ignored.push("--range");
     }
@@ -611,6 +631,45 @@ fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     }
     if cli.unix.is_some() {
         ignored.push("--unix");
+    }
+    if cli.bearer.is_some() {
+        ignored.push("--bearer");
+    }
+    if cli.basic.is_some() {
+        ignored.push("--basic");
+    }
+    if cli.digest.is_some() {
+        ignored.push("--digest");
+    }
+    if cli.aws_sigv4.is_some() {
+        ignored.push("--aws-sigv4");
+    }
+    if cli.compress.is_some() || cli.no_encode {
+        ignored.push("--compress/--no-encode");
+    }
+    if cli.format.is_some() {
+        ignored.push("--format");
+    }
+    if cli.image.is_some() {
+        ignored.push("--image");
+    }
+    if cli.pager.is_some() {
+        ignored.push("--pager");
+    }
+    if cli.ignore_status {
+        ignored.push("--ignore-status");
+    }
+    if cli.sort_headers {
+        ignored.push("--sort-headers");
+    }
+    if cli.ws_interactive.is_some() {
+        ignored.push("--ws-interactive");
+    }
+    if cli.ws_message_mode.is_some() {
+        ignored.push("--ws-message-mode");
+    }
+    if cli.dry_run {
+        ignored.push("--dry-run");
     }
     ignored
 }
@@ -1541,12 +1600,38 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
             "-d",
             "body",
             "--grpc",
+            "--proto-file",
+            "Cargo.toml",
+            "--proto-import",
+            ".",
             "--output",
             "out.txt",
             "--copy",
+            "--clobber",
+            "--compress",
+            "off",
+            "--image",
+            "off",
+            "--pager",
+            "off",
+            "--ignore-status",
             "--timing",
             "--proxy",
             "http://proxy.test",
+            "--redirects",
+            "1",
+            "--retry-delay",
+            "0.1",
+            "--sort-headers",
+            "--bearer",
+            "token",
+            "--format",
+            "off",
+            "--ws-interactive",
+            "off",
+            "--ws-message-mode",
+            "text",
+            "--dry-run",
         ])
         .unwrap();
 
@@ -1555,10 +1640,25 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
             [
                 "--data/--json/--xml",
                 "--grpc",
+                "--proto-file",
+                "--proto-import",
                 "--output",
                 "--copy",
+                "--clobber",
+                "--retry-delay",
+                "--redirects",
                 "--timing",
-                "--proxy"
+                "--proxy",
+                "--bearer",
+                "--compress/--no-encode",
+                "--format",
+                "--image",
+                "--pager",
+                "--ignore-status",
+                "--sort-headers",
+                "--ws-interactive",
+                "--ws-message-mode",
+                "--dry-run",
             ]
         );
     }

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -635,6 +635,41 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
     assert!(res.stderr.contains("Addresses: 2"));
     assert!(res.stderr.contains("Records:"));
 
+    let res = run_fetch(&[
+        "--inspect-dns",
+        "--data",
+        "hi",
+        "--compress",
+        "off",
+        "127.0.0.1",
+    ]);
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(
+        res.stderr
+            .contains("No HTTP request will be sent; these flags have no effect")
+    );
+    assert!(res.stderr.contains("--data/--json/--xml"));
+    assert!(res.stderr.contains("--compress/--no-encode"));
+    assert!(!res.stderr.contains("--inspect-dns ignores"));
+
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("config");
+    fs::write(
+        &config,
+        "compress = off\nformat = off\npager = off\ntiming = true\n",
+    )
+    .unwrap();
+    let res = run_fetch(&[
+        "--config",
+        config.to_str().unwrap(),
+        "--inspect-dns",
+        "127.0.0.1",
+    ]);
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(!res.stderr.contains("No HTTP request will be sent"));
+
     let res = run_fetch(&["--silent", "--inspect-dns", "--data", "hi", "127.0.0.1"]);
     assert_exit(&res, 0);
     assert!(res.stdout.is_empty());
@@ -1038,6 +1073,47 @@ fn tls_certificate_validation_inspection_and_bounds_cases() {
     assert!(res.stdout.is_empty());
     assert!(res.stderr.contains("TLS"));
     assert!(res.stderr.contains("Certificate") || res.stderr.contains("certificate"));
+
+    let res = run_fetch(&[
+        "--inspect-tls",
+        "--insecure",
+        "--data",
+        "hi",
+        "--bearer",
+        "token",
+        "--format",
+        "off",
+        &tls.url,
+    ]);
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(
+        res.stderr
+            .contains("No HTTP request will be sent; these flags have no effect")
+    );
+    assert!(res.stderr.contains("--data/--json/--xml"));
+    assert!(res.stderr.contains("--bearer"));
+    assert!(res.stderr.contains("--format"));
+    assert!(!res.stderr.contains("--insecure"));
+    assert!(!res.stderr.contains("--inspect-tls ignores"));
+
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("config");
+    fs::write(
+        &config,
+        "compress = off\nformat = off\npager = off\ntiming = true\n",
+    )
+    .unwrap();
+    let res = run_fetch(&[
+        "--config",
+        config.to_str().unwrap(),
+        "--inspect-tls",
+        "--insecure",
+        &tls.url,
+    ]);
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(!res.stderr.contains("No HTTP request will be sent"));
 
     let stalling_tls = start_stalling_proxy("https");
     let res = run_fetch(&[


### PR DESCRIPTION
## Summary
- Update `--inspect-dns` and `--inspect-tls` to warn with clearer wording when request-only CLI flags are supplied.
- Expand the ignored-flag detection to cover additional request, transport, formatting, and WebSocket options.
- Keep config-file defaults from triggering the warning so only explicit CLI flags are reported.
- Refresh docs to describe the new warning behavior.

## Testing
- Added integration coverage for both inspection modes, including explicit CLI flags and config-backed defaults.
- Verified the new warning text and ensured the older `--inspect-*- ignores` wording no longer appears.
- Existing inspection behavior remains unchanged when no ignored CLI flags are present.