### PR TITLE
Persist learned HTTP/3 alternatives in cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - Rustls is built with `aws-lc-rs` and `prefer-post-quantum`; keep post-quantum key exchange preference enabled unless there is a concrete compatibility or provider reason to disable it.
 - TLS inspection keeps its custom verifier for certificate display and OCSP capture, but Rustls protocol-version selection and PEM/client-auth material parsing should stay centralized in `src/tls/mod.rs`.
 - Direct HTTPS requests discover HTTP/3 via DNS HTTPS/SVCB records advertising `h3`, race QUIC setup against the normal TCP/TLS `h2`/`http/1.1` ALPN path, and send the request once on the winning transport. With `--dns-server`, HTTPS-record discovery uses that custom UDP or DoH resolver; without it, discovery uses the platform resolver, matching normal A/AAAA lookup behavior. Proxy, Unix socket, explicit HTTP version, and gRPC/WebSocket paths bypass auto-H3. Explicit `--http 1`, `--http 2`, and `--http 3` remain forced protocol selections, not version caps. Auto-H3 HTTPS/SVCB discovery is opportunistic and must not delay normal connection setup: start it in parallel with normal A/AAAA lookup and TCP/TLS setup, race QUIC only when a usable `h3` candidate is discovered before TCP/TLS wins, and skip SVCB target-name resolution that would require an extra DNS wait unless address hints, an origin target, or an IP target are already available. The auto-H3 QUIC/TCP race shares one started `--connect-timeout` budget across both branches; do not create fresh branch-local connect budgets after the fallback delay.
+- Automatic HTTP/3 stores learned alternatives in a bounded sharded JSON cache under the user cache directory (`http3/<prefix>/<hash>.json`). Cache entries are scoped by normalized origin and resolver key, store alternative authorities instead of IP addresses, expire by HTTPS/SVCB TTL or `Alt-Svc` `ma` with a hard retention cap, and should not be used for proxy, Unix socket, IP-literal, non-HTTPS, explicit `--http`, or gRPC/WebSocket paths. Fresh HTTPS/SVCB candidates take precedence when available promptly, but cached alternatives race while slower HTTPS/SVCB discovery continues so learned `Alt-Svc` entries are not hidden behind unsupported or slow HTTPS-record lookups. `Alt-Svc` learning is disabled for `--insecure` responses.
 - The custom transport should preserve reqwest's safe default retries for HTTP/2/3 protocol NACKs such as remote `REFUSED_STREAM`, remote `GOAWAY(NO_ERROR)`, and HTTP/3 connection timeout signals, but only when the request body can be replayed.
 - WebSocket terminal sessions use the interactive prompt by default and can be controlled with `--ws-interactive auto|on|off`; output-file/clipboard/retry flags are rejected because the WebSocket path streams through the message loop instead of the normal response pipeline.
 - WebSocket requests require HTTP/1.1 for the upgrade handshake; reject explicit `--http 2` and `--http 3` instead of silently performing an HTTP/1.1 upgrade.
@@ -207,6 +208,10 @@ Rust request uploads use a replayable body descriptor instead of a universal `Ve
   harness code split by domain under `tests/support/` (HTTP, TLS, HTTP/3,
   gRPC, DNS, WebSocket, proxy, PTY, terminal, update, and auth helpers), and
   run the compiled Rust binary via Cargo.
+- The shared integration `run_fetch` harness isolates automatic HTTP/3 cache
+  state with a per-process temp `FETCH_INTERNAL_HTTP3_CACHE_DIR` by default;
+  cache-specific tests should pass an explicit shared temp dir through
+  `FetchOpts.env`.
 - CI runs Rust checks once on Ubuntu and runs the Rust integration harness once on each supported GitHub Actions runner: Ubuntu, macOS, and Windows.
 
 ## Docs

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -166,6 +166,14 @@ OS resolver, or returns no usable `h3` record, HTTPS uses the normal ALPN path
 and offers `h2` then `http/1.1`. Proxy and Unix socket requests also use the
 normal ALPN path.
 
+`fetch` also remembers recent HTTP/3 alternatives learned from HTTPS/SVCB
+records and `Alt-Svc: h3=...` response headers in a bounded per-origin cache
+under the user cache directory. Cached alternatives are scoped to the resolver
+that learned them, expire with DNS TTL or `Alt-Svc` `ma`, and are only used for
+the same automatic direct HTTPS path. Prompt fresh HTTPS/SVCB results are tried
+before cached entries, while cached entries can race slower HTTPS-record
+discovery so a learned `Alt-Svc` alternative can be used on later requests.
+
 Setting `--http 1`, `--http 2`, or `--http 3` forces that protocol; it does not
 set a version cap. Use `--http 1` or `--http 2` to opt out of automatic HTTP/3.
 
@@ -211,12 +219,14 @@ By default, `fetch` negotiates the best available version:
 
 1. Uses DNS HTTPS/SVCB records from the platform resolver, or from
    `--dns-server` when set, to discover `h3` candidates for direct HTTPS
-2. Resolves A and AAAA in parallel and starts TCP/TLS as soon as an address is
+2. Reuses fresh cached HTTP/3 alternatives learned from prior HTTPS/SVCB or
+   `Alt-Svc` responses
+3. Resolves A and AAAA in parallel and starts TCP/TLS as soon as an address is
    usable
-3. Races QUIC setup against TCP/TLS when a usable `h3` candidate is discovered
+4. Races QUIC setup against TCP/TLS when a usable `h3` candidate is discovered
    before TCP/TLS wins
-4. Otherwise offers HTTP/2 via ALPN
-5. Falls back to HTTP/1.1 if needed
+5. Otherwise offers HTTP/2 via ALPN
+6. Falls back to HTTP/1.1 if needed
 
 ## TLS Configuration
 

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -131,10 +131,11 @@ Automatic update scheduling and update locking use the user cache directory:
 
 Files in this directory include:
 
-| File            | Purpose                                                                   |
-| --------------- | ------------------------------------------------------------------------- |
-| `metadata.json` | Stores the last update attempt timestamp for auto-update interval checks. |
-| `.update-lock`  | Advisory lock that prevents concurrent update attempts.                   |
+| File or directory | Purpose                                                                   |
+| ----------------- | ------------------------------------------------------------------------- |
+| `metadata.json`   | Stores the last update attempt timestamp for auto-update interval checks. |
+| `.update-lock`    | Advisory lock that prevents concurrent update attempts.                   |
+| `http3/`          | Bounded per-origin cache for learned HTTP/3 alternatives.                 |
 
 Manual and automatic update attempts both refresh `metadata.json`, including
 `fetch --update --dry-run`.

--- a/src/dns/svcb.rs
+++ b/src/dns/svcb.rs
@@ -40,6 +40,7 @@ pub(crate) struct SvcbRecord {
     pub(crate) ipv6_hint: Vec<Ipv6Addr>,
     pub(crate) mandatory: Vec<u16>,
     pub(crate) unsupported_mandatory: Vec<u16>,
+    pub(crate) ttl: Option<u32>,
 }
 
 impl SvcbRecord {
@@ -105,6 +106,7 @@ fn record_from_params(priority: u16, target: String, params: &[SvcParam]) -> Opt
         ipv6_hint: Vec::new(),
         mandatory: Vec::new(),
         unsupported_mandatory: Vec::new(),
+        ttl: None,
     };
 
     for param in params {
@@ -268,8 +270,14 @@ async fn lookup_doh_https_records(
     Ok(answers
         .into_iter()
         .filter(|answer| answer.answer_type == DNS_TYPE_HTTPS)
-        .filter_map(|answer| parse_generic_rdata(&answer.data))
-        .filter_map(|raw| parse_rdata(&raw))
+        .filter_map(|answer| {
+            parse_generic_rdata(&answer.data).and_then(|raw| {
+                parse_rdata(&raw).map(|mut record| {
+                    record.ttl = answer.ttl;
+                    record
+                })
+            })
+        })
         .collect())
 }
 
@@ -300,7 +308,12 @@ async fn lookup_udp_https_records(
     Ok(raw_records
         .into_iter()
         .filter(|record| record.class == DNS_CLASS_IN && record.typ == DNS_TYPE_HTTPS)
-        .filter_map(|record| parse_rdata(record.data))
+        .filter_map(|record| {
+            parse_rdata(record.data).map(|mut parsed| {
+                parsed.ttl = Some(record.ttl);
+                parsed
+            })
+        })
         .collect())
 }
 

--- a/src/dns/svcb/system.rs
+++ b/src/dns/svcb/system.rs
@@ -100,7 +100,7 @@ fn lookup_https_records_blocking(
         rrclass: u16,
         rdlen: u16,
         rdata: *const c_void,
-        _ttl: u32,
+        ttl: u32,
         context: *mut c_void,
     ) {
         if context.is_null() {
@@ -114,7 +114,8 @@ fn lookup_https_records_blocking(
         }
         if rrtype == wire::TYPE_HTTPS && rrclass == wire::CLASS_IN && !rdata.is_null() {
             let raw = unsafe { std::slice::from_raw_parts(rdata.cast::<u8>(), usize::from(rdlen)) };
-            if let Some(record) = parse_rdata(raw) {
+            if let Some(mut record) = parse_rdata(raw) {
+                record.ttl = Some(ttl);
                 state.records.push(record);
             }
         }
@@ -277,15 +278,16 @@ fn lookup_https_records_blocking(
     let mut parsed = Vec::new();
     let mut current = records;
     while !current.is_null() {
-        let record = unsafe { &*current };
-        if record.wType == DNS_TYPE_HTTPS {
-            if let Some(raw) = windows_svcb_rdata(record) {
-                if let Some(record) = parse_rdata(&raw) {
-                    parsed.push(record);
+        let dns_record = unsafe { &*current };
+        if dns_record.wType == DNS_TYPE_HTTPS {
+            if let Some(raw) = windows_svcb_rdata(dns_record) {
+                if let Some(mut parsed_record) = parse_rdata(&raw) {
+                    parsed_record.ttl = Some(dns_record.dwTtl);
+                    parsed.push(parsed_record);
                 }
             }
         }
-        current = record.pNext;
+        current = dns_record.pNext;
     }
     Ok(parsed)
 }
@@ -414,7 +416,12 @@ fn records_from_wire_response(raw: &[u8]) -> Result<Vec<SvcbRecord>, FetchError>
     Ok(records
         .into_iter()
         .filter(|record| record.class == wire::CLASS_IN && record.typ == wire::TYPE_HTTPS)
-        .filter_map(|record| parse_rdata(record.data))
+        .filter_map(|record| {
+            parse_rdata(record.data).map(|mut parsed| {
+                parsed.ttl = Some(record.ttl);
+                parsed
+            })
+        })
         .collect())
 }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -7,6 +7,7 @@ use ipnet::IpNet;
 use tokio::task::JoinHandle;
 use url::Url;
 
+use super::http3_cache::Http3Cache;
 use super::transport::{AutoHttp3Config, Client, ClientBuilder, NoProxy, Proxy, redirect};
 use crate::cli::{Cli, HttpVersion};
 use crate::dns::custom;
@@ -129,6 +130,12 @@ pub(crate) async fn build_client_for_url(
     }
     if discovery.auto_http3_discovery {
         builder = builder.auto_http3_discovery();
+    }
+    if auto_http3 {
+        let cache = Http3Cache::new();
+        if cache.is_enabled() {
+            builder = builder.http3_cache(Arc::new(cache), !cli.insecure);
+        }
     }
     if let Some(dns_server) = discovery.dns_server {
         builder = builder.dns_server(dns_server);
@@ -261,7 +268,7 @@ async fn resolve_dns_for_client_inner(
         };
         let timing_addrs = dns_timing_addrs(addrs.iter().copied());
         let socket_addrs = custom::socket_addrs_for_override(&addrs);
-        let auto_http3 = auto_http3_config_for_records(
+        let auto_http3_config = auto_http3_config_for_records(
             Some(dns_server),
             url,
             &https_records,
@@ -270,6 +277,9 @@ async fn resolve_dns_for_client_inner(
             false,
         )
         .await;
+        if auto_http3 {
+            Http3Cache::new().store_https_records(url, Some(dns_server), &https_records);
+        }
         return Ok(ClientDnsDiscovery {
             dns_resolution: Some(DnsResolution {
                 socket_addrs,
@@ -281,7 +291,7 @@ async fn resolve_dns_for_client_inner(
             }),
             runtime_dns_resolution: None,
             dns_server: None,
-            auto_http3,
+            auto_http3: auto_http3_config,
             auto_http3_discovery: false,
         });
     }
@@ -325,7 +335,7 @@ async fn resolve_dns_for_client_inner(
         )
     };
     let addrs = dns_timing_addrs(socket_addrs.iter().map(|addr| addr.ip()));
-    let auto_http3 = auto_http3_config_for_records(
+    let auto_http3_config = auto_http3_config_for_records(
         None,
         url,
         &https_records,
@@ -334,6 +344,9 @@ async fn resolve_dns_for_client_inner(
         false,
     )
     .await;
+    if auto_http3 {
+        Http3Cache::new().store_https_records(url, None, &https_records);
+    }
     Ok(ClientDnsDiscovery {
         dns_resolution: Some(DnsResolution {
             socket_addrs,
@@ -345,7 +358,7 @@ async fn resolve_dns_for_client_inner(
         }),
         runtime_dns_resolution: None,
         dns_server: None,
-        auto_http3,
+        auto_http3: auto_http3_config,
         auto_http3_discovery: false,
     })
 }
@@ -990,6 +1003,7 @@ mod tests {
             ipv6_hint: Vec::new(),
             mandatory: Vec::new(),
             unsupported_mandatory: Vec::new(),
+            ttl: Some(60),
         }
     }
 

--- a/src/http/http3_cache.rs
+++ b/src/http/http3_cache.rs
@@ -1,0 +1,819 @@
+use std::fs;
+use std::io::Write;
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use http::HeaderMap;
+use http::header::HeaderName;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::dns::svcb::SvcbRecord;
+use crate::fileutil::FileLock;
+
+const CACHE_VERSION: u32 = 1;
+const MAX_CANDIDATES_PER_ORIGIN: usize = 4;
+const MAX_SHARDS: usize = 1024;
+const MAX_RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
+const DEFAULT_ALT_SVC_MA_SECS: u64 = 24 * 60 * 60;
+const GLOBAL_PRUNE_INTERVAL_SECS: u64 = 24 * 60 * 60;
+const LOCK_WAIT_TIMEOUT: Duration = Duration::from_millis(200);
+
+const SOURCE_HTTPS: &str = "https";
+const SOURCE_ALT_SVC: &str = "alt-svc";
+const SYSTEM_RESOLVER_KEY: &str = "system";
+const ALT_SVC: HeaderName = HeaderName::from_static("alt-svc");
+
+#[derive(Clone, Debug)]
+pub(crate) struct Http3Cache {
+    dir: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Http3CacheCandidate {
+    pub(crate) alt_host: String,
+    pub(crate) alt_port: u16,
+    pub(crate) priority: Option<u16>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ShardFile {
+    version: u32,
+    origin: String,
+    resolver_key: String,
+    candidates: Vec<StoredCandidate>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct StoredCandidate {
+    source: String,
+    alt_host: String,
+    alt_port: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    priority: Option<u16>,
+    expires_at: u64,
+    learned_at: u64,
+    last_used_at: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CacheKey {
+    origin: String,
+    resolver_key: String,
+}
+
+#[derive(Debug)]
+struct AltSvcUpdate {
+    clear: bool,
+    candidates: Vec<StoredCandidate>,
+    remove: Vec<(String, u16)>,
+}
+
+#[derive(Debug)]
+struct ShardSummary {
+    path: PathBuf,
+    expired: bool,
+    last_used_at: u64,
+}
+
+impl Http3Cache {
+    pub(crate) fn new() -> Self {
+        Self {
+            dir: http3_cache_dir().ok(),
+        }
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.dir.is_some()
+    }
+
+    #[cfg(test)]
+    fn with_dir(dir: PathBuf) -> Self {
+        Self { dir: Some(dir) }
+    }
+
+    pub(crate) fn candidates(
+        &self,
+        url: &Url,
+        dns_server: Option<&str>,
+    ) -> Vec<Http3CacheCandidate> {
+        let Some((key, path)) = self.key_and_path(url, dns_server) else {
+            return Vec::new();
+        };
+        let now = now_secs();
+        let Some(mut shard) = self.read_valid_shard(&path, &key) else {
+            return Vec::new();
+        };
+        prune_expired_candidates(&mut shard.candidates, now);
+        if shard.candidates.is_empty() {
+            self.update_shard(&path, &key, |_, _| {});
+            return Vec::new();
+        }
+        let candidates = shard
+            .candidates
+            .into_iter()
+            .map(|candidate| Http3CacheCandidate {
+                alt_host: candidate.alt_host,
+                alt_port: candidate.alt_port,
+                priority: candidate.priority,
+            })
+            .collect::<Vec<_>>();
+        self.update_shard(&path, &key, |shard, now| {
+            prune_expired_candidates(&mut shard.candidates, now);
+            for stored in &mut shard.candidates {
+                if candidates
+                    .iter()
+                    .any(|candidate| candidate.matches_stored(stored))
+                {
+                    stored.last_used_at = now;
+                }
+            }
+        });
+        self.maybe_prune_global(now);
+        candidates
+    }
+
+    pub(crate) fn remove_candidates(
+        &self,
+        url: &Url,
+        dns_server: Option<&str>,
+        candidates: &[Http3CacheCandidate],
+    ) {
+        if candidates.is_empty() {
+            return;
+        }
+        let Some((key, path)) = self.key_and_path(url, dns_server) else {
+            return;
+        };
+        self.update_shard(&path, &key, |shard, now| {
+            prune_expired_candidates(&mut shard.candidates, now);
+            shard.candidates.retain(|stored| {
+                !candidates
+                    .iter()
+                    .any(|candidate| candidate.matches_stored(stored))
+            });
+        });
+    }
+
+    pub(crate) fn store_https_records(
+        &self,
+        url: &Url,
+        dns_server: Option<&str>,
+        records: &[SvcbRecord],
+    ) {
+        let Some((key, path)) = self.key_and_path(url, dns_server) else {
+            return;
+        };
+        let Some(origin_host) = normalized_host(url) else {
+            return;
+        };
+        let Some(origin_port) = url.port_or_known_default() else {
+            return;
+        };
+        let mut candidates = records
+            .iter()
+            .filter(|record| !record.is_alias_mode())
+            .filter(|record| record.is_usable())
+            .filter(|record| record.advertises_alpn("h3"))
+            .filter_map(|record| {
+                let ttl = record.ttl?;
+                if ttl == 0 {
+                    return None;
+                }
+                let alt_host = normalized_svcb_target(&origin_host, &record.target)?;
+                Some((
+                    record.priority,
+                    alt_host,
+                    record.port.unwrap_or(origin_port),
+                    ttl,
+                ))
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_by_key(|(priority, _, _, _)| *priority);
+        if candidates.is_empty() {
+            return;
+        }
+
+        self.update_shard(&path, &key, |shard, now| {
+            prune_expired_candidates(&mut shard.candidates, now);
+            for (priority, alt_host, alt_port, ttl) in &candidates {
+                let ttl = u64::from(*ttl).min(MAX_RETENTION_SECS);
+                let candidate = StoredCandidate {
+                    source: SOURCE_HTTPS.to_string(),
+                    alt_host: alt_host.clone(),
+                    alt_port: *alt_port,
+                    priority: Some(*priority),
+                    expires_at: now.saturating_add(ttl),
+                    learned_at: now,
+                    last_used_at: now,
+                };
+                upsert_candidate(&mut shard.candidates, candidate);
+            }
+            prune_candidate_count(&mut shard.candidates);
+        });
+    }
+
+    pub(crate) fn store_alt_svc(&self, url: &Url, dns_server: Option<&str>, headers: &HeaderMap) {
+        let Some((key, path)) = self.key_and_path(url, dns_server) else {
+            return;
+        };
+        let Some(update) = parse_alt_svc_headers(url, headers, now_secs()) else {
+            return;
+        };
+        self.update_shard(&path, &key, |shard, now| {
+            prune_expired_candidates(&mut shard.candidates, now);
+            if update.clear {
+                shard
+                    .candidates
+                    .retain(|candidate| candidate.source != SOURCE_ALT_SVC);
+            }
+            for (alt_host, alt_port) in &update.remove {
+                shard.candidates.retain(|candidate| {
+                    !(candidate.source == SOURCE_ALT_SVC
+                        && candidate.alt_host.eq_ignore_ascii_case(alt_host)
+                        && candidate.alt_port == *alt_port)
+                });
+            }
+            for candidate in update.candidates.clone() {
+                upsert_candidate(&mut shard.candidates, candidate);
+            }
+            prune_candidate_count(&mut shard.candidates);
+        });
+    }
+
+    fn key_and_path(&self, url: &Url, dns_server: Option<&str>) -> Option<(CacheKey, PathBuf)> {
+        let dir = self.dir.as_ref()?;
+        let key = cache_key(url, dns_server)?;
+        let hash = sha256_hex(format!("{}\n{}", key.origin, key.resolver_key).as_bytes());
+        let path = dir.join(&hash[..2]).join(format!("{hash}.json"));
+        Some((key, path))
+    }
+
+    fn read_valid_shard(&self, path: &Path, key: &CacheKey) -> Option<ShardFile> {
+        let data = fs::read(path).ok()?;
+        let shard = serde_json::from_slice::<ShardFile>(&data).ok()?;
+        if shard.version != CACHE_VERSION
+            || shard.origin != key.origin
+            || shard.resolver_key != key.resolver_key
+        {
+            return None;
+        }
+        Some(shard)
+    }
+
+    fn update_shard(&self, path: &Path, key: &CacheKey, update: impl FnOnce(&mut ShardFile, u64)) {
+        let Some(parent) = path.parent() else {
+            return;
+        };
+        if create_cache_dir(parent).is_err() {
+            return;
+        }
+        let lock_path = shard_lock_path(path);
+        let Ok(_lock) = FileLock::acquire_with_timeout(
+            &lock_path,
+            LOCK_WAIT_TIMEOUT,
+            || {},
+            |timeout| std::io::Error::new(std::io::ErrorKind::TimedOut, format!("{timeout:?}")),
+        ) else {
+            return;
+        };
+        let now = now_secs();
+        let mut shard = self
+            .read_valid_shard(path, key)
+            .unwrap_or_else(|| ShardFile {
+                version: CACHE_VERSION,
+                origin: key.origin.clone(),
+                resolver_key: key.resolver_key.clone(),
+                candidates: Vec::new(),
+            });
+        update(&mut shard, now);
+        prune_expired_candidates(&mut shard.candidates, now);
+        prune_candidate_count(&mut shard.candidates);
+        if shard.candidates.is_empty() {
+            let _ = fs::remove_file(path);
+            return;
+        }
+        let _ = write_shard(path, &shard);
+    }
+
+    fn maybe_prune_global(&self, now: u64) {
+        let Some(dir) = &self.dir else {
+            return;
+        };
+        if create_cache_dir(dir).is_err() {
+            return;
+        }
+        let marker = dir.join(".last-prune");
+        let should_prune = fs::read_to_string(&marker)
+            .ok()
+            .and_then(|value| value.trim().parse::<u64>().ok())
+            .is_none_or(|last| now.saturating_sub(last) >= GLOBAL_PRUNE_INTERVAL_SECS);
+        if !should_prune {
+            return;
+        }
+        prune_global(dir, now);
+        let _ = fs::write(marker, now.to_string());
+    }
+}
+
+impl Http3CacheCandidate {
+    fn matches_stored(&self, stored: &StoredCandidate) -> bool {
+        self.alt_host.eq_ignore_ascii_case(&stored.alt_host) && self.alt_port == stored.alt_port
+    }
+}
+
+fn http3_cache_dir() -> std::io::Result<PathBuf> {
+    if let Some(dir) = std::env::var_os("FETCH_INTERNAL_HTTP3_CACHE_DIR") {
+        let dir = PathBuf::from(dir);
+        create_cache_dir(&dir)?;
+        return Ok(dir);
+    }
+    let base = default_cache_dir()?;
+    let dir = base.join("fetch").join("http3");
+    create_cache_dir(&dir)?;
+    Ok(dir)
+}
+
+fn default_cache_dir() -> std::io::Result<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(dir) = std::env::var_os("LOCALAPPDATA") {
+            return Ok(PathBuf::from(dir));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(home) = std::env::var_os("HOME") {
+            return Ok(PathBuf::from(home).join("Library").join("Caches"));
+        }
+    }
+
+    if let Some(dir) = std::env::var_os("XDG_CACHE_HOME") {
+        return Ok(PathBuf::from(dir));
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return Ok(PathBuf::from(home).join(".cache"));
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "unable to determine user cache directory",
+    ))
+}
+
+#[cfg(unix)]
+fn create_cache_dir(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true).mode(0o700).create(path)?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_cache_dir(path: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(path)
+}
+
+fn cache_key(url: &Url, dns_server: Option<&str>) -> Option<CacheKey> {
+    if url.scheme() != "https" {
+        return None;
+    }
+    let host = normalized_host(url)?;
+    if host.parse::<IpAddr>().is_ok() {
+        return None;
+    }
+    let port = url.port_or_known_default()?;
+    Some(CacheKey {
+        origin: format!("https://{host}:{port}"),
+        resolver_key: resolver_key(dns_server),
+    })
+}
+
+fn resolver_key(dns_server: Option<&str>) -> String {
+    dns_server
+        .map(|server| format!("dns-server:{server}"))
+        .unwrap_or_else(|| SYSTEM_RESOLVER_KEY.to_string())
+}
+
+fn normalized_host(url: &Url) -> Option<String> {
+    Some(url.host_str()?.trim_end_matches('.').to_ascii_lowercase())
+}
+
+fn normalized_svcb_target(origin_host: &str, target: &str) -> Option<String> {
+    let target = if target == "." {
+        origin_host.to_string()
+    } else {
+        target.trim_end_matches('.').to_ascii_lowercase()
+    };
+    (!target.is_empty()).then_some(target)
+}
+
+fn parse_alt_svc_headers(url: &Url, headers: &HeaderMap, now: u64) -> Option<AltSvcUpdate> {
+    let origin_host = normalized_host(url)?;
+    let mut update = AltSvcUpdate {
+        clear: false,
+        candidates: Vec::new(),
+        remove: Vec::new(),
+    };
+    for value in headers.get_all(ALT_SVC).iter() {
+        let Ok(value) = value.to_str() else {
+            continue;
+        };
+        if value.trim().eq_ignore_ascii_case("clear") {
+            update.clear = true;
+            continue;
+        }
+        for item in split_quoted(value, ',') {
+            let Some(candidate) = parse_alt_svc_item(&item, &origin_host, now) else {
+                continue;
+            };
+            if candidate.expires_at <= now {
+                update
+                    .remove
+                    .push((candidate.alt_host.clone(), candidate.alt_port));
+            } else {
+                update.candidates.push(candidate);
+            }
+        }
+    }
+    (update.clear || !update.candidates.is_empty() || !update.remove.is_empty()).then_some(update)
+}
+
+fn parse_alt_svc_item(item: &str, origin_host: &str, now: u64) -> Option<StoredCandidate> {
+    let parts = split_quoted(item, ';');
+    let first = parts.first()?.trim();
+    let (protocol, authority) = first.split_once('=')?;
+    if !protocol.trim().eq_ignore_ascii_case("h3") {
+        return None;
+    }
+    let authority = unquote(authority.trim())?;
+    let (alt_host, alt_port) = parse_alt_authority(authority, origin_host)?;
+    let mut ma = DEFAULT_ALT_SVC_MA_SECS;
+    for part in parts.iter().skip(1) {
+        let Some((name, value)) = part.split_once('=') else {
+            continue;
+        };
+        if name.trim().eq_ignore_ascii_case("ma")
+            && let Ok(parsed) = unquote(value.trim()).unwrap_or(value.trim()).parse::<u64>()
+        {
+            ma = parsed;
+        }
+    }
+    let ma = ma.min(MAX_RETENTION_SECS);
+    Some(StoredCandidate {
+        source: SOURCE_ALT_SVC.to_string(),
+        alt_host,
+        alt_port,
+        priority: None,
+        expires_at: now.saturating_add(ma),
+        learned_at: now,
+        last_used_at: now,
+    })
+}
+
+fn parse_alt_authority(authority: &str, origin_host: &str) -> Option<(String, u16)> {
+    if let Some(port) = authority.strip_prefix(':') {
+        let port = port.parse::<u16>().ok()?;
+        return Some((origin_host.to_string(), port));
+    }
+    let url = Url::parse(&format!("https://{authority}/")).ok()?;
+    let host = normalized_host(&url)?;
+    let port = url.port()?;
+    Some((host, port))
+}
+
+fn split_quoted(value: &str, separator: char) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut quoted = false;
+    let mut escaped = false;
+    for ch in value.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
+        if quoted && ch == '\\' {
+            escaped = true;
+            current.push(ch);
+            continue;
+        }
+        if ch == '"' {
+            quoted = !quoted;
+            current.push(ch);
+            continue;
+        }
+        if !quoted && ch == separator {
+            out.push(current.trim().to_string());
+            current.clear();
+            continue;
+        }
+        current.push(ch);
+    }
+    out.push(current.trim().to_string());
+    out
+}
+
+fn unquote(value: &str) -> Option<&str> {
+    if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+        return Some(&value[1..value.len() - 1]);
+    }
+    if value.starts_with('"') || value.ends_with('"') {
+        return None;
+    }
+    Some(value)
+}
+
+fn upsert_candidate(candidates: &mut Vec<StoredCandidate>, candidate: StoredCandidate) {
+    if let Some(existing) = candidates.iter_mut().find(|existing| {
+        existing.source == candidate.source
+            && existing.alt_host.eq_ignore_ascii_case(&candidate.alt_host)
+            && existing.alt_port == candidate.alt_port
+    }) {
+        *existing = candidate;
+    } else {
+        candidates.push(candidate);
+    }
+}
+
+fn prune_expired_candidates(candidates: &mut Vec<StoredCandidate>, now: u64) {
+    candidates.retain(|candidate| candidate.expires_at > now);
+}
+
+fn prune_candidate_count(candidates: &mut Vec<StoredCandidate>) {
+    candidates.sort_by(|a, b| {
+        a.priority
+            .unwrap_or(u16::MAX)
+            .cmp(&b.priority.unwrap_or(u16::MAX))
+            .then(b.last_used_at.cmp(&a.last_used_at))
+            .then(b.expires_at.cmp(&a.expires_at))
+    });
+    candidates.truncate(MAX_CANDIDATES_PER_ORIGIN);
+}
+
+fn write_shard(path: &Path, shard: &ShardFile) -> std::io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    create_cache_dir(parent)?;
+    let tmp = parent.join(format!(
+        ".http3-{}-{}.tmp",
+        std::process::id(),
+        now_secs_nanos()
+    ));
+    let data = serde_json::to_vec_pretty(shard)?;
+    let mut file = create_temp_file(&tmp)?;
+    file.write_all(&data)?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    drop(file);
+    if let Err(err) = crate::fileutil::atomic_replace_file(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_temp_file(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn create_temp_file(path: &Path) -> std::io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+}
+
+fn shard_lock_path(path: &Path) -> PathBuf {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "http3.json".into());
+    path.with_file_name(format!(".{name}.lock"))
+}
+
+fn prune_global(dir: &Path, now: u64) {
+    let mut summaries = Vec::new();
+    collect_shard_summaries(dir, now, &mut summaries);
+    for summary in summaries.iter().filter(|summary| summary.expired) {
+        let _ = fs::remove_file(&summary.path);
+    }
+    summaries.retain(|summary| !summary.expired);
+    if summaries.len() <= MAX_SHARDS {
+        return;
+    }
+    summaries.sort_by_key(|summary| summary.last_used_at);
+    for summary in summaries.iter().take(summaries.len() - MAX_SHARDS) {
+        let _ = fs::remove_file(&summary.path);
+    }
+}
+
+fn collect_shard_summaries(dir: &Path, now: u64, out: &mut Vec<ShardSummary>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_shard_summaries(&path, now, out);
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(mut shard) = fs::read(&path)
+            .ok()
+            .and_then(|data| serde_json::from_slice::<ShardFile>(&data).ok())
+        else {
+            continue;
+        };
+        prune_expired_candidates(&mut shard.candidates, now);
+        let expired = shard.candidates.is_empty();
+        let last_used_at = shard
+            .candidates
+            .iter()
+            .map(|candidate| candidate.last_used_at)
+            .max()
+            .unwrap_or(0);
+        out.push(ShardSummary {
+            path,
+            expired,
+            last_used_at,
+        });
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push(hex_char(byte >> 4));
+        out.push(hex_char(byte & 0x0f));
+    }
+    out
+}
+
+fn hex_char(nibble: u8) -> char {
+    match nibble {
+        0..=9 => (b'0' + nibble) as char,
+        _ => (b'a' + (nibble - 10)) as char,
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn now_secs_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::HeaderValue;
+    use tempfile::TempDir;
+
+    fn test_url() -> Url {
+        Url::parse("https://Example.com:8443/path").unwrap()
+    }
+
+    fn record(target: &str, port: Option<u16>, ttl: Option<u32>) -> SvcbRecord {
+        SvcbRecord {
+            priority: 1,
+            target: target.to_string(),
+            alpn: vec!["h3".to_string()],
+            no_default_alpn: false,
+            port,
+            ipv4_hint: Vec::new(),
+            ipv6_hint: Vec::new(),
+            mandatory: Vec::new(),
+            unsupported_mandatory: Vec::new(),
+            ttl,
+        }
+    }
+
+    #[test]
+    fn cache_key_normalizes_origin_and_scopes_resolver() {
+        let key = cache_key(&test_url(), Some("127.0.0.1:53")).unwrap();
+        assert_eq!(key.origin, "https://example.com:8443");
+        assert_eq!(key.resolver_key, "dns-server:127.0.0.1:53");
+
+        let key = cache_key(&test_url(), None).unwrap();
+        assert_eq!(key.resolver_key, "system");
+    }
+
+    #[test]
+    fn stores_https_records_per_origin_shard() {
+        let dir = TempDir::new().unwrap();
+        let cache = Http3Cache::with_dir(dir.path().to_path_buf());
+        cache.store_https_records(&test_url(), None, &[record(".", Some(9443), Some(60))]);
+
+        let got = cache.candidates(&test_url(), None);
+        assert_eq!(
+            got,
+            vec![Http3CacheCandidate {
+                alt_host: "example.com".to_string(),
+                alt_port: 9443,
+                priority: Some(1),
+            }]
+        );
+        assert!(
+            cache
+                .candidates(&test_url(), Some("127.0.0.1:53"))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn ignores_https_records_without_ttl() {
+        let dir = TempDir::new().unwrap();
+        let cache = Http3Cache::with_dir(dir.path().to_path_buf());
+        cache.store_https_records(&test_url(), None, &[record(".", Some(9443), None)]);
+
+        assert!(cache.candidates(&test_url(), None).is_empty());
+    }
+
+    #[test]
+    fn removes_failed_candidates() {
+        let dir = TempDir::new().unwrap();
+        let cache = Http3Cache::with_dir(dir.path().to_path_buf());
+        cache.store_https_records(&test_url(), None, &[record(".", Some(9443), Some(60))]);
+        let candidates = cache.candidates(&test_url(), None);
+
+        cache.remove_candidates(&test_url(), None, &candidates);
+
+        assert!(cache.candidates(&test_url(), None).is_empty());
+    }
+
+    #[test]
+    fn parses_alt_svc_h3_candidates_and_clear() {
+        let url = test_url();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            ALT_SVC,
+            HeaderValue::from_static(r#"h3=":443"; ma=60, h2=":443", h3="alt.example:9443""#),
+        );
+        let update = parse_alt_svc_headers(&url, &headers, 100).unwrap();
+
+        assert!(!update.clear);
+        assert_eq!(update.candidates.len(), 2);
+        assert_eq!(update.candidates[0].alt_host, "example.com");
+        assert_eq!(update.candidates[0].alt_port, 443);
+        assert_eq!(update.candidates[0].expires_at, 160);
+        assert_eq!(update.candidates[1].alt_host, "alt.example");
+        assert_eq!(update.candidates[1].alt_port, 9443);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(ALT_SVC, HeaderValue::from_static("clear"));
+        assert!(parse_alt_svc_headers(&url, &headers, 100).unwrap().clear);
+    }
+
+    #[test]
+    fn alt_svc_ma_zero_removes_matching_candidate() {
+        let url = test_url();
+        let mut headers = HeaderMap::new();
+        headers.insert(ALT_SVC, HeaderValue::from_static(r#"h3=":443"; ma=0"#));
+        let update = parse_alt_svc_headers(&url, &headers, 100).unwrap();
+
+        assert!(update.candidates.is_empty());
+        assert_eq!(update.remove, vec![("example.com".to_string(), 443)]);
+    }
+
+    #[test]
+    fn caps_candidates_per_origin() {
+        let dir = TempDir::new().unwrap();
+        let cache = Http3Cache::with_dir(dir.path().to_path_buf());
+        let records = (0..8)
+            .map(|idx| {
+                let mut record = record(&format!("alt{idx}.example."), Some(9443), Some(60));
+                record.priority = idx + 1;
+                record
+            })
+            .collect::<Vec<_>>();
+
+        cache.store_https_records(&test_url(), None, &records);
+
+        let got = cache.candidates(&test_url(), None);
+        assert_eq!(got.len(), MAX_CANDIDATES_PER_ORIGIN);
+        assert_eq!(got[0].priority, Some(1));
+        assert_eq!(got[3].priority, Some(4));
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -60,6 +60,7 @@ use crate::timing::{self, AttemptTiming, DnsTiming, ResponseTiming};
 pub(crate) mod client;
 mod edit;
 mod encoding;
+mod http3_cache;
 mod metadata;
 pub mod multipart;
 mod request;

--- a/src/http/transport.rs
+++ b/src/http/transport.rs
@@ -40,6 +40,7 @@ use crate::cli::HttpVersion;
 use crate::dns::svcb::{HttpsRecordResolver, SvcbRecord};
 use crate::duration::{TimeoutBudget, request_timeout_message};
 use crate::error::FetchError;
+use crate::http::http3_cache::{Http3Cache, Http3CacheCandidate};
 use crate::timing::{DnsTiming, TransportTiming};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -291,6 +292,8 @@ struct ClientConfig {
     local_address: Option<IpAddr>,
     auto_http3: Option<AutoHttp3Config>,
     auto_http3_discovery: bool,
+    http3_cache: Option<Arc<Http3Cache>>,
+    learn_alt_svc: bool,
 }
 
 pub(crate) struct ClientBuilder {
@@ -322,6 +325,8 @@ impl Client {
                 local_address: None,
                 auto_http3: None,
                 auto_http3_discovery: false,
+                http3_cache: None,
+                learn_alt_svc: false,
             },
         }
     }
@@ -389,7 +394,9 @@ impl Client {
         self.apply_proxy_authorization(&url, &mut headers)?;
         apply_host_header(&url, &mut headers)?;
         let response = match version {
-            None if (self.config.auto_http3.is_some() || self.config.auto_http3_discovery)
+            None if (self.config.auto_http3.is_some()
+                || self.config.auto_http3_discovery
+                || self.config.http3_cache.is_some())
                 && url.scheme() == "https" =>
             {
                 self.send_auto_http3(method, url.clone(), headers, body, body_deadline)
@@ -408,6 +415,7 @@ impl Client {
             ))),
         };
         if let Ok(response) = &response {
+            self.store_http3_alt_svc(&url, response.headers());
             self.store_response_cookies(&url, response.headers());
         }
         Ok(response)
@@ -430,6 +438,16 @@ impl Client {
             return;
         };
         session.set_cookies(&mut headers.get_all(SET_COOKIE).iter(), url);
+    }
+
+    fn store_http3_alt_svc(&self, url: &Url, headers: &HeaderMap) {
+        if !self.config.learn_alt_svc {
+            return;
+        }
+        let Some(cache) = &self.config.http3_cache else {
+            return;
+        };
+        cache.store_alt_svc(url, self.config.dns_server.as_deref(), headers);
     }
 
     fn apply_proxy_authorization(
@@ -569,7 +587,9 @@ impl Client {
     }
 
     async fn race_auto_http3_connection(&self, url: Url) -> Result<AutoRaceWinner, Error> {
-        if self.config.auto_http3_discovery {
+        if self.config.auto_http3_discovery
+            || (self.config.auto_http3.is_none() && self.config.http3_cache.is_some())
+        {
             return self.race_dynamic_auto_http3_connection(url).await;
         }
         let connect_timeout = TimeoutBudget::new(self.config.connect_timeout);
@@ -642,15 +662,43 @@ impl Client {
             .host_str()
             .ok_or_else(|| Error::request("URL host is required"))?;
         let discovery_start = std::time::Instant::now();
-        let origin_addrs_task = spawn_auto_http3_origin_addrs(
-            self.config.dns_server.clone(),
+        let cached_candidates = self
+            .config
+            .http3_cache
+            .as_ref()
+            .map(|cache| cache.candidates(url, self.config.dns_server.as_deref()))
+            .unwrap_or_default();
+        let fresh = self.connect_fresh_dynamic_auto_http3_client(
+            url,
+            origin.clone(),
             host.to_string(),
+            discovery_start,
             timeout,
         );
+        let cached =
+            self.connect_cached_dynamic_auto_http3_client(url, origin, cached_candidates, timeout);
+        race_dynamic_auto_http3_candidates(fresh, cached).await
+    }
+
+    async fn connect_fresh_dynamic_auto_http3_client(
+        &self,
+        url: &Url,
+        origin: String,
+        host: String,
+        discovery_start: std::time::Instant,
+        timeout: TimeoutBudget,
+    ) -> DynamicHttp3ConnectOutcome {
+        let origin_addrs_task =
+            spawn_auto_http3_origin_addrs(self.config.dns_server.clone(), host.clone(), timeout);
         let records =
-            lookup_auto_http3_https_records(self.config.dns_server.as_deref(), host, timeout).await;
+            lookup_auto_http3_https_records(self.config.dns_server.as_deref(), &host, timeout)
+                .await;
+        if let Some(cache) = &self.config.http3_cache {
+            cache.store_https_records(url, self.config.dns_server.as_deref(), &records);
+        }
         if records.is_empty() {
-            return Err(Error::connect("no HTTP/3 candidates discovered"));
+            origin_addrs_task.abort();
+            return DynamicHttp3ConnectOutcome::NoCandidates;
         }
         let origin_addrs = take_finished_auto_http3_origin_addrs(origin_addrs_task).await;
         let addrs = auto_http3_addrs_for_records(
@@ -662,11 +710,33 @@ impl Client {
         )
         .await;
         if addrs.is_empty() {
-            return Err(Error::connect("no HTTP/3 candidates discovered"));
+            return DynamicHttp3ConnectOutcome::NoCandidates;
         }
         record_dns_addrs_trace(&self.config, url, &addrs, discovery_start.elapsed());
-        self.connect_http3_client_with_addrs(url, origin, addrs, timeout)
+        match self
+            .connect_http3_client_with_addrs(url, origin, addrs, timeout)
             .await
+        {
+            Ok(result) => DynamicHttp3ConnectOutcome::Connected(result),
+            Err(err) => DynamicHttp3ConnectOutcome::Failed(err),
+        }
+    }
+
+    async fn connect_cached_dynamic_auto_http3_client(
+        &self,
+        url: &Url,
+        origin: String,
+        candidates: Vec<Http3CacheCandidate>,
+        timeout: TimeoutBudget,
+    ) -> DynamicHttp3ConnectOutcome {
+        match self
+            .connect_cached_auto_http3_client_with_candidates(url, origin, candidates, timeout)
+            .await
+        {
+            Some(Ok(result)) => DynamicHttp3ConnectOutcome::Connected(result),
+            Some(Err(err)) => DynamicHttp3ConnectOutcome::Failed(err),
+            None => DynamicHttp3ConnectOutcome::NoCandidates,
+        }
     }
 
     async fn connect_auto_tcp_tls(
@@ -848,6 +918,98 @@ where
     }
 }
 
+enum DynamicHttp3ConnectOutcome {
+    Connected(Http3ConnectResult),
+    Failed(Error),
+    NoCandidates,
+}
+
+async fn race_dynamic_auto_http3_candidates<FreshFuture, CachedFuture>(
+    fresh: FreshFuture,
+    cached: CachedFuture,
+) -> Result<Http3ConnectResult, Error>
+where
+    FreshFuture: Future<Output = DynamicHttp3ConnectOutcome>,
+    CachedFuture: Future<Output = DynamicHttp3ConnectOutcome>,
+{
+    let mut fresh = Box::pin(fresh);
+    let prompt_fresh = tokio::task::yield_now();
+    tokio::pin!(prompt_fresh);
+
+    let mut fresh_done = false;
+    let mut cached_done = false;
+    let mut fresh_err = None;
+    let mut cached_err = None;
+
+    tokio::select! {
+        result = fresh.as_mut() => {
+            fresh_done = true;
+            if let Some(result) = record_dynamic_http3_outcome(result, &mut fresh_err) {
+                return Ok(result);
+            }
+        }
+        _ = &mut prompt_fresh => {}
+    }
+
+    let mut cached = Box::pin(cached);
+
+    loop {
+        if fresh_done && cached_done {
+            return Err(fresh_err
+                .or(cached_err)
+                .unwrap_or_else(|| Error::connect("no HTTP/3 candidates discovered")));
+        }
+
+        match (fresh_done, cached_done) {
+            (false, false) => {
+                tokio::select! {
+                    result = fresh.as_mut() => {
+                        fresh_done = true;
+                        if let Some(result) = record_dynamic_http3_outcome(result, &mut fresh_err) {
+                            return Ok(result);
+                        }
+                    }
+                    result = cached.as_mut() => {
+                        cached_done = true;
+                        if let Some(result) = record_dynamic_http3_outcome(result, &mut cached_err) {
+                            return Ok(result);
+                        }
+                    }
+                }
+            }
+            (false, true) => {
+                let result = fresh.as_mut().await;
+                fresh_done = true;
+                if let Some(result) = record_dynamic_http3_outcome(result, &mut fresh_err) {
+                    return Ok(result);
+                }
+            }
+            (true, false) => {
+                let result = cached.as_mut().await;
+                cached_done = true;
+                if let Some(result) = record_dynamic_http3_outcome(result, &mut cached_err) {
+                    return Ok(result);
+                }
+            }
+            (true, true) => unreachable!("handled at top of loop"),
+        }
+    }
+}
+
+fn record_dynamic_http3_outcome(
+    outcome: DynamicHttp3ConnectOutcome,
+    error: &mut Option<Error>,
+) -> Option<Http3ConnectResult> {
+    match outcome {
+        DynamicHttp3ConnectOutcome::Connected(result) => Some(result),
+        DynamicHttp3ConnectOutcome::Failed(err) => {
+            *error = Some(err);
+            None
+        }
+        DynamicHttp3ConnectOutcome::NoCandidates => None,
+    }
+}
+
 fn spawn_auto_http3_origin_addrs(
     dns_server: Option<String>,
     host: String,
@@ -945,6 +1107,30 @@ async fn auto_http3_addrs_for_records(
                 record_addrs.push(SocketAddr::new(ip, port));
             }
         }
+        append_unique_socket_addrs(&mut addrs, record_addrs);
+    }
+    addrs
+}
+
+async fn auto_http3_addrs_for_cached_candidates(
+    dns_server: Option<&str>,
+    candidates: &[Http3CacheCandidate],
+    timeout: TimeoutBudget,
+) -> Vec<SocketAddr> {
+    let mut sorted = candidates.iter().collect::<Vec<_>>();
+    sorted.sort_by_key(|candidate| candidate.priority.unwrap_or(u16::MAX));
+    let mut addrs = Vec::new();
+    for candidate in sorted {
+        let record_addrs = if let Ok(ip) = candidate.alt_host.parse::<IpAddr>() {
+            vec![SocketAddr::new(ip, candidate.alt_port)]
+        } else {
+            crate::net::resolve_host(&candidate.alt_host, dns_server, timeout)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|addr| SocketAddr::new(addr.ip(), candidate.alt_port))
+                .collect()
+        };
         append_unique_socket_addrs(&mut addrs, record_addrs);
     }
     addrs
@@ -1122,15 +1308,71 @@ impl Client {
                 timing: TransportTiming::default(),
             });
         }
-        let addrs = self
+        let mut fresh_error = None;
+        if let Some(addrs) = self
             .config
             .auto_http3
             .as_ref()
             .map(|config| config.addrs.clone())
             .filter(|addrs| !addrs.is_empty())
-            .ok_or_else(|| Error::connect("no HTTP/3 candidates discovered"))?;
-        self.connect_http3_client_with_addrs(url, origin, addrs, timeout)
+        {
+            match self
+                .connect_http3_client_with_addrs(url, origin.clone(), addrs, timeout)
+                .await
+            {
+                Ok(result) => return Ok(result),
+                Err(err) => fresh_error = Some(err),
+            }
+        }
+        let cached_error = match self
+            .connect_cached_auto_http3_client(url, origin, timeout)
             .await
+        {
+            Some(Ok(result)) => return Ok(result),
+            Some(Err(err)) => Some(err),
+            None => None,
+        };
+        Err(fresh_error
+            .or(cached_error)
+            .unwrap_or_else(|| Error::connect("no HTTP/3 candidates discovered")))
+    }
+
+    async fn connect_cached_auto_http3_client(
+        &self,
+        url: &Url,
+        origin: String,
+        timeout: TimeoutBudget,
+    ) -> Option<Result<Http3ConnectResult, Error>> {
+        let cache = self.config.http3_cache.as_ref()?;
+        let candidates = cache.candidates(url, self.config.dns_server.as_deref());
+        self.connect_cached_auto_http3_client_with_candidates(url, origin, candidates, timeout)
+            .await
+    }
+
+    async fn connect_cached_auto_http3_client_with_candidates(
+        &self,
+        url: &Url,
+        origin: String,
+        candidates: Vec<Http3CacheCandidate>,
+        timeout: TimeoutBudget,
+    ) -> Option<Result<Http3ConnectResult, Error>> {
+        let cache = self.config.http3_cache.as_ref()?;
+        let addrs = auto_http3_addrs_for_cached_candidates(
+            self.config.dns_server.as_deref(),
+            &candidates,
+            timeout,
+        )
+        .await;
+        if addrs.is_empty() {
+            return None;
+        }
+        let result = self
+            .connect_http3_client_with_addrs(url, origin, addrs, timeout)
+            .await;
+        if result.is_err() {
+            cache.remove_candidates(url, self.config.dns_server.as_deref(), &candidates);
+        }
+        Some(result)
     }
 
     async fn connect_http3_client(
@@ -1290,6 +1532,12 @@ impl ClientBuilder {
 
     pub(crate) fn auto_http3_discovery(mut self) -> Self {
         self.config.auto_http3_discovery = true;
+        self
+    }
+
+    pub(crate) fn http3_cache(mut self, cache: Arc<Http3Cache>, learn_alt_svc: bool) -> Self {
+        self.config.http3_cache = Some(cache);
+        self.config.learn_alt_svc = learn_alt_svc;
         self
     }
 
@@ -2587,6 +2835,7 @@ mod tests {
             ipv6_hint: Vec::new(),
             mandatory: Vec::new(),
             unsupported_mandatory: Vec::new(),
+            ttl: Some(60),
         }
     }
 

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -14,7 +14,8 @@ use support::dns::{
     parse_dns_question, start_udp_dns_server, start_udp_dns_server_dropping_https,
     start_udp_dns_server_with_delayed_aaaa, start_udp_dns_server_with_hosts,
     start_udp_dns_server_with_https, start_udp_dns_server_with_https_target_dropping_target,
-    start_udp_dns_server_with_https_targets_dropping_targets, start_unresponsive_udp_dns_server,
+    start_udp_dns_server_with_https_targets_dropping_targets,
+    start_udp_dns_server_with_toggleable_https, start_unresponsive_udp_dns_server,
 };
 use support::grpc::{
     grpc_frame, grpc_frame_with_flag, gzip_bytes, proto_field_string, proto_field_varint,
@@ -25,7 +26,9 @@ use support::proxy::{
     assert_socks_seen, start_http_connect_proxy, start_https_proxy, start_socks5_proxy,
     start_stalling_proxy,
 };
-use support::tls::{start_h2_tls_server, start_mtls_server, start_tls_server};
+use support::tls::{
+    start_h2_tls_server, start_h2_tls_server_with_accept_delay, start_mtls_server, start_tls_server,
+};
 use tempfile::TempDir;
 use url::Url;
 
@@ -584,6 +587,275 @@ fn default_https_uses_http3_from_https_dns_record() {
     assert!(res.stderr.contains("QUIC"), "{}", res.stderr);
     let requests = wait_for_h3_requests(&h3, 1);
     assert_eq!(requests[0].path, "/auto-h3");
+}
+
+#[test]
+fn default_https_uses_cached_http3_from_https_dns_record() {
+    let cache_dir = TempDir::new().unwrap();
+    let h3 = start_http3_server(|req| match req.path.as_str() {
+        "/learn-h3-cache" => H3Response::ok("learned h3 cache"),
+        "/use-h3-cache" => H3Response::ok("used h3 cache"),
+        _ => H3Response::status(404, "not found"),
+    });
+    let h3_port = Url::parse(&h3.url).unwrap().port().unwrap();
+    let (dns_addr, advertise_https) = start_udp_dns_server_with_toggleable_https(
+        "localhost.",
+        Ipv4Addr::new(127, 0, 0, 1),
+        h3_port,
+    );
+    let env = vec![(
+        "FETCH_INTERNAL_HTTP3_CACHE_DIR".to_string(),
+        cache_dir.path().display().to_string(),
+    )];
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            env: env.clone(),
+            ..Default::default()
+        },
+        &[
+            "--dns-server",
+            &dns_addr,
+            "--ca-cert",
+            h3.ca_cert_path.to_str().unwrap(),
+            &format!("https://localhost:{h3_port}/learn-h3-cache"),
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "learned h3 cache");
+    assert!(res.stderr.contains("HTTP/3.0 200 OK"), "{}", res.stderr);
+
+    advertise_https.store(false, Ordering::SeqCst);
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            env,
+            ..Default::default()
+        },
+        &[
+            "--dns-server",
+            &dns_addr,
+            "--ca-cert",
+            h3.ca_cert_path.to_str().unwrap(),
+            &format!("https://localhost:{h3_port}/use-h3-cache"),
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "used h3 cache");
+    assert!(res.stderr.contains("HTTP/3.0 200 OK"), "{}", res.stderr);
+    let requests = wait_for_h3_requests(&h3, 2);
+    assert_eq!(requests[0].path, "/learn-h3-cache");
+    assert_eq!(requests[1].path, "/use-h3-cache");
+}
+
+#[test]
+fn default_https_uses_cached_http3_from_alt_svc_header() {
+    let cache_dir = TempDir::new().unwrap();
+    let h3 = start_http3_server(|req| {
+        if req.path == "/alt-svc-cache" {
+            return H3Response::ok("alt-svc h3 cache");
+        }
+        H3Response::status(404, "not found")
+    });
+    let h3_port = Url::parse(&h3.url).unwrap().port().unwrap();
+    let h2 = start_h2_tls_server(move |req| {
+        if req.path == "/alt-svc-cache" {
+            return TestResponse::ok("learned alt-svc")
+                .header("Alt-Svc", &format!("h3=\":{h3_port}\"; ma=60"));
+        }
+        TestResponse::status(404, "Not Found", "")
+    });
+    let h2_url = format!("{}/alt-svc-cache", h2.url);
+    let h2_ca = h2.ca_cert_path.clone();
+    let h3_ca = h3.ca_cert_path.clone();
+    let env = vec![(
+        "FETCH_INTERNAL_HTTP3_CACHE_DIR".to_string(),
+        cache_dir.path().display().to_string(),
+    )];
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            env: env.clone(),
+            ..Default::default()
+        },
+        &[
+            "--ca-cert",
+            h2_ca.to_str().unwrap(),
+            "--ca-cert",
+            h3_ca.to_str().unwrap(),
+            &h2_url,
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "learned alt-svc");
+    assert!(res.stderr.contains("HTTP/2.0 200 OK"), "{}", res.stderr);
+    drop(h2);
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            env,
+            ..Default::default()
+        },
+        &[
+            "--ca-cert",
+            h2_ca.to_str().unwrap(),
+            "--ca-cert",
+            h3_ca.to_str().unwrap(),
+            &h2_url,
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "alt-svc h3 cache");
+    assert!(res.stderr.contains("HTTP/3.0 200 OK"), "{}", res.stderr);
+    let requests = wait_for_h3_requests(&h3, 1);
+    assert_eq!(requests[0].path, "/alt-svc-cache");
+}
+
+#[test]
+fn default_https_races_cached_alt_svc_without_waiting_for_slow_https_record_lookup() {
+    let cache_dir = TempDir::new().unwrap();
+    let h3 = start_http3_server(|req| {
+        if req.path == "/cached-alt-svc-race" {
+            return H3Response::ok("cached alt-svc wins");
+        }
+        H3Response::status(404, "not found")
+    });
+    let h3_port = Url::parse(&h3.url).unwrap().port().unwrap();
+    let h2 = start_h2_tls_server_with_accept_delay(
+        move |req| {
+            if req.path == "/cached-alt-svc-race" {
+                return TestResponse::ok("learned alt-svc")
+                    .header("Alt-Svc", &format!("h3=\":{h3_port}\"; ma=60"));
+            }
+            TestResponse::status(404, "Not Found", "")
+        },
+        Duration::from_millis(250),
+    );
+    let h2_url = format!("{}/cached-alt-svc-race", h2.url);
+    let dns_addr = start_udp_dns_server_dropping_https("localhost.", Ipv4Addr::new(127, 0, 0, 1));
+    let h2_ca = h2.ca_cert_path.clone();
+    let h3_ca = h3.ca_cert_path.clone();
+    let env = vec![(
+        "FETCH_INTERNAL_HTTP3_CACHE_DIR".to_string(),
+        cache_dir.path().display().to_string(),
+    )];
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            env: env.clone(),
+            ..Default::default()
+        },
+        &[
+            "--dns-server",
+            &dns_addr,
+            "--ca-cert",
+            h2_ca.to_str().unwrap(),
+            "--ca-cert",
+            h3_ca.to_str().unwrap(),
+            &h2_url,
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "learned alt-svc");
+    assert!(res.stderr.contains("HTTP/2.0 200 OK"), "{}", res.stderr);
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            env,
+            ..Default::default()
+        },
+        &[
+            "--dns-server",
+            &dns_addr,
+            "--ca-cert",
+            h2_ca.to_str().unwrap(),
+            "--ca-cert",
+            h3_ca.to_str().unwrap(),
+            &h2_url,
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "cached alt-svc wins");
+    assert!(res.stderr.contains("HTTP/3.0 200 OK"), "{}", res.stderr);
+    let requests = wait_for_h3_requests(&h3, 1);
+    assert_eq!(requests[0].path, "/cached-alt-svc-race");
+}
+
+#[test]
+fn default_https_prefers_fresh_https_record_over_stale_http3_cache() {
+    let cache_dir = TempDir::new().unwrap();
+    let h3 = start_http3_server(|req| {
+        if req.path == "/fresh-h3-after-stale-cache" {
+            return H3Response::ok("fresh h3 wins");
+        }
+        H3Response::status(404, "not found")
+    });
+    let h3_port = Url::parse(&h3.url).unwrap().port().unwrap();
+    let quic_blackhole = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let stale_h3_port = quic_blackhole.local_addr().unwrap().port();
+    let h2 = start_h2_tls_server(move |req| {
+        if req.path == "/learn-stale-h3-cache" {
+            return TestResponse::ok("learned stale h3 cache")
+                .header("Alt-Svc", &format!("h3=\":{stale_h3_port}\"; ma=60"));
+        }
+        TestResponse::status(404, "Not Found", "")
+    });
+    let h2_url = h2.url.clone();
+    let h2_ca = h2.ca_cert_path.clone();
+    let h3_ca = h3.ca_cert_path.clone();
+    let (dns_addr, advertise_https) = start_udp_dns_server_with_toggleable_https(
+        "localhost.",
+        Ipv4Addr::new(127, 0, 0, 1),
+        h3_port,
+    );
+    advertise_https.store(false, Ordering::SeqCst);
+    let env = vec![(
+        "FETCH_INTERNAL_HTTP3_CACHE_DIR".to_string(),
+        cache_dir.path().display().to_string(),
+    )];
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            env: env.clone(),
+            ..Default::default()
+        },
+        &[
+            "--dns-server",
+            &dns_addr,
+            "--ca-cert",
+            h2_ca.to_str().unwrap(),
+            &format!("{h2_url}/learn-stale-h3-cache"),
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "learned stale h3 cache");
+    assert!(res.stderr.contains("HTTP/2.0 200 OK"), "{}", res.stderr);
+
+    advertise_https.store(true, Ordering::SeqCst);
+    drop(h2);
+
+    let res = run_fetch_opts(
+        FetchOpts {
+            env,
+            ..Default::default()
+        },
+        &[
+            "--dns-server",
+            &dns_addr,
+            "--ca-cert",
+            h2_ca.to_str().unwrap(),
+            "--ca-cert",
+            h3_ca.to_str().unwrap(),
+            "--connect-timeout",
+            "1",
+            &format!("{h2_url}/fresh-h3-after-stale-cache"),
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "fresh h3 wins");
+    assert!(res.stderr.contains("HTTP/3.0 200 OK"), "{}", res.stderr);
+    let requests = wait_for_h3_requests(&h3, 1);
+    assert_eq!(requests[0].path, "/fresh-h3-after-stale-cache");
 }
 
 #[test]

--- a/tests/support/common.rs
+++ b/tests/support/common.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use tempfile::TempDir;
 use url::Url;
 
 #[cfg(unix)]
@@ -37,6 +38,12 @@ pub(crate) struct ReadCapture {
 
 pub(crate) fn fetch_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_fetch"))
+}
+
+fn isolate_http3_cache(cmd: &mut Command) -> TempDir {
+    let cache_dir = TempDir::new().expect("create isolated HTTP/3 cache dir");
+    cmd.env("FETCH_INTERNAL_HTTP3_CACHE_DIR", cache_dir.path());
+    cache_dir
 }
 
 pub(crate) fn run_fetch(args: &[&str]) -> FetchOutput {
@@ -88,6 +95,7 @@ pub(crate) fn run_fetch_once(opts: FetchOpts, args: &[&str]) -> FetchOutput {
     cmd.env("HTTPS_PROXY", "");
     cmd.env("ALL_PROXY", "");
     cmd.env("NO_PROXY", "*");
+    let _http3_cache_dir = isolate_http3_cache(&mut cmd);
     for (key, value) in opts.env {
         cmd.env(key, value);
     }
@@ -147,6 +155,7 @@ pub(crate) fn run_fetch_with_closed_stdout(args: &[&str]) -> FetchOutput {
     cmd.env("HTTPS_PROXY", "");
     cmd.env("ALL_PROXY", "");
     cmd.env("NO_PROXY", "*");
+    let _http3_cache_dir = isolate_http3_cache(&mut cmd);
 
     let out = cmd.output().expect("run fetch with closed stdout");
     FetchOutput {

--- a/tests/support/dns.rs
+++ b/tests/support/dns.rs
@@ -1,7 +1,7 @@
 use std::net::{Ipv4Addr, UdpSocket};
 use std::sync::{
     Arc,
-    atomic::{AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::thread;
 use std::time::Duration;
@@ -39,6 +39,38 @@ pub(crate) fn start_udp_dns_server_with_https(
         }
     });
     addr
+}
+
+pub(crate) fn start_udp_dns_server_with_toggleable_https(
+    host: &'static str,
+    ip: Ipv4Addr,
+    https_port: u16,
+) -> (String, Arc<AtomicBool>) {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("bind udp dns server");
+    let addr = socket.local_addr().unwrap().to_string();
+    let advertise_https = Arc::new(AtomicBool::new(true));
+    let advertise_for_thread = advertise_https.clone();
+    thread::spawn(move || {
+        let mut buf = [0_u8; 512];
+        while let Ok((n, peer)) = socket.recv_from(&mut buf) {
+            let Some((name, qtype, question_end)) = parse_dns_question(&buf[..n]) else {
+                continue;
+            };
+            let answer = if name == host && qtype == TYPE_A {
+                Some((TYPE_A, ip.octets().to_vec()))
+            } else if name == host
+                && qtype == TYPE_HTTPS
+                && advertise_for_thread.load(Ordering::SeqCst)
+            {
+                Some((TYPE_HTTPS, https_rdata(https_port, ip)))
+            } else {
+                None
+            };
+            let response = dns_response(&buf[..n], question_end, answer);
+            let _ = socket.send_to(&response, peer);
+        }
+    });
+    (addr, advertise_https)
 }
 
 pub(crate) fn start_udp_dns_server_with_https_target_dropping_target(

--- a/tests/support/tls.rs
+++ b/tests/support/tls.rs
@@ -117,6 +117,13 @@ pub(crate) fn start_tls_server(
 pub(crate) fn start_h2_tls_server(
     handler: impl Fn(TestRequest) -> TestResponse + Send + Sync + 'static,
 ) -> TlsTestServer {
+    start_h2_tls_server_with_accept_delay(handler, Duration::ZERO)
+}
+
+pub(crate) fn start_h2_tls_server_with_accept_delay(
+    handler: impl Fn(TestRequest) -> TestResponse + Send + Sync + 'static,
+    accept_delay: Duration,
+) -> TlsTestServer {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let certified =
         rcgen::generate_simple_self_signed(vec!["127.0.0.1".to_string(), "localhost".to_string()])
@@ -158,6 +165,9 @@ pub(crate) fn start_h2_tls_server(
                         let Ok(stream) = tokio::net::TcpStream::from_std(stream) else {
                             return;
                         };
+                        if !accept_delay.is_zero() {
+                            tokio::time::sleep(accept_delay).await;
+                        }
                         let Ok(tls) = acceptor.accept(stream).await else {
                             return;
                         };


### PR DESCRIPTION
## Summary
- Add a bounded per-origin HTTP/3 cache for learned HTTPS/SVCB and `Alt-Svc` alternatives
- Prefer fresh DNS candidates over cached entries and scope cache use to direct HTTPS auto-H3 flows
- Extend DNS TTL handling and update docs plus integration coverage for cache isolation and reuse

## Testing
- Added integration tests covering cached HTTP/3 reuse, `Alt-Svc` learning, and fresh-record precedence
- Updated shared test harness to isolate HTTP/3 cache state per run