### PR TITLE
centralize color_for_status in core.rs

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -259,6 +259,14 @@ impl Sequence {
     }
 }
 
+pub fn color_for_status(code: u16) -> Sequence {
+    match code {
+        200..=299 => Sequence::Green,
+        300..=399 => Sequence::Yellow,
+        _ => Sequence::Red,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Printer {
     buf: Vec<u8>,

--- a/src/http/metadata.rs
+++ b/src/http/metadata.rs
@@ -239,14 +239,6 @@ pub(super) fn flush_stderr(mut printer: core::Printer) {
     let _ = printer.flush_to(&mut stderr);
 }
 
-pub(super) fn color_for_status(code: u16) -> core::Sequence {
-    match code {
-        200..=299 => core::Sequence::Green,
-        300..=399 => core::Sequence::Yellow,
-        _ => core::Sequence::Red,
-    }
-}
-
 pub(crate) fn request_target(url: &Url) -> String {
     let mut target = if url.path().is_empty() {
         "/".to_string()

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -68,6 +68,7 @@ mod response;
 mod retry;
 pub(crate) mod transport;
 
+pub(crate) use core::color_for_status;
 pub(crate) use metadata::{
     apply_headers, apply_query, has_authority_scheme, load_session, normalize_url, request_target,
     save_session, validate_ech_for_url,

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -655,7 +655,7 @@ fn print_response_metadata(
     }
     printer.write_styled(ws_version_label(response.version()), &[core::Sequence::Dim]);
     printer.push_str(" ");
-    let status_color = color_for_status(status.as_u16());
+    let status_color = core::color_for_status(status.as_u16());
     printer.write_styled(
         &status.as_u16().to_string(),
         &[status_color, core::Sequence::Bold],
@@ -715,14 +715,6 @@ fn ws_version_label(version: WsVersion) -> &'static str {
         WsVersion::HTTP_2 => "HTTP/2.0",
         WsVersion::HTTP_3 => "HTTP/3.0",
         _ => "HTTP/?",
-    }
-}
-
-fn color_for_status(code: u16) -> core::Sequence {
-    match code {
-        200..=299 => core::Sequence::Green,
-        300..=399 => core::Sequence::Yellow,
-        _ => core::Sequence::Red,
     }
 }
 


### PR DESCRIPTION
Removes two duplicate definitions of `color_for_status` from `src/http/metadata.rs` and `src/websocket/mod.rs`, replacing them with a single `pub fn` in `src/core.rs`. Adds a `pub(crate)` re-export in `src/http/mod.rs` so that existing call sites in `src/http/response/metadata.rs` and `src/http/retry.rs` continue to work via `use super::*`.