### PR TITLE
dedupe: remove three private copies of flush_stderr

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -340,7 +340,7 @@ pub fn write_cli_error_with_color(err: impl std::fmt::Display, color: Option<&st
     printer.push_str("\nFor more information, try '");
     printer.write_styled("--help", &[Sequence::Bold]);
     printer.push_str("'.\n");
-    flush_stderr(printer);
+    core::flush_stderr(printer);
 }
 
 pub fn write_runtime_error(err: FetchError) {
@@ -358,7 +358,7 @@ pub fn write_runtime_error_with_color(err: FetchError, color: Option<&str>) {
             printer.push_str("\nIf you absolutely trust the server, try '");
             printer.write_styled("--insecure", &[Sequence::Bold]);
             printer.push_str("'.\n");
-            flush_stderr(printer);
+            core::flush_stderr(printer);
         }
         _ => write_cli_error_with_color(err, color),
     }
@@ -368,20 +368,20 @@ pub fn write_error_with_color(err: impl std::fmt::Display, color: Option<&str>) 
     let err = FetchError::from_message(err.to_string());
     let mut printer = Printer::stderr(color);
     write_fetch_error_msg_no_flush(&mut printer, &err);
-    flush_stderr(printer);
+    core::flush_stderr(printer);
 }
 
 pub fn write_warning_with_color(msg: impl std::fmt::Display, color: Option<&str>) {
     let mut printer = Printer::stderr(color);
     core::write_warning_msg_no_flush(&mut printer, msg);
-    flush_stderr(printer);
+    core::flush_stderr(printer);
 }
 
 pub fn write_warning_with_separator_with_color(msg: impl std::fmt::Display, color: Option<&str>) {
     let mut printer = Printer::stderr(color);
     core::write_warning_msg_no_flush(&mut printer, msg);
     core::write_warning_separator_no_flush(&mut printer);
-    flush_stderr(printer);
+    core::flush_stderr(printer);
 }
 
 pub fn write_warnings_with_separator_with_color<I, M>(warnings: I, color: Option<&str>)
@@ -397,13 +397,8 @@ where
     }
     if wrote_warning {
         core::write_warning_separator_no_flush(&mut printer);
-        flush_stderr(printer);
+        core::flush_stderr(printer);
     }
-}
-
-fn flush_stderr(mut printer: Printer) {
-    let mut stderr = std::io::stderr();
-    let _ = printer.flush_to(&mut stderr);
 }
 
 fn write_fetch_error_msg_no_flush(printer: &mut Printer, err: &FetchError) {

--- a/src/http/metadata.rs
+++ b/src/http/metadata.rs
@@ -161,7 +161,7 @@ pub(super) fn print_request_metadata(
         printer.write_request_prefix();
         printer.push_str("\n");
     }
-    flush_stderr(printer);
+    core::flush_stderr(printer);
     Ok(())
 }
 
@@ -232,11 +232,6 @@ pub(crate) fn validate_ech_for_url(cli: &Cli, url: &Url) -> Result<(), FetchErro
         return Err("--ech requires an https:// URL".into());
     }
     Ok(())
-}
-
-pub(super) fn flush_stderr(mut printer: core::Printer) {
-    let mut stderr = std::io::stderr();
-    let _ = printer.flush_to(&mut stderr);
 }
 
 pub(crate) fn request_target(url: &Url) -> String {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -58,7 +58,7 @@ pub(super) fn print_dry_run_body(cli: &Cli, body: &RequestBody) -> Result<(), Fe
     if cli.verbose < 2 {
         let mut printer = core::Printer::stderr(cli.color.as_deref());
         core::write_status_line_no_flush(&mut printer, "");
-        flush_stderr(printer);
+        core::flush_stderr(printer);
     }
     let preview = dry_run_body_preview(body, DRY_RUN_BODY_PREVIEW_BYTES)?;
     if !is_printable(&preview.bytes) {
@@ -83,7 +83,7 @@ pub(super) fn print_dry_run_body(cli: &Cli, body: &RequestBody) -> Result<(), Fe
 fn print_dry_run_binary_warning(cli: &Cli) {
     let mut printer = core::Printer::stderr(cli.color.as_deref());
     core::write_warning_msg_no_flush(&mut printer, "the request body appears to be binary");
-    flush_stderr(printer);
+    core::flush_stderr(printer);
 }
 
 fn print_dry_run_truncation_warning(cli: &Cli, limit: usize) {
@@ -92,7 +92,7 @@ fn print_dry_run_truncation_warning(cli: &Cli, limit: usize) {
         &mut printer,
         format!("the request body preview was truncated after {limit} bytes"),
     );
-    flush_stderr(printer);
+    core::flush_stderr(printer);
 }
 
 pub(super) fn build_request(

--- a/src/http/response/metadata.rs
+++ b/src/http/response/metadata.rs
@@ -132,7 +132,7 @@ pub(super) fn print_response_metadata(cli: &Cli, response: &Response) {
         printer.write_response_prefix();
     }
     printer.push_str("\n");
-    flush_stderr(printer);
+    core::flush_stderr(printer);
 }
 
 pub(super) fn exit_code(status: u16, ignore_status: bool) -> i32 {

--- a/src/http/retry.rs
+++ b/src/http/retry.rs
@@ -261,7 +261,7 @@ pub(super) fn print_redirect_status(cli: &Cli, response: &Response) {
         printer.write_styled(reason, &[status_color]);
     }
     printer.push_str("\n");
-    flush_stderr(printer);
+    core::flush_stderr(printer);
 }
 
 pub(super) fn timeout_error_message(cli: &Cli, err: &transport::Error) -> Option<String> {

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -637,7 +637,7 @@ fn print_request_metadata(cli: &Cli, method: &str, url: &Url, headers: Option<&W
         printer.write_request_prefix();
         printer.push_str("\n");
     }
-    flush_stderr(printer);
+    core::flush_stderr(printer);
 }
 
 fn print_response_metadata(
@@ -684,7 +684,7 @@ fn print_response_metadata(
         printer.write_response_prefix();
     }
     printer.push_str("\n");
-    flush_stderr(printer);
+    core::flush_stderr(printer);
 }
 
 fn header_lines(headers: &WsHeaderMap) -> Vec<(String, String)> {
@@ -716,11 +716,6 @@ fn ws_version_label(version: WsVersion) -> &'static str {
         WsVersion::HTTP_3 => "HTTP/3.0",
         _ => "HTTP/?",
     }
-}
-
-fn flush_stderr(mut printer: core::Printer) {
-    let mut stderr = std::io::stderr();
-    let _ = printer.flush_to(&mut stderr);
 }
 
 async fn read_messages<S>(cli: &Cli, stream: &mut S) -> Result<(), FetchError>


### PR DESCRIPTION
Delete the local `flush_stderr` definitions in `websocket/mod.rs`, `error.rs`, and `http/metadata.rs`. Update all call sites to use the canonical `core::flush_stderr` instead.

Removes 12 lines of dead duplication.