### PR TITLE
Refactor home-path expansion into fileutil

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - **src/cli** - Command-line argument parsing, shell completion, and `--from-curl` support.
 - **src/config** - INI-format config file parsing with host-specific overrides.
 - **src/core.rs** - Shared printer, color, format, and terminal utilities.
-- **src/fileutil.rs** - Atomic file replacement and shared cross-platform advisory file locks.
+- **src/fileutil.rs** - Atomic file replacement, home-directory path expansion, and shared cross-platform advisory file locks.
 - **src/dns** - DNS-over-HTTPS, UDP DNS, system resolver fallback, and `--inspect-dns`.
 - **src/format** - Response body formatters for JSON, XML, YAML, HTML, CSS, CSV, Markdown, msgpack, protobuf, SSE, NDJSON, gRPC, and images.
 - **src/grpc** - gRPC framing, reflection, status handling, and protobuf request/response support.
@@ -166,6 +166,7 @@ metadata/update/DNS/TLS inspection modes, and executes requests via `src/http`.
 - Named session saves take a per-session advisory lock, reload the latest JSON, and merge only local cookie creates/updates/deletes before atomic replacement so concurrent `--session` invocations preserve distinct cookie changes. Session saves use a short bounded lock wait and report a warning instead of hanging indefinitely when another process keeps the session lock.
 - Explicit self-updates use a bounded update-lock wait capped by the request timeout or the fixed update-lock timeout; background auto-update checks keep using nonblocking lock acquisition.
 - Session and update lock acquisition should go through `fileutil::FileLock` so cross-platform open/retry/flock/LockFileEx/unlock behavior stays centralized while call sites own their timeout diagnostics.
+- User-supplied paths that support `~/` expansion should use `fileutil::expand_home`; keep the raw input string separately when diagnostics must preserve exactly what the user typed.
 - Self-update release metadata, artifact, checksum, and redirect-target URLs require HTTPS by default; only internal update/test overrides such as an `http://` `FETCH_INTERNAL_UPDATE_URL` may use HTTP for local fixtures.
 - `install.sh` verifies release archives against their `.sha256` sidecars before extraction and must not auto-edit shell startup files for completions during default installs. Completion installation is opt-in via `--completions` or `FETCH_INSTALL_COMPLETIONS=1`; otherwise print manual commands.
 - Output-file downloads keep `*.download` temp files behind a drop guard so cancellation paths such as Ctrl-C clean up partial files; Unix atomic installs also sync the parent directory after rename/link updates for stronger crash durability.

--- a/src/app.rs
+++ b/src/app.rs
@@ -885,7 +885,7 @@ fn append_body_value(value: &str, out: &mut Vec<u8>) -> Result<(), FetchError> {
         return append_materialized_curl_reader(stdin.lock(), out);
     }
     if let Some(path) = value.strip_prefix('@') {
-        let file = std::fs::File::open(expand_home(path))?;
+        let file = std::fs::File::open(crate::fileutil::expand_home(path))?;
         return append_materialized_curl_reader(file, out);
     }
     append_materialized_curl_bytes(out, value.as_bytes())
@@ -908,7 +908,7 @@ fn append_url_encode_from_value(value: &str, out: &mut Vec<u8>) -> Result<(), Fe
 }
 
 fn append_url_encoded_file(path: &str, out: &mut Vec<u8>) -> Result<(), FetchError> {
-    let file = std::fs::File::open(expand_home(path))?;
+    let file = std::fs::File::open(crate::fileutil::expand_home(path))?;
     append_query_escaped_reader(file, out)
 }
 
@@ -960,15 +960,6 @@ fn materialized_curl_data_limit_error() -> FetchError {
     FetchError::Message(format!(
         "--from-curl data requires materializing more than {MAX_MATERIALIZED_CURL_DATA_BYTES} bytes; use a single -d @file/-d @- body for streaming input"
     ))
-}
-
-fn expand_home(path: &str) -> String {
-    if let Some(rest) = path.strip_prefix("~/")
-        && let Some(home) = std::env::var_os("HOME")
-    {
-        return format!("{}/{}", home.to_string_lossy(), rest);
-    }
-    path.to_string()
 }
 
 fn append_raw_query(url: &mut String, query: &str) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -834,7 +834,7 @@ pub fn validate(cli: &Cli) -> Result<(), FetchError> {
 
 fn get_config_file(path: Option<&str>) -> Result<Option<(PathBuf, String)>, FetchError> {
     if let Some(path) = path {
-        let path = absolute_path(expand_home(path))?;
+        let path = absolute_path(crate::fileutil::expand_home(path))?;
         let contents = std::fs::read_to_string(&path)?;
         return Ok(Some((path, contents)));
     }
@@ -1416,15 +1416,6 @@ fn file_error(path: &Path, line_num: usize, message: &str) -> String {
         "config file '{}': line {line_num}: {message}",
         path.display()
     )
-}
-
-fn expand_home(path: &str) -> PathBuf {
-    if let Some(rest) = path.strip_prefix("~/")
-        && let Some(home) = env::var_os("HOME")
-    {
-        return PathBuf::from(home).join(rest);
-    }
-    PathBuf::from(path)
 }
 
 fn absolute_path(path: PathBuf) -> Result<PathBuf, FetchError> {
@@ -2281,24 +2272,6 @@ mod tests {
                 PathBuf::from("C:/AppData/Roaming/fetch/config"),
             ]
         );
-    }
-
-    #[test]
-    fn explicit_config_path_is_absolute_and_expands_home() {
-        let dir = tempfile::tempdir().unwrap();
-        let home = dir.path().join("home");
-        std::fs::create_dir_all(&home).unwrap();
-        let path = expand_home_with_home("~/fetch.conf", Some(&home));
-        assert_eq!(path, home.join("fetch.conf"));
-    }
-
-    fn expand_home_with_home(path: &str, home: Option<&Path>) -> PathBuf {
-        if let Some(rest) = path.strip_prefix("~/")
-            && let Some(home) = home
-        {
-            return home.join(rest);
-        }
-        PathBuf::from(path)
     }
 
     fn write_temp_config_pem(contents: &[u8]) -> (tempfile::NamedTempFile, String) {

--- a/src/fileutil.rs
+++ b/src/fileutil.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -25,6 +25,20 @@ pub fn atomic_write_new_file(
     target_path: impl AsRef<Path>,
 ) -> io::Result<()> {
     atomic_write_new_file_impl(temp_path.as_ref(), target_path.as_ref())
+}
+
+pub fn expand_home(path: &str) -> PathBuf {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    expand_home_with(path, home.as_deref())
+}
+
+fn expand_home_with(path: &str, home: Option<&Path>) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Some(home) = home
+    {
+        return home.join(rest);
+    }
+    PathBuf::from(path)
 }
 
 #[derive(Debug)]
@@ -255,6 +269,35 @@ fn unlock_file(_file: &std::fs::File) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn expand_home_expands_leading_home_segment() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+
+        assert_eq!(
+            expand_home_with("~/fetch.conf", Some(&home)),
+            home.join("fetch.conf")
+        );
+    }
+
+    #[test]
+    fn expand_home_leaves_other_paths_unchanged() {
+        let home = Path::new("/home/me");
+
+        assert_eq!(
+            expand_home_with("~fetch.conf", Some(home)),
+            PathBuf::from("~fetch.conf")
+        );
+        assert_eq!(
+            expand_home_with("fetch.conf", Some(home)),
+            PathBuf::from("fetch.conf")
+        );
+        assert_eq!(
+            expand_home_with("~/fetch.conf", None),
+            PathBuf::from("~/fetch.conf")
+        );
+    }
 
     #[cfg(any(unix, windows))]
     #[test]

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -61,8 +61,8 @@ impl Multipart {
             let name = name.trim().to_string();
             validate_multipart_disposition_value("field name", &name)?;
             let field = if let Some(path) = value.strip_prefix('@') {
-                let path = expand_home(path);
-                file_field(&name, PathBuf::from(path))?
+                let path = crate::fileutil::expand_home(path);
+                file_field(&name, path)?
             } else {
                 text_field(&name, value)
             };
@@ -229,15 +229,6 @@ fn validate_file_path(path: &Path) -> Result<std::fs::Metadata, MultipartError> 
         return Err(MultipartError::FileIsDirectory(path.display().to_string()));
     }
     Ok(metadata)
-}
-
-fn expand_home(path: &str) -> String {
-    if let Some(rest) = path.strip_prefix("~/")
-        && let Some(home) = std::env::var_os("HOME")
-    {
-        return format!("{}/{}", home.to_string_lossy(), rest);
-    }
-    path.to_string()
 }
 
 fn escape_multipart_string(value: &str) -> String {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -894,7 +894,7 @@ pub(super) fn body_value_source(
         ));
     }
     if let Some(path) = value.strip_prefix('@') {
-        let expanded = expand_home(path);
+        let expanded = crate::fileutil::expand_home(path);
         let metadata = std::fs::metadata(&expanded).map_err(|err| {
             if err.kind() == std::io::ErrorKind::NotFound {
                 FetchError::Message(format!("file '{path}' does not exist"))
@@ -912,7 +912,7 @@ pub(super) fn body_value_source(
         };
         return Ok((
             RequestBodySource::File {
-                path: expanded,
+                path: expanded.to_string_lossy().into_owned(),
                 len: metadata.len(),
             },
             content_type,
@@ -924,23 +924,17 @@ pub(super) fn body_value_source(
     ))
 }
 
-pub(super) fn expand_home(path: &str) -> String {
-    if let Some(rest) = path.strip_prefix("~/")
-        && let Some(home) = std::env::var_os("HOME")
-    {
-        return format!("{}/{}", home.to_string_lossy(), rest);
-    }
-    path.to_string()
-}
-
-pub(super) fn detect_body_file_content_type(path: &str) -> Result<String, FetchError> {
-    if let Some(content_type) = content_type::request_content_type_for_path(Path::new(path)) {
+pub(super) fn detect_body_file_content_type(path: &Path) -> Result<String, FetchError> {
+    if let Some(content_type) = content_type::request_content_type_for_path(path) {
         return Ok(content_type.to_string());
     }
     Ok(sniff_content_type_like_go(&read_file_prefix(path, 512)?))
 }
 
-pub(super) fn read_file_prefix(path: &str, limit: usize) -> Result<Vec<u8>, FetchError> {
+pub(super) fn read_file_prefix(
+    path: impl AsRef<Path>,
+    limit: usize,
+) -> Result<Vec<u8>, FetchError> {
     let mut file = std::fs::File::open(path)?;
     let mut out = vec![0_u8; limit];
     let len = file.read(&mut out)?;


### PR DESCRIPTION
## Summary
- Move `~/` expansion into `src/fileutil.rs` as a shared helper
- Update config, request, multipart, and curl body handling to use the shared path logic
- Preserve the original user path where diagnostics need the unexpanded value
- Add unit coverage for home-path expansion behavior

## Testing
- Not run (not requested)