### PR TITLE
Add plaintext URL hints for schemeless HTTPS failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,9 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
   `--multipart`, and `--edit`) infer `POST` when `--method` is omitted.
   Explicit methods still win, including `-m GET` with a body.
 - Schemeless URLs default to HTTPS for hostnames, but `localhost` and all IP
-  literals default to HTTP.
+  literals default to HTTP. Dry-run output includes the normalized absolute URL,
+  and schemeless HTTPS connect/TLS failures suggest the equivalent `http://`
+  URL for plaintext services.
 
 Retryable requests use replayable request bodies so retries and 307/308 redirects can resend data without holding unrelated state.
 Multipart `-F` request bodies are produced with a stable boundary so redirected requests preserve the original body shape.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,7 +10,10 @@ fetch [OPTIONS] [URL]
 
 ## URL Handling
 
-When no scheme is provided, `fetch` defaults to HTTPS for hostnames. `localhost` and all IP literals default to HTTP.
+When no scheme is provided, `fetch` defaults to HTTPS for hostnames. `localhost`
+and all IP literals default to HTTP. If a schemeless hostname defaults to HTTPS
+and the connection fails during setup, `fetch` suggests the equivalent
+`http://` URL for plaintext services.
 
 ```sh
 fetch example.com          # https://example.com
@@ -752,7 +755,9 @@ fetch --complete fish > ~/.config/fish/completions/fetch.fish
 
 ### `--dry-run`
 
-Print request information without sending. When used with `--update`, checks for the latest version without installing.
+Print request information without sending, including the normalized absolute
+URL. When used with `--update`, checks for the latest version without
+installing.
 
 ```sh
 fetch --dry-run -j '{"test": true}' example.com

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,6 +81,10 @@ fetch http://example.com   # Force HTTP
 fetch https://localhost    # Force HTTPS for localhost
 ```
 
+If a schemeless hostname such as `example.com:8080` defaults to HTTPS but the
+port is serving plaintext HTTP, `fetch` includes a hint to retry with the
+equivalent `http://` URL.
+
 ## Understanding the Output
 
 `fetch` separates its output into two streams:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,6 +75,7 @@ fetch --dry-run -j '{"test": true}' example.com
 Shows:
 
 - Complete request that would be sent
+- Normalized absolute URL after schemeless URL defaults and query flags
 - Headers and body
 - Useful for debugging authentication and body formatting
 

--- a/src/http/metadata.rs
+++ b/src/http/metadata.rs
@@ -122,6 +122,15 @@ pub(super) fn print_request_metadata(
     printer.push_str(" ");
     printer.write_styled(request_protocol_label(http_version), &[core::Sequence::Dim]);
     printer.push_str("\n");
+    if cli.dry_run {
+        if debug {
+            printer.write_request_prefix();
+        }
+        printer.write_styled("url", &[core::Sequence::Bold, core::Sequence::Blue]);
+        printer.push_str(": ");
+        printer.push_str(url.as_str());
+        printer.push_str("\n");
+    }
     let mut lines = header_lines(headers);
     lines.retain(|(name, _)| !name.eq_ignore_ascii_case("host"));
     if let Some(len) = inferred_request_body_content_len(headers, body)? {
@@ -296,6 +305,22 @@ fn normalize_schemeless_url(raw: &str) -> Result<Url, FetchError> {
     Url::parse(&format!("{scheme}://{raw}")).map_err(Into::into)
 }
 
+pub(super) fn schemeless_plaintext_hint_url(raw: &str, url: &Url) -> Option<String> {
+    if has_authority_scheme(raw) || url.scheme() != "https" {
+        return None;
+    }
+    let mut plaintext_url = url.clone();
+    plaintext_url.set_scheme("http").ok()?;
+    let mut hint = plaintext_url.to_string();
+    if plaintext_url.path() == "/"
+        && plaintext_url.query().is_none()
+        && plaintext_url.fragment().is_none()
+    {
+        hint.pop();
+    }
+    Some(hint)
+}
+
 pub(super) fn rewrite_url_scheme(mut url: Url, scheme: &str) -> Result<Url, FetchError> {
     let original = url.scheme().to_string();
     url.set_scheme(scheme)
@@ -426,6 +451,33 @@ mod tests {
     fn default_scheme_non_loopback_is_https() {
         let url = normalize_url("example.com/path").unwrap();
         assert_eq!(url.as_str(), "https://example.com/path");
+    }
+
+    #[test]
+    fn schemeless_plaintext_hint_rewrites_only_default_https_urls() {
+        let url = normalize_url("example.com:8080/path?debug=true").unwrap();
+        assert_eq!(
+            schemeless_plaintext_hint_url("example.com:8080/path?debug=true", &url).as_deref(),
+            Some("http://example.com:8080/path?debug=true")
+        );
+
+        let root_url = normalize_url("example.com:8080").unwrap();
+        assert_eq!(
+            schemeless_plaintext_hint_url("example.com:8080", &root_url).as_deref(),
+            Some("http://example.com:8080")
+        );
+
+        let explicit = normalize_url("https://example.com:8080/path").unwrap();
+        assert_eq!(
+            schemeless_plaintext_hint_url("https://example.com:8080/path", &explicit),
+            None
+        );
+
+        let loopback = normalize_url("localhost:8080/path").unwrap();
+        assert_eq!(
+            schemeless_plaintext_hint_url("localhost:8080/path", &loopback),
+            None
+        );
     }
 
     #[test]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -422,7 +422,8 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                 if let Some(message) = timeout_error_message(cli, &err) {
                     break Err(FetchError::Runtime(message));
                 }
-                let message = transport_request_error_message(&err);
+                let mut message = transport_request_error_message(&err);
+                append_schemeless_plaintext_hint(&mut message, cli, &url, &request_url, &err);
                 if is_certificate_validation_error(&err) {
                     break Err(FetchError::CertificateValidation(message));
                 }

--- a/src/http/retry.rs
+++ b/src/http/retry.rs
@@ -287,6 +287,32 @@ pub(super) fn transport_request_error_message(err: &transport::Error) -> String 
     message
 }
 
+pub(super) fn append_schemeless_plaintext_hint(
+    message: &mut String,
+    cli: &Cli,
+    original_url: &Url,
+    request_url: &Url,
+    err: &transport::Error,
+) {
+    if !err.is_connect()
+        || url_client_endpoint(original_url) != url_client_endpoint(request_url)
+        || is_certificate_validation_error(err)
+    {
+        return;
+    }
+
+    let Some(raw_url) = cli.url.as_deref() else {
+        return;
+    };
+    let Some(plaintext_url) = schemeless_plaintext_hint_url(raw_url, request_url) else {
+        return;
+    };
+    message.push('\n');
+    message.push_str("If this is a plaintext service, use ");
+    message.push_str(&plaintext_url);
+    message.push('.');
+}
+
 pub(super) fn transport_response_body_error_message(err: &transport::Error) -> String {
     let mut details = Vec::new();
     let mut source = err.source();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -186,6 +186,7 @@ fn dry_run_prints_effective_request_without_network() {
     assert_exit(&res, 0);
     assert!(res.stdout.is_empty());
     assert!(res.stderr.contains("POST / HTTP/1.1\n"));
+    assert!(res.stderr.contains("url: http://localhost:3000/\n"));
     assert!(res.stderr.contains("accept: application/json, */*;q=0.5"));
     assert!(res.stderr.contains("accept-encoding: gzip, br, zstd\n"));
     assert!(res.stderr.contains("content-length: 14\n"));
@@ -233,6 +234,13 @@ fn dry_run_prints_effective_request_without_network() {
     assert!(res.stderr.contains("content-length: 99\n"));
     assert!(!res.stderr.contains("content-length: 5\n"));
     assert_eq!(res.stderr.matches("content-length:").count(), 1);
+
+    let res = run_fetch(&["example.com:8080/path?debug=true", "--dry-run"]);
+    assert_exit(&res, 0);
+    assert!(
+        res.stderr
+            .contains("url: https://example.com:8080/path?debug=true\n")
+    );
 
     let res = run_fetch(&[
         "localhost:3000",

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -90,6 +90,54 @@ fn request_construction_and_data_sources() {
     assert_eq!(req.body_string(), r#"{"key":"val"}"#);
 }
 
+#[test]
+fn schemeless_https_connect_error_suggests_plaintext_url() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind plaintext listener");
+    listener
+        .set_nonblocking(true)
+        .expect("set plaintext listener nonblocking");
+    let port = listener.local_addr().expect("local addr").port();
+    let join = thread::spawn(move || {
+        for _ in 0..2 {
+            let Ok(mut stream) =
+                accept_tcp_connection(&listener, Duration::from_secs(5), "plaintext TLS hint")
+            else {
+                return;
+            };
+            let _ = stream
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nconnection: close\r\n\r\nok");
+            let _ = stream.flush();
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+    });
+
+    let dns_addr = start_udp_dns_server("fetch-plaintext-hint.test.", Ipv4Addr::new(127, 0, 0, 1));
+    let raw_url = format!("fetch-plaintext-hint.test:{port}/status");
+    let res = run_fetch_once(FetchOpts::default(), &["--dns-server", &dns_addr, &raw_url]);
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr.contains(&format!(
+            "If this is a plaintext service, use http://fetch-plaintext-hint.test:{port}/status."
+        )),
+        "missing plaintext hint\nstderr:\n{}",
+        res.stderr
+    );
+
+    let explicit_url = format!("https://fetch-plaintext-hint.test:{port}/status");
+    let res = run_fetch_once(
+        FetchOpts::default(),
+        &["--dns-server", &dns_addr, &explicit_url],
+    );
+    assert_exit(&res, 1);
+    assert!(
+        !res.stderr.contains("plaintext service"),
+        "explicit HTTPS should not get schemeless hint\nstderr:\n{}",
+        res.stderr
+    );
+
+    join.join().expect("plaintext listener thread");
+}
+
 #[cfg(unix)]
 #[test]
 fn http_stdout_broken_pipe_exits_cleanly() {


### PR DESCRIPTION
## Summary
- Show the normalized absolute URL in dry-run metadata output
- Add a plaintext `http://` retry hint for schemeless HTTPS connect failures
- Update CLI docs and troubleshooting guidance for the new URL handling behavior

## Testing
- Added unit coverage for schemeless plaintext hint generation
- Added integration coverage for dry-run output and plaintext connect failure hints