### PR TITLE
Refactor gRPC descriptor formatting to stream printers

### DIFF
--- a/src/format/grpc.rs
+++ b/src/format/grpc.rs
@@ -1,5 +1,9 @@
 use std::fmt;
 
+use prost_reflect::{DynamicMessage, MessageDescriptor, SerializeOptions};
+
+use crate::core::Printer;
+use crate::format::json;
 use crate::grpc::encoding::{self, MessageEncoding};
 use crate::grpc::framing;
 
@@ -40,12 +44,61 @@ pub fn format_grpc_frame(
     crate::format::protobuf::format_protobuf(&data).map_err(|err| GrpcFormatError(err.to_string()))
 }
 
+pub fn format_grpc_stream_with_descriptor_to(
+    buf: &[u8],
+    desc: &MessageDescriptor,
+    message_encoding: &MessageEncoding,
+    out: &mut Printer,
+) -> Result<(), GrpcFormatError> {
+    let frames = framing::read_frames(buf)
+        .map_err(|err| GrpcFormatError(format!("failed to read gRPC stream: {err}")))?;
+    for frame in &frames {
+        format_grpc_frame_with_descriptor_to(frame, desc, message_encoding, out)?;
+    }
+    Ok(())
+}
+
+pub fn format_grpc_frame_with_descriptor_to(
+    frame: &framing::Frame,
+    desc: &MessageDescriptor,
+    message_encoding: &MessageEncoding,
+    out: &mut Printer,
+) -> Result<(), GrpcFormatError> {
+    let data = encoding::decompress_frame(frame, message_encoding)
+        .map_err(|err| GrpcFormatError(err.to_string()))?;
+    let msg = decode_dynamic_message(data.as_slice(), desc)?;
+    let value = dynamic_message_to_json_value(&msg)?;
+    json::format_json_value_to(&value, out);
+    Ok(())
+}
+
+fn decode_dynamic_message(
+    bytes: &[u8],
+    desc: &MessageDescriptor,
+) -> Result<DynamicMessage, GrpcFormatError> {
+    DynamicMessage::decode(desc.clone(), bytes)
+        .map_err(|err| GrpcFormatError(format!("failed to decode protobuf message: {err}")))
+}
+
+fn dynamic_message_to_json_value(
+    msg: &DynamicMessage,
+) -> Result<serde_json::Value, GrpcFormatError> {
+    let options = SerializeOptions::new().use_proto_field_name(true);
+    msg.serialize_with_options(serde_json::value::Serializer, &options)
+        .map_err(|err| GrpcFormatError(format!("failed to format protobuf JSON: {err}")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::grpc::framing::frame;
     use flate2::Compression;
     use flate2::write::GzEncoder;
+    use prost::Message;
+    use prost_types::{
+        DescriptorProto, FieldDescriptorProto, FileDescriptorProto, FileDescriptorSet,
+        field_descriptor_proto::{Label, Type},
+    };
     use std::io::Write;
 
     #[test]
@@ -138,6 +191,90 @@ mod tests {
         assert!(output.contains("\"first\""));
         assert!(output.contains("20"));
         assert!(output.contains("\"second\""));
+    }
+
+    #[test]
+    fn descriptor_stream_outputs_proto_json() {
+        let desc = test_response_descriptor();
+        let body = frame(b"\x08\x03", false).unwrap();
+        let mut out = Printer::new(false);
+
+        format_grpc_stream_with_descriptor_to(&body, &desc, &MessageEncoding::Identity, &mut out)
+            .unwrap();
+
+        assert_eq!(out.into_string().unwrap(), "{\n  \"count\": \"3\"\n}\n");
+    }
+
+    #[test]
+    fn descriptor_stream_decodes_gzip_messages() {
+        let desc = test_response_descriptor();
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(b"\x08\x03").unwrap();
+        let body = frame(&encoder.finish().unwrap(), true).unwrap();
+        let mut out = Printer::new(false);
+
+        format_grpc_stream_with_descriptor_to(&body, &desc, &MessageEncoding::Gzip, &mut out)
+            .unwrap();
+
+        assert!(out.into_string().unwrap().contains("\"count\": \"3\""));
+    }
+
+    #[test]
+    fn descriptor_stream_preserves_empty_messages() {
+        let desc = test_response_descriptor();
+        let mut body = frame(&[], false).unwrap();
+        body.extend_from_slice(&frame(b"\x08\x03", false).unwrap());
+        let mut out = Printer::new(false);
+
+        format_grpc_stream_with_descriptor_to(&body, &desc, &MessageEncoding::Identity, &mut out)
+            .unwrap();
+
+        assert_eq!(out.into_string().unwrap(), "{}\n{\n  \"count\": \"3\"\n}\n");
+    }
+
+    #[test]
+    fn descriptor_frame_uses_json_color_policy() {
+        let desc = test_response_descriptor();
+        let body = frame(b"\x08\x03", false).unwrap();
+        let frames = framing::read_frames(&body).unwrap();
+        let mut out = Printer::new(true);
+
+        format_grpc_frame_with_descriptor_to(
+            &frames[0],
+            &desc,
+            &MessageEncoding::Identity,
+            &mut out,
+        )
+        .unwrap();
+
+        let out = out.into_string().unwrap();
+        assert!(out.contains("\x1b[34m\x1b[1mcount\x1b[0m"));
+        assert!(out.contains("\x1b[32m3\x1b[0m"));
+    }
+
+    fn test_response_descriptor() -> MessageDescriptor {
+        let fds = FileDescriptorSet {
+            file: vec![FileDescriptorProto {
+                name: Some("stream.proto".to_string()),
+                package: Some("streampkg".to_string()),
+                syntax: Some("proto3".to_string()),
+                message_type: vec![DescriptorProto {
+                    name: Some("StreamResponse".to_string()),
+                    field: vec![FieldDescriptorProto {
+                        name: Some("count".to_string()),
+                        number: Some(1),
+                        label: Some(Label::Optional as i32),
+                        r#type: Some(Type::Int64 as i32),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+        let pool = prost_reflect::DescriptorPool::decode(fds.encode_to_vec().as_slice()).unwrap();
+        pool.get_message_by_name("streampkg.StreamResponse")
+            .unwrap()
     }
 
     fn append_varint(mut bytes: Vec<u8>, field_number: u64, value: u64) -> Vec<u8> {

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -27,9 +27,13 @@ pub(crate) fn format_ndjson(bytes: &[u8], color: bool) -> Result<Vec<u8>, serde_
 
 pub fn format_json_to(bytes: &[u8], out: &mut Printer) -> Result<(), serde_json::Error> {
     let value: Value = serde_json::from_slice(bytes)?;
-    write_value(out, &value, 0);
-    out.push('\n');
+    format_json_value_to(&value, out);
     Ok(())
+}
+
+pub(crate) fn format_json_value_to(value: &Value, out: &mut Printer) {
+    write_value(out, value, 0);
+    out.push('\n');
 }
 
 pub fn format_json_line_to(bytes: &[u8], out: &mut Printer) -> Result<(), serde_json::Error> {

--- a/src/http/response/formatters.rs
+++ b/src/http/response/formatters.rs
@@ -238,8 +238,6 @@ struct FormattedGrpcStream {
     grpc_response_desc: Option<prost_reflect::MessageDescriptor>,
     use_color: bool,
     frame_index: usize,
-    descriptor_wrote_any: bool,
-    descriptor_output_ends_with_newline: bool,
 }
 
 impl FormattedGrpcStream {
@@ -254,27 +252,20 @@ impl FormattedGrpcStream {
             grpc_response_desc,
             use_color,
             frame_index: 0,
-            descriptor_wrote_any: false,
-            descriptor_output_ends_with_newline: true,
         }
     }
 
     fn format_frame(&mut self, frame: &crate::grpc::framing::Frame) -> Result<Vec<u8>, FetchError> {
         if let Some(desc) = self.grpc_response_desc.as_ref() {
-            let formatted = format_grpc_frame_with_descriptor_json(
+            let mut output = core::Printer::new(self.use_color);
+            grpc_format::format_grpc_frame_with_descriptor_to(
                 frame,
                 desc,
                 &self.grpc_message_encoding,
-                self.use_color,
-            )?;
-            let mut output = Vec::new();
-            if self.descriptor_wrote_any && !self.descriptor_output_ends_with_newline {
-                output.push(b'\n');
-            }
-            self.descriptor_output_ends_with_newline = formatted.ends_with(b"\n");
-            output.extend_from_slice(&formatted);
-            self.descriptor_wrote_any = true;
-            return Ok(output);
+                &mut output,
+            )
+            .map_err(|err| FetchError::Message(err.to_string()))?;
+            return Ok(output.into_bytes());
         }
 
         let formatted = grpc_format::format_grpc_frame(frame, &self.grpc_message_encoding)
@@ -287,44 +278,6 @@ impl FormattedGrpcStream {
         self.frame_index += 1;
         Ok(output)
     }
-}
-
-fn format_grpc_frame_with_descriptor_json(
-    frame: &crate::grpc::framing::Frame,
-    desc: &prost_reflect::MessageDescriptor,
-    message_encoding: &grpc_encoding::MessageEncoding,
-    use_color: bool,
-) -> Result<Vec<u8>, FetchError> {
-    let formatted = proto::format_grpc_frame_with_descriptor(frame, desc, message_encoding)
-        .map_err(|err| FetchError::Message(err.to_string()))?;
-    Ok(format_printer_bytes(use_color, |out| {
-        json::format_json_to(formatted.as_bytes(), out)
-    })
-    .unwrap_or_else(|_| formatted.into_bytes()))
-}
-
-fn format_grpc_stream_with_descriptor_json(
-    bytes: &[u8],
-    desc: &prost_reflect::MessageDescriptor,
-    message_encoding: &grpc_encoding::MessageEncoding,
-    use_color: bool,
-) -> Result<Vec<u8>, FetchError> {
-    let frames = crate::grpc::framing::read_frames(bytes)
-        .map_err(|err| FetchError::Message(format!("failed to read gRPC stream: {err}")))?;
-    let mut out = Vec::new();
-    let mut wrote_any = false;
-    let mut output_ends_with_newline = true;
-    for frame in &frames {
-        let formatted =
-            format_grpc_frame_with_descriptor_json(frame, desc, message_encoding, use_color)?;
-        if wrote_any && !output_ends_with_newline {
-            out.push(b'\n');
-        }
-        output_ends_with_newline = formatted.ends_with(b"\n");
-        out.extend_from_slice(&formatted);
-        wrote_any = true;
-    }
-    Ok(out)
 }
 
 impl StdoutStreamFormatter for FormattedGrpcStream {
@@ -532,12 +485,15 @@ pub(super) fn format_stdout_bytes_with_terminal(
         ContentType::Grpc => {
             let grpc_message_encoding = grpc_encoding::MessageEncoding::from_headers(headers);
             if let Some(desc) = grpc_response_desc {
-                format_grpc_stream_with_descriptor_json(
+                let mut out = core::Printer::new(use_color);
+                grpc_format::format_grpc_stream_with_descriptor_to(
                     &bytes,
                     &desc,
                     &grpc_message_encoding,
-                    use_color,
+                    &mut out,
                 )
+                .map(|()| out.into_bytes())
+                .map_err(|err| FetchError::Message(err.to_string()))
             } else {
                 grpc_format::format_grpc_stream(&bytes, &grpc_message_encoding)
                     .map(|formatted| formatted.into_bytes())

--- a/src/proto/convert.rs
+++ b/src/proto/convert.rs
@@ -3,7 +3,6 @@ use prost_reflect::{DynamicMessage, MessageDescriptor, MethodDescriptor, Seriali
 use serde::de::IntoDeserializer;
 
 use crate::error::FetchError;
-use crate::grpc::encoding::{self, MessageEncoding};
 use crate::grpc::framing;
 use crate::proto::ProtoError;
 
@@ -41,40 +40,6 @@ pub(crate) fn grpc_request_body(
         framing::frame(&raw, false).map_err(|err| FetchError::Message(err.to_string()))?,
         Some(grpc_content_type()),
     )))
-}
-
-pub fn format_grpc_stream_with_descriptor(
-    bytes: &[u8],
-    desc: &MessageDescriptor,
-    message_encoding: &MessageEncoding,
-) -> Result<String, ProtoError> {
-    let frames = framing::read_frames(bytes)
-        .map_err(|err| ProtoError::Message(format!("failed to read gRPC stream: {err}")))?;
-    let mut out = String::new();
-    let mut wrote_any = false;
-    for frame in &frames {
-        let formatted = format_grpc_frame_with_descriptor(frame, desc, message_encoding)?;
-        if wrote_any && !out.ends_with('\n') {
-            out.push('\n');
-        }
-        out.push_str(&formatted);
-        wrote_any = true;
-    }
-    Ok(out)
-}
-
-pub fn format_grpc_frame_with_descriptor(
-    frame: &framing::Frame,
-    desc: &MessageDescriptor,
-    message_encoding: &MessageEncoding,
-) -> Result<String, ProtoError> {
-    let data = encoding::decompress_frame(frame, message_encoding)
-        .map_err(|err| ProtoError::Message(err.to_string()))?;
-    let msg = decode_dynamic_message(data.as_slice(), desc)?;
-    let mut formatted = String::from_utf8(serialize_dynamic_message_json(&msg, true)?)
-        .map_err(|err| ProtoError::Message(format!("failed to format protobuf JSON: {err}")))?;
-    formatted.push('\n');
-    Ok(formatted)
 }
 
 pub fn json_to_protobuf(json: &[u8], desc: &MessageDescriptor) -> Result<Vec<u8>, ProtoError> {

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -5,10 +5,7 @@ mod json_stream;
 mod schema;
 
 pub(crate) use convert::grpc_request_body;
-pub use convert::{
-    format_grpc_frame_with_descriptor, format_grpc_stream_with_descriptor, json_to_protobuf,
-    protobuf_to_json, protobuf_to_json_compact,
-};
+pub use convert::{json_to_protobuf, protobuf_to_json, protobuf_to_json_compact};
 pub use discovery::{describe_symbol, execute_local_discovery};
 #[cfg(test)]
 pub(crate) use json_stream::json_reader_to_grpc_frame_stream_with_limit;
@@ -34,10 +31,7 @@ pub enum ProtoError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::grpc::encoding::MessageEncoding;
     use crate::grpc::framing;
-    use flate2::Compression;
-    use flate2::write::GzEncoder;
     use futures_util::TryStreamExt;
     use prost::Message;
     use prost_reflect::MessageDescriptor;
@@ -47,7 +41,6 @@ mod tests {
         OneofDescriptorProto, ServiceDescriptorProto,
         field_descriptor_proto::{Label, Type},
     };
-    use std::io::Write;
     use std::path::Path;
 
     fn stream_descriptor_set() -> Vec<u8> {
@@ -535,54 +528,6 @@ mod tests {
             json_to_protobuf(br#"{"value":"one","unknown":true}"#, &method.input()).unwrap();
 
         assert_eq!(encoded, b"\x0a\x03one");
-    }
-
-    #[test]
-    fn format_grpc_stream_with_descriptor_outputs_proto_json() {
-        let schema = Schema::from_descriptor_set(&stream_descriptor_set()).unwrap();
-        let method = schema
-            .find_method("streampkg.StreamService/ClientStream")
-            .unwrap();
-        let body = framing::frame(b"\x08\x03", false).unwrap();
-
-        let out =
-            format_grpc_stream_with_descriptor(&body, &method.output(), &MessageEncoding::Identity)
-                .unwrap();
-
-        assert!(out.contains("\"count\": \"3\""));
-    }
-
-    #[test]
-    fn format_grpc_stream_with_descriptor_decodes_gzip_messages() {
-        let schema = Schema::from_descriptor_set(&stream_descriptor_set()).unwrap();
-        let method = schema
-            .find_method("streampkg.StreamService/ClientStream")
-            .unwrap();
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(b"\x08\x03").unwrap();
-        let body = framing::frame(&encoder.finish().unwrap(), true).unwrap();
-
-        let out =
-            format_grpc_stream_with_descriptor(&body, &method.output(), &MessageEncoding::Gzip)
-                .unwrap();
-
-        assert!(out.contains("\"count\": \"3\""));
-    }
-
-    #[test]
-    fn format_grpc_stream_with_descriptor_preserves_empty_messages() {
-        let schema = Schema::from_descriptor_set(&stream_descriptor_set()).unwrap();
-        let method = schema
-            .find_method("streampkg.StreamService/ClientStream")
-            .unwrap();
-        let mut body = framing::frame(&[], false).unwrap();
-        body.extend_from_slice(&framing::frame(b"\x08\x03", false).unwrap());
-
-        let out =
-            format_grpc_stream_with_descriptor(&body, &method.output(), &MessageEncoding::Identity)
-                .unwrap();
-
-        assert_eq!(out, "{}\n{\n  \"count\": \"3\"\n}\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Move descriptor-based gRPC frame and stream formatting onto `Printer`-backed helpers
- Reuse shared JSON value formatting for protobuf JSON output
- Simplify stdout gRPC formatting by removing ad hoc newline handling

## Testing
- Not run (not requested)
- Added unit coverage for descriptor stream decoding, gzip handling, empty messages, and color-aware JSON output