### PR TITLE
Box async dispatch futures in request and inspection paths

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -240,7 +240,7 @@ impl std::fmt::Display for RuntimeErrorWithColor {
 }
 
 async fn run(mut cli: Cli) -> Result<i32, RuntimeErrorWithColor> {
-    match run_inner(&mut cli).await {
+    match Box::pin(run_inner(&mut cli)).await {
         Ok(code) => Ok(code),
         Err(error) => Err(RuntimeErrorWithColor {
             error,
@@ -318,7 +318,11 @@ async fn run_inner(cli: &mut Cli) -> Result<i32, FetchError> {
     }
 
     if cli.inspect_tls {
-        return crate::tls::inspect::execute(cli, &direct_inspection_ignored_flags).await;
+        return Box::pin(crate::tls::inspect::execute(
+            cli,
+            &direct_inspection_ignored_flags,
+        ))
+        .await;
     }
 
     let is_websocket = cli
@@ -334,14 +338,14 @@ async fn run_inner(cli: &mut Cli) -> Result<i32, FetchError> {
     }
     if is_websocket {
         validate_websocket_exclusives(cli)?;
-        return crate::websocket::execute(cli).await;
+        return Box::pin(crate::websocket::execute(cli)).await;
     }
 
     if cli.has_grpc_discovery() {
-        return crate::grpc::reflection::execute_discovery(cli).await;
+        return Box::pin(crate::grpc::reflection::execute_discovery(cli)).await;
     }
 
-    crate::http::execute(cli).await
+    Box::pin(crate::http::execute(cli)).await
 }
 
 fn normalize_extra_args(cli: &mut Cli) -> Result<(), FetchError> {
@@ -1597,7 +1601,7 @@ mod tests {
     async fn websocket_interactive_requires_websocket_url() {
         let cli = Cli::try_parse_from(["fetch", "https://example.com", "--ws-interactive", "off"])
             .unwrap();
-        let err = run(cli).await.unwrap_err().to_string();
+        let err = Box::pin(run(cli)).await.unwrap_err().to_string();
 
         assert!(err.contains("requires a ws:// or wss:// URL"));
     }

--- a/src/grpc/reflection.rs
+++ b/src/grpc/reflection.rs
@@ -66,7 +66,7 @@ pub async fn execute_discovery(cli: &Cli) -> Result<i32, FetchError> {
 
     if cli.grpc_list {
         core::write_stdout(service_list_output(
-            list_services(cli, &url, &client).await?,
+            Box::pin(list_services(cli, &url, &client)).await?,
         ))?;
         return Ok(0);
     }
@@ -75,7 +75,7 @@ pub async fn execute_discovery(cli: &Cli) -> Result<i32, FetchError> {
         return Err("gRPC discovery requires --grpc-list or --grpc-describe".into());
     };
     let symbol = normalize_reflection_symbol(symbol);
-    let schema = schema_for_symbol(cli, &url, &client, &symbol).await?;
+    let schema = Box::pin(schema_for_symbol(cli, &url, &client, &symbol)).await?;
     core::write_stdout(crate::proto::describe_symbol(&schema, &symbol)?)?;
     Ok(0)
 }
@@ -91,13 +91,21 @@ fn service_list_output(services: Vec<String>) -> String {
 
 pub async fn schema_for_call(cli: &Cli, url: &Url, client: &Client) -> Result<Schema, FetchError> {
     let service = service_from_path(url.path())?;
-    schema_for_symbol(cli, url, client, service).await
+    Box::pin(schema_for_symbol(cli, url, client, service)).await
 }
 
 async fn list_services(cli: &Cli, url: &Url, client: &Client) -> Result<Vec<String>, FetchError> {
     let mut last_unimplemented = None;
     for (index, path) in REFLECTION_PROTOCOLS.iter().enumerate() {
-        match invoke(cli, url, client, path, build_reflection_list_request()).await {
+        match Box::pin(invoke(
+            cli,
+            url,
+            client,
+            path,
+            build_reflection_list_request(),
+        ))
+        .await
+        {
             Ok(frames) => {
                 let Some(first) = frames.first() else {
                     return Err(reflection_unavailable("empty reflection response"));
@@ -134,13 +142,13 @@ async fn schema_for_symbol(
 ) -> Result<Schema, FetchError> {
     let mut last_unimplemented = None;
     'protocols: for (index, path) in REFLECTION_PROTOCOLS.iter().enumerate() {
-        match invoke(
+        match Box::pin(invoke(
             cli,
             url,
             client,
             path,
             build_reflection_symbol_request(symbol),
-        )
+        ))
         .await
         {
             Ok(frames) => {
@@ -187,12 +195,7 @@ async fn invoke(
         framing::frame(&payload, false).map_err(|err| FetchError::Message(err.to_string()))?;
 
     let headers = reflection_headers(cli, &url, &request_body)?;
-    let response = client
-        .post(url)
-        .headers(headers)
-        .body(request_body)
-        .send()
-        .await?;
+    let response = Box::pin(client.post(url).headers(headers).body(request_body).send()).await?;
     let status_code = response.status();
     if status_code != StatusCode::OK {
         return Err(format!(

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -132,7 +132,13 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let initial_client = client::build_client_for_url(cli, &url, &client_build).await?;
     if cli.grpc && grpc_method.is_none() {
         let request_requires_schema = grpc_request_requires_schema(cli);
-        match crate::grpc::reflection::schema_for_call(cli, &url, &initial_client.client).await {
+        match Box::pin(crate::grpc::reflection::schema_for_call(
+            cli,
+            &url,
+            &initial_client.client,
+        ))
+        .await
+        {
             Ok(schema) => match proto::method_for_url(&schema, &url) {
                 Ok(method) => grpc_method = Some(method),
                 Err(err) if request_requires_schema => return Err(err),

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -38,7 +38,7 @@ pub async fn execute(cli: &Cli, ignored_flags: &[&'static str]) -> Result<i32, F
     let request_timeout = inspection_request_timeout(cli)?;
     let connect_timeout = inspection_connect_timeout(cli, request_timeout, request_start)?;
     let inspection = TimeoutBudget::started_at(request_timeout, request_start)
-        .run(inspect(cli, &url, http_version, connect_timeout))
+        .run(Box::pin(inspect(cli, &url, http_version, connect_timeout)))
         .await?;
 
     if !cli.silent {

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -89,7 +89,13 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let request_timeout = websocket_request_timeout(cli)?;
     let request_budget = TimeoutBudget::started_at(request_timeout, request_start);
     let connect_timeout = websocket_connect_timeout(cli, request_timeout, request_start)?;
-    let connect = async { connect_websocket(cli, &url, request, connector, connect_timeout).await };
+    let connect = Box::pin(connect_websocket(
+        cli,
+        &url,
+        request,
+        connector,
+        connect_timeout,
+    ));
     let (stream, response) = request_budget.run(connect).await?;
     store_handshake_cookies(session.as_ref(), &url, response.headers());
     crate::http::save_session(cli, session.as_ref());
@@ -180,13 +186,13 @@ async fn connect_websocket(
     ),
     FetchError,
 > {
-    let stream = dial_websocket(cli, url, timeout)
+    let stream = Box::pin(dial_websocket(cli, url, timeout))
         .await
         .map_err(websocket_network_error)?;
-    timeout_ws(
+    Box::pin(timeout_ws(
         timeout,
         client_async_tls_with_config(request, stream, Some(websocket_config()), connector),
-    )
+    ))
     .await
 }
 
@@ -203,12 +209,12 @@ async fn dial_websocket(
     url: &Url,
     timeout: TimeoutBudget,
 ) -> Result<DialStream, FetchError> {
-    crate::net::dial_url(
+    Box::pin(crate::net::dial_url(
         url,
         cli.proxy.as_deref(),
         cli.dns_server.as_deref(),
         timeout,
-    )
+    ))
     .await
 }
 


### PR DESCRIPTION
## Summary
- Box key async calls before awaiting them in app, HTTP, gRPC reflection, TLS inspection, and WebSocket paths
- Keep the request and discovery flow behavior unchanged while avoiding large stack use from deeply nested futures
- Update the affected async test call site to match the new boxed invocation pattern

## Testing
- Not run (not requested)