### PR TITLE
Document proxy environment precedence and lowercase variables

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -107,12 +107,22 @@ fetch --proxy http://user:password@proxy.example.com:8080 example.com
 ```sh
 export HTTP_PROXY="http://proxy.example.com:8080"
 export HTTPS_PROXY="http://proxy.example.com:8080"
+export ALL_PROXY="socks5://proxy.example.com:1080"
 export NO_PROXY="localhost,127.0.0.1,192.168.0.0/16,.internal.com"
 
 fetch example.com  # Uses proxy from environment
 ```
 
-`NO_PROXY` entries may be hosts, domains, IP addresses, CIDR ranges, or `*`.
+Proxy variables also support lowercase forms: `http_proxy`, `https_proxy`,
+`all_proxy`, and `no_proxy`. Uppercase names are checked before lowercase names
+for each variable, except uppercase `HTTP_PROXY` is ignored when
+`REQUEST_METHOD` is set.
+
+Proxy precedence is: an explicit `--proxy` or configured `proxy = ...` value,
+then scheme-specific environment variables (`HTTP_PROXY` for HTTP requests and
+`HTTPS_PROXY` for HTTPS requests), then `ALL_PROXY`, then the system proxy
+configuration. `NO_PROXY`/`no_proxy` entries may be hosts, domains, IP
+addresses, CIDR ranges, ports, or `*`.
 
 ### Configuration File
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -786,9 +786,21 @@ fetch --update --dry-run
 | `LESS`                  | Options for `less`; disables fetch's default `less` flags |
 | `NO_PAGER`              | Disable the default `auto` pager when set                 |
 | `VISUAL` / `EDITOR`     | Editor for `--edit` option                                |
-| `HTTPS_PROXY`           | HTTPS proxy URL                                           |
 | `HTTP_PROXY`            | HTTP proxy URL                                            |
+| `HTTPS_PROXY`           | HTTPS proxy URL                                           |
+| `ALL_PROXY`             | Fallback proxy URL for any request scheme                 |
 | `NO_PROXY`              | Hosts, domains, IPs, or CIDR ranges to bypass proxy       |
+
+Proxy variables also support lowercase forms: `http_proxy`, `https_proxy`,
+`all_proxy`, and `no_proxy`. Uppercase names are checked before lowercase names
+for each variable, except uppercase `HTTP_PROXY` is ignored when
+`REQUEST_METHOD` is set.
+
+Proxy precedence is: an explicit `--proxy` or configured `proxy = ...` value,
+then scheme-specific environment variables (`HTTP_PROXY` for HTTP requests and
+`HTTPS_PROXY` for HTTPS requests), then `ALL_PROXY`, then the system proxy
+configuration. `NO_PROXY`/`no_proxy` applies to environment proxies and may use
+hosts, domains, IP addresses, CIDR ranges, ports, or `*`.
 
 ## File References
 


### PR DESCRIPTION
## Summary
- Document lowercase proxy environment variables alongside uppercase forms
- Clarify that `HTTP_PROXY` is ignored when `REQUEST_METHOD` is set
- Describe proxy precedence across explicit config, env vars, and system settings
- Expand `NO_PROXY` handling to include ports

## Testing
- Not run (not requested)