### PR TITLE
Add HTTP version aliases and clearer protocol errors

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -151,7 +151,8 @@ fetch --unix ~/myapp.sock http://localhost/health
 
 ### `--http VERSION`
 
-Force a specific HTTP version.
+Force a specific HTTP version. `--http1`, `--http2`, and `--http3` are aliases
+for `--http 1`, `--http 2`, and `--http 3`.
 
 When `--http` is unset, HTTPS requests offer `h2` and then `http/1.1` through
 ALPN, using HTTP/2 when the server negotiates it and falling back to HTTP/1.1
@@ -173,6 +174,7 @@ fetch --http 1 example.com
 
 ```sh
 fetch --http 2 example.com
+fetch --http2 example.com
 ```
 
 - Forces HTTP/2

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -478,6 +478,7 @@ fetch --ca-cert ca-cert.pem example.com
 ### `--http VERSION`
 
 Force a specific HTTP protocol version. Values: `1`, `2`, `3`.
+Aliases: `--http1`, `--http2`, `--http3`.
 
 - `1` - HTTP/1.1
 - `2` - HTTP/2
@@ -494,6 +495,7 @@ plaintext servers.
 
 ```sh
 fetch --http 1 example.com
+fetch --http2 example.com
 fetch --http 3 example.com
 fetch --grpc --http 2 http://localhost:50051/pkg.Svc/Method  # uses h2c
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -287,7 +287,7 @@ async fn run_inner(cli: &mut Cli) -> Result<i32, FetchError> {
     };
     let config_path = crate::config::apply(cli)?;
     crate::config::validate(cli)?;
-    crate::cli::parse_http_version(cli.http.as_deref()).map_err(FetchError::Message)?;
+    crate::cli::selected_http_version(cli).map_err(FetchError::Message)?;
     crate::cli::normalize_range_values(&mut cli.ranges).map_err(FetchError::Message)?;
     validate_proto_schema_files(cli)?;
     validate_client_certificate_flags(cli, direct_cli_sources)?;
@@ -682,8 +682,8 @@ fn validate_from_curl_exclusives(cli: &Cli) -> Result<(), FetchError> {
         Some("min-tls")
     } else if cli.tls.is_some() {
         Some("tls")
-    } else if cli.http.is_some() {
-        Some("http")
+    } else if let Some(flag) = crate::cli::http_version_flag_name(cli) {
+        Some(flag)
     } else if cli.cert.is_some() {
         Some("cert")
     } else if cli.key.is_some() {
@@ -721,8 +721,7 @@ fn validate_websocket_exclusives(cli: &Cli) -> Result<(), FetchError> {
         .and_then(|url| url.split_once("://").map(|(scheme, _)| scheme))
         .unwrap_or("ws")
         .to_ascii_lowercase();
-    if let Some(version) =
-        crate::cli::parse_http_version(cli.http.as_deref()).map_err(FetchError::Message)?
+    if let Some(version) = crate::cli::selected_http_version(cli).map_err(FetchError::Message)?
         && version != crate::cli::HttpVersion::Http1
     {
         return Err(format!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -279,8 +279,34 @@ pub struct Cli {
     #[arg(short = 'h', long, help = "Print help")]
     pub help: bool,
 
-    #[arg(long, value_name = "VERSION", help = "HTTP version to use [1, 2, 3]")]
+    #[arg(
+        long,
+        value_name = "VERSION",
+        conflicts_with_all = ["http1", "http2", "http3"],
+        help = "HTTP version to use [1, 2, 3]"
+    )]
     pub http: Option<String>,
+
+    #[arg(
+        long = "http1",
+        conflicts_with_all = ["http", "http2", "http3"],
+        hide = true
+    )]
+    pub http1: bool,
+
+    #[arg(
+        long = "http2",
+        conflicts_with_all = ["http", "http1", "http3"],
+        hide = true
+    )]
+    pub http2: bool,
+
+    #[arg(
+        long = "http3",
+        conflicts_with_all = ["http", "http1", "http2"],
+        hide = true
+    )]
+    pub http3: bool,
 
     #[arg(long = "ignore-status", help = "Do not exit nonzero for HTTP 4xx/5xx")]
     pub ignore_status: bool,
@@ -568,6 +594,36 @@ pub fn parse_http_version(value: Option<&str>) -> Result<Option<HttpVersion>, St
     }
 }
 
+pub fn selected_http_version(cli: &Cli) -> Result<Option<HttpVersion>, String> {
+    if cli.http1 {
+        Ok(Some(HttpVersion::Http1))
+    } else if cli.http2 {
+        Ok(Some(HttpVersion::Http2))
+    } else if cli.http3 {
+        Ok(Some(HttpVersion::Http3))
+    } else {
+        parse_http_version(cli.http.as_deref())
+    }
+}
+
+pub fn has_http_version_flag(cli: &Cli) -> bool {
+    cli.http.is_some() || cli.http1 || cli.http2 || cli.http3
+}
+
+pub fn http_version_flag_name(cli: &Cli) -> Option<&'static str> {
+    if cli.http.is_some() {
+        Some("http")
+    } else if cli.http1 {
+        Some("http1")
+    } else if cli.http2 {
+        Some("http2")
+    } else if cli.http3 {
+        Some("http3")
+    } else {
+        None
+    }
+}
+
 fn normalize_range_value(value: &str) -> Result<String, String> {
     let value = value.trim();
     let Some((start, end)) = value.split_once('-') else {
@@ -632,6 +688,9 @@ mod tests {
                 "--ws-message-mode <MODE>      WebSocket frame mode [auto, text, binary]"
             )
         );
+        assert!(!help.contains("--http1"));
+        assert!(!help.contains("--http2"));
+        assert!(!help.contains("--http3"));
 
         for line in help.lines() {
             assert!(
@@ -746,6 +805,20 @@ mod tests {
         for (arg, want) in tests {
             let cli = Cli::try_parse_from(["fetch", "--http", arg, "http://example.com"]).unwrap();
             assert_eq!(parse_http_version(cli.http.as_deref()).unwrap(), want);
+        }
+    }
+
+    #[test]
+    fn http_alias_flags_select_protocol_versions() {
+        let tests = [
+            ("--http1", Some(HttpVersion::Http1)),
+            ("--http2", Some(HttpVersion::Http2)),
+            ("--http3", Some(HttpVersion::Http3)),
+        ];
+
+        for (arg, want) in tests {
+            let cli = Cli::try_parse_from(["fetch", arg, "http://example.com"]).unwrap();
+            assert_eq!(selected_http_version(&cli).unwrap(), want);
         }
     }
 

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -275,6 +275,9 @@ const FLAGS: &[Flag] = &[
         aliases: &[],
         values: HTTP_VALUES,
     },
+    flag(None, "http1", "", "Force HTTP/1.1"),
+    flag(None, "http2", "", "Force HTTP/2"),
+    flag(None, "http3", "", "Force HTTP/3"),
     flag(
         None,
         "ignore-status",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -312,7 +312,7 @@ config_options! {
         documented_keys: ["http"],
         cli_flags: ["http"],
         trim: ConfigValueTrim::Both,
-        cli_source: |cli| cli.http.is_some(),
+        cli_source: |cli| crate::cli::has_http_version_flag(cli),
         parse: |path, line_num, config, _key, value| {
             validate_choice(path, line_num, "http", value, &["1", "2", "3"])?;
             config.http = Some(value.to_string());
@@ -320,7 +320,7 @@ config_options! {
         },
         overlay: |target, higher| choose(&mut target.http, &higher.http),
         apply: |cli, values, _sources| {
-            if cli.http.is_none() {
+            if !crate::cli::has_http_version_flag(cli) {
                 cli.http = values.http.clone();
             }
         },
@@ -2068,6 +2068,7 @@ mod tests {
               color = on
               compress = zstd
               format = on
+              http = 1
               retry = 2
               retry-delay = 0.5
             ",
@@ -2081,6 +2082,7 @@ mod tests {
             "gzip",
             "--format",
             "off",
+            "--http2",
             "--retry",
             "0",
             "--retry-delay",
@@ -2095,6 +2097,10 @@ mod tests {
         assert_eq!(cli.color.as_deref(), Some("off"));
         assert_eq!(cli.compress.as_deref(), Some("gzip"));
         assert_eq!(cli.format.as_deref(), Some("off"));
+        assert_eq!(
+            crate::cli::selected_http_version(&cli).unwrap(),
+            Some(crate::cli::HttpVersion::Http2)
+        );
         assert_eq!(cli.retry, Some(0));
         assert_eq!(cli.retry_delay, Some(1.0));
     }

--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -1100,8 +1100,13 @@ pub(crate) fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     if cli.unix.is_some() {
         ignored.push("--unix");
     }
-    if cli.http.is_some() {
-        ignored.push("--http");
+    if let Some(flag) = crate::cli::http_version_flag_name(cli) {
+        ignored.push(match flag {
+            "http1" => "--http1",
+            "http2" => "--http2",
+            "http3" => "--http3",
+            _ => "--http",
+        });
     }
     if cli.inspect_tls {
         ignored.push("--inspect-tls");

--- a/src/http/metadata.rs
+++ b/src/http/metadata.rs
@@ -213,9 +213,10 @@ pub(super) fn validate_http_version_options(
     unix_socket: Option<&str>,
 ) -> Result<(), FetchError> {
     match version {
-        Some(HttpVersion::Http2) if url.scheme() == "http" && !allow_h2c => {
-            Err("http2: unsupported scheme".into())
-        }
+        Some(HttpVersion::Http2) if url.scheme() == "http" && !allow_h2c => Err(
+            "plain HTTP/2 is only supported for gRPC h2c; use https://, --grpc, or --http 1."
+                .into(),
+        ),
         Some(HttpVersion::Http3) if unix_socket.is_some() => {
             Err("cannot use a unix socket with HTTP/3.0".into())
         }
@@ -777,12 +778,15 @@ mod tests {
     }
 
     #[test]
-    fn http2_plain_http_rejects_like_go_transport() {
+    fn http2_plain_http_rejects_with_h2c_guidance() {
         let url = Url::parse("http://127.0.0.1:3000/").unwrap();
         let err =
             validate_http_version_options(Some(HttpVersion::Http2), &url, false, None).unwrap_err();
 
-        assert_eq!(err.to_string(), "http2: unsupported scheme");
+        assert_eq!(
+            err.to_string(),
+            "plain HTTP/2 is only supported for gRPC h2c; use https://, --grpc, or --http 1."
+        );
     }
 
     #[test]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -91,8 +91,7 @@ use transport::{Body, Client, RequestBuilder, Response};
 type AsyncReadBox = Pin<Box<dyn AsyncRead + Send>>;
 
 pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
-    let http_version =
-        crate::cli::parse_http_version(cli.http.as_deref()).map_err(FetchError::Message)?;
+    let http_version = crate::cli::selected_http_version(cli).map_err(FetchError::Message)?;
     let http_version = effective_http_version(cli, http_version);
     let mut url = normalize_url(cli.url.as_deref().expect("URL checked by app"))?;
     apply_query(&mut url, &cli.query);

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -182,8 +182,7 @@ pub(crate) fn apply_builder_authorization_headers(
 pub(super) fn transport_request_version_for_cli(
     cli: &Cli,
 ) -> Result<Option<http::Version>, FetchError> {
-    let version =
-        crate::cli::parse_http_version(cli.http.as_deref()).map_err(FetchError::Message)?;
+    let version = crate::cli::selected_http_version(cli).map_err(FetchError::Message)?;
     Ok(match effective_http_version(cli, version) {
         Some(HttpVersion::Http1) => Some(http::Version::HTTP_11),
         Some(HttpVersion::Http2) => Some(http::Version::HTTP_2),

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -33,8 +33,7 @@ pub async fn execute(cli: &Cli, ignored_flags: &[&'static str]) -> Result<i32, F
         );
     }
 
-    let http_version =
-        crate::cli::parse_http_version(cli.http.as_deref()).map_err(FetchError::Message)?;
+    let http_version = crate::cli::selected_http_version(cli).map_err(FetchError::Message)?;
 
     let request_timeout = inspection_request_timeout(cli)?;
     let connect_timeout = inspection_connect_timeout(cli, request_timeout, request_start)?;

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -1333,7 +1333,23 @@ fn request_construction_host_header_form_and_http_version() {
     assert_exit(&res, 0);
     let res = run_fetch(&[&server.url, "--http", "2"]);
     assert_exit(&res, 1);
-    assert!(res.stderr.contains("http2:"));
+    assert!(
+        res.stderr.contains(
+            "plain HTTP/2 is only supported for gRPC h2c; use https://, --grpc, or --http 1."
+        ),
+        "{}",
+        res.stderr
+    );
+
+    let res = run_fetch(&[&server.url, "--http2"]);
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr.contains(
+            "plain HTTP/2 is only supported for gRPC h2c; use https://, --grpc, or --http 1."
+        ),
+        "{}",
+        res.stderr
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add hidden `--http1`, `--http2`, and `--http3` aliases alongside `--http`
- Route HTTP version selection through shared CLI helpers so config, HTTP, TLS, WebSocket, and inspection paths agree
- Improve the plain-HTTP/2 error to explain the h2c limitation
- Update docs and completion metadata to match the new aliases

## Testing
- Unit tests added for alias parsing and updated HTTP version validation
- Integration test coverage updated to verify `--http2` fails with the new guidance