### PR TITLE
dedupe: replace 5 duplicated flag-check functions with unified registry

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -641,89 +641,15 @@ fn streaming_curl_data_value(values: &[from_curl::DataValue]) -> Option<&str> {
     value.value.starts_with('@').then_some(value.value.as_str())
 }
 
-enum ConflictRule<T> {
-    Flag {
-        flag: &'static str,
-        is_present: fn(&T) -> bool,
-    },
-    DynamicFlag {
-        flag_name: fn(&T) -> Option<&'static str>,
-    },
-}
-
-impl<T> ConflictRule<T> {
-    const fn flag(flag: &'static str, is_present: fn(&T) -> bool) -> Self {
-        Self::Flag { flag, is_present }
-    }
-
-    const fn dynamic_flag(flag_name: fn(&T) -> Option<&'static str>) -> Self {
-        Self::DynamicFlag { flag_name }
-    }
-}
-
-fn first_conflict<T>(target: &T, conflicts: &[ConflictRule<T>]) -> Option<&'static str> {
-    conflicts.iter().find_map(|conflict| match conflict {
-        ConflictRule::Flag { flag, is_present } => is_present(target).then_some(*flag),
-        ConflictRule::DynamicFlag { flag_name } => flag_name(target),
-    })
-}
-
 fn validate_from_curl_exclusives(cli: &Cli) -> Result<(), FetchError> {
     if cli.url.is_some() {
         return Err("'--from-curl' and a URL argument cannot be used together".into());
     }
 
-    let conflicting_flag = first_conflict(
-        cli,
-        &[
-            ConflictRule::flag("method", |cli: &Cli| cli.method.is_some()),
-            ConflictRule::flag("header", |cli: &Cli| !cli.headers.is_empty()),
-            ConflictRule::flag("data", |cli: &Cli| cli.data.is_some()),
-            ConflictRule::flag("json", |cli: &Cli| cli.json.is_some()),
-            ConflictRule::flag("xml", |cli: &Cli| cli.xml.is_some()),
-            ConflictRule::flag("form", |cli: &Cli| !cli.form.is_empty()),
-            ConflictRule::flag("multipart", |cli: &Cli| !cli.multipart.is_empty()),
-            ConflictRule::flag("basic", |cli: &Cli| cli.basic.is_some()),
-            ConflictRule::flag("bearer", |cli: &Cli| cli.bearer.is_some()),
-            ConflictRule::flag("digest", |cli: &Cli| cli.digest.is_some()),
-            ConflictRule::flag("aws-sigv4", |cli: &Cli| cli.aws_sigv4.is_some()),
-            ConflictRule::flag("output", |cli: &Cli| cli.output.is_some()),
-            ConflictRule::flag("remote-name", |cli: &Cli| cli.remote_name),
-            ConflictRule::flag("remote-header-name", |cli: &Cli| cli.remote_header_name),
-            ConflictRule::flag("range", |cli: &Cli| !cli.ranges.is_empty()),
-            ConflictRule::flag("unix", |cli: &Cli| cli.unix.is_some()),
-            ConflictRule::flag("timeout", |cli: &Cli| cli.timeout.is_some()),
-            ConflictRule::flag("connect-timeout", |cli: &Cli| cli.connect_timeout.is_some()),
-            ConflictRule::flag("redirects", |cli: &Cli| cli.redirects.is_some()),
-            ConflictRule::flag("proxy", |cli: &Cli| cli.proxy.is_some()),
-            ConflictRule::flag("insecure", |cli: &Cli| cli.insecure),
-            ConflictRule::flag("max-tls", |cli: &Cli| cli.max_tls.is_some()),
-            ConflictRule::flag("min-tls", |cli: &Cli| cli.min_tls.is_some()),
-            ConflictRule::flag("tls", |cli: &Cli| cli.tls.is_some()),
-            ConflictRule::dynamic_flag(crate::cli::http_version_flag_name),
-            ConflictRule::flag("cert", |cli: &Cli| cli.cert.is_some()),
-            ConflictRule::flag("key", |cli: &Cli| cli.key.is_some()),
-            ConflictRule::flag("ca-cert", |cli: &Cli| !cli.ca_cert.is_empty()),
-            ConflictRule::flag("dns-server", |cli: &Cli| cli.dns_server.is_some()),
-            ConflictRule::flag("retry", |cli: &Cli| cli.retry.is_some()),
-            ConflictRule::flag("retry-delay", |cli: &Cli| cli.retry_delay.is_some()),
-            ConflictRule::flag("grpc", |cli: &Cli| cli.grpc),
-            ConflictRule::flag("grpc-describe", |cli: &Cli| cli.grpc_describe.is_some()),
-            ConflictRule::flag("grpc-list", |cli: &Cli| cli.grpc_list),
-            ConflictRule::flag("query", |cli: &Cli| !cli.query.is_empty()),
-            ConflictRule::flag("ech", |cli: &Cli| cli.ech.is_some()),
-        ],
-    );
-
-    if let Some(flag) = conflicting_flag {
+    if let Some(flag) = crate::flag_registry::first_from_curl_conflicting_flag(cli) {
         return Err(format!("'--from-curl' and '--{flag}' cannot be used together").into());
     }
     Ok(())
-}
-
-struct WebSocketConflictContext<'a> {
-    cli: &'a Cli,
-    plain_ws: bool,
 }
 
 fn validate_websocket_exclusives(cli: &Cli) -> Result<(), FetchError> {
@@ -747,84 +673,18 @@ fn validate_websocket_exclusives(cli: &Cli) -> Result<(), FetchError> {
     {
         return Err(format!("WebSocket requires GET; method {method} is not supported").into());
     }
-    let context = WebSocketConflictContext {
-        cli,
-        plain_ws: scheme == "ws",
-    };
-    let conflicting_flag = first_conflict(
-        &context,
-        &[
-            ConflictRule::flag("clobber", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.cli.clobber
-            }),
-            ConflictRule::flag("copy", |ctx: &WebSocketConflictContext<'_>| ctx.cli.copy),
-            ConflictRule::flag("discard", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.cli.discard
-            }),
-            ConflictRule::flag("digest", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.cli.digest.is_some()
-            }),
-            ConflictRule::flag("edit", |ctx: &WebSocketConflictContext<'_>| ctx.cli.edit),
-            ConflictRule::flag("form", |ctx: &WebSocketConflictContext<'_>| {
-                !ctx.cli.form.is_empty()
-            }),
-            ConflictRule::flag("grpc", |ctx: &WebSocketConflictContext<'_>| ctx.cli.grpc),
-            ConflictRule::flag("grpc-describe", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.cli.grpc_describe.is_some()
-            }),
-            ConflictRule::flag("grpc-list", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.cli.grpc_list
-            }),
-            ConflictRule::flag("multipart", |ctx: &WebSocketConflictContext<'_>| {
-                !ctx.cli.multipart.is_empty()
-            }),
-            ConflictRule::flag("output", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.cli.output.is_some()
-            }),
-            ConflictRule::flag(
-                "remote-header-name",
-                |ctx: &WebSocketConflictContext<'_>| ctx.cli.remote_header_name,
-            ),
-            ConflictRule::flag("remote-name", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.cli.remote_name
-            }),
-            ConflictRule::flag("retry", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.cli.retry() > 0
-            }),
-            ConflictRule::flag("retry-delay", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.cli.retry_delay.is_some()
-            }),
-            ConflictRule::flag("xml", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.cli.xml.is_some()
-            }),
-            ConflictRule::flag("insecure", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.plain_ws && ctx.cli.insecure
-            }),
-            ConflictRule::flag("max-tls", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.plain_ws && ctx.cli.max_tls.is_some()
-            }),
-            ConflictRule::flag("min-tls", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.plain_ws && ctx.cli.min_tls.is_some()
-            }),
-            ConflictRule::flag("tls", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.plain_ws && ctx.cli.tls.is_some()
-            }),
-            ConflictRule::flag("cert", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.plain_ws && ctx.cli.cert.is_some()
-            }),
-            ConflictRule::flag("key", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.plain_ws && ctx.cli.key.is_some()
-            }),
-            ConflictRule::flag("ca-cert", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.plain_ws && !ctx.cli.ca_cert.is_empty()
-            }),
-            ConflictRule::flag("ech", |ctx: &WebSocketConflictContext<'_>| {
-                ctx.plain_ws && ctx.cli.ech.is_some()
-            }),
-        ],
-    );
 
-    if let Some(flag) = conflicting_flag {
+    // Flags that always conflict with websocket.
+    if let Some(flag) = crate::flag_registry::first_websocket_always_conflicting_flag(cli) {
+        return Err(
+            format!("'{scheme}://' scheme and '--{flag}' flag cannot be used together").into(),
+        );
+    }
+
+    // TLS flags only conflict with plain ws:// (not wss://).
+    if scheme == "ws"
+        && let Some(flag) = crate::flag_registry::first_websocket_plain_conflicting_flag(cli)
+    {
         return Err(
             format!("'{scheme}://' scheme and '--{flag}' flag cannot be used together").into(),
         );

--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -730,36 +730,12 @@ fn truncated_warning(types: &[&'static str]) -> String {
 pub(crate) fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     let mut ignored = Vec::new();
     crate::inspection::append_shared_ignored_request_flags(cli, &mut ignored);
-    if let Some(flag) = crate::cli::http_version_flag_name(cli) {
-        ignored.push(match flag {
-            "http1" => "--http1",
-            "http2" => "--http2",
-            "http3" => "--http3",
-            _ => "--http",
-        });
-    }
+    crate::inspection::append_shared_ignored_http_version_flags(cli, &mut ignored);
     if cli.inspect_tls {
         ignored.push("--inspect-tls");
     }
     crate::inspection::append_shared_ignored_auth_flags(cli, &mut ignored);
-    if !cli.ca_cert.is_empty() {
-        ignored.push("--ca-cert");
-    }
-    if cli.cert.is_some() {
-        ignored.push("--cert");
-    }
-    if cli.key.is_some() {
-        ignored.push("--key");
-    }
-    if cli.tls.is_some() || cli.min_tls.is_some() {
-        ignored.push("--tls");
-    }
-    if cli.max_tls.is_some() {
-        ignored.push("--max-tls");
-    }
-    if cli.insecure {
-        ignored.push("--insecure");
-    }
+    crate::inspection::append_shared_ignored_tls_flags(cli, &mut ignored);
     crate::inspection::append_shared_ignored_response_flags(cli, &mut ignored);
     ignored
 }
@@ -1277,7 +1253,7 @@ mod tests {
         assert_eq!(
             ignored_inspection_flags(&cli),
             [
-                "--data/--json/--xml",
+                "--data",
                 "--grpc",
                 "--proto-file",
                 "--proto-import",
@@ -1291,7 +1267,7 @@ mod tests {
                 "--http",
                 "--bearer",
                 "--insecure",
-                "--compress/--no-encode",
+                "--compress",
                 "--format",
                 "--image",
                 "--pager",
@@ -1301,6 +1277,25 @@ mod tests {
                 "--ws-message-mode",
                 "--dry-run",
             ]
+        );
+    }
+
+    #[test]
+    fn inspect_dns_dns_server_is_not_reported_as_ignored() {
+        let cli = Cli::try_parse_from([
+            "fetch",
+            "https://example.com",
+            "--inspect-dns",
+            "--dns-server",
+            "1.1.1.1",
+        ])
+        .unwrap();
+
+        let ignored = ignored_inspection_flags(&cli);
+
+        assert!(
+            !ignored.contains(&"--dns-server"),
+            "--dns-server must not be in ignored flags for --inspect-dns: {ignored:?}"
         );
     }
 

--- a/src/flag_registry.rs
+++ b/src/flag_registry.rs
@@ -1,0 +1,316 @@
+//! Unified declarative registry of all CLI flags.
+//!
+//! Every flag is defined once with its name, category, and a predicate that
+//! returns `true` when the flag is set on the [`Cli`].  The shared inspection
+//! ignored-flag functions and the `--from-curl` / websocket conflict
+//! validators all filter this single registry instead of duplicating checks.
+//!
+//! Flag names include the `"--"` prefix so inspection warnings can join them
+//! directly.  Conflict validators strip the two-character prefix for their
+//! error messages (e.g. `"--method"` → `method`).
+
+use crate::cli::Cli;
+
+/// Category for grouping flags in inspection ignored-flag warnings.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FlagCategory {
+    Request,
+    Auth,
+    Response,
+    Tls,
+    HttpVersion,
+}
+
+/// One entry in the unified flag registry.
+pub(crate) struct FlagDef {
+    /// Flag name including the `"--"` prefix (e.g. `"--method"`).
+    pub name: &'static str,
+    /// Category for inspection ignored-flag grouping, or `None` for flags
+    /// that don't belong to any standard group.
+    pub category: Option<FlagCategory>,
+    /// Predicate: returns `true` when this flag is explicitly set on `Cli`.
+    pub is_set: fn(&Cli) -> bool,
+    /// Optional WebSocket-specific predicate, used instead of [`is_set`] for
+    /// websocket conflict checks.  When `None`, falls back to `is_set`.
+    pub is_ws_conflict: Option<fn(&Cli) -> bool>,
+    /// Whether this flag conflicts with `--from-curl`.
+    pub conflicts_from_curl: bool,
+    /// Whether this flag unconditionally conflicts with WebSocket.
+    pub conflicts_websocket_always: bool,
+    /// Whether this flag conflicts with `ws://` (plain WebSocket, no TLS).
+    pub conflicts_websocket_plain: bool,
+}
+
+impl FlagDef {
+    pub const fn new(
+        name: &'static str,
+        category: Option<FlagCategory>,
+        is_set: fn(&Cli) -> bool,
+    ) -> Self {
+        Self {
+            name,
+            category,
+            is_set,
+            is_ws_conflict: None,
+            conflicts_from_curl: false,
+            conflicts_websocket_always: false,
+            conflicts_websocket_plain: false,
+        }
+    }
+
+    pub const fn with_from_curl(mut self) -> Self {
+        self.conflicts_from_curl = true;
+        self
+    }
+
+    pub const fn with_ws_always(mut self) -> Self {
+        self.conflicts_websocket_always = true;
+        self
+    }
+
+    pub const fn with_ws_conflict(mut self, predicate: fn(&Cli) -> bool) -> Self {
+        self.is_ws_conflict = Some(predicate);
+        self
+    }
+
+    pub const fn with_ws_plain(mut self) -> Self {
+        self.conflicts_websocket_plain = true;
+        self
+    }
+
+    /// Return the effective websocket-conflict predicate.
+    fn ws_is_conflict(&self, cli: &Cli) -> bool {
+        match self.is_ws_conflict {
+            Some(p) => p(cli),
+            None => (self.is_set)(cli),
+        }
+    }
+
+    /// Return the flag name without the `"--"` prefix, for conflict error messages.
+    pub fn conflict_name(&self) -> &str {
+        &self.name[2..]
+    }
+}
+
+// ── the single source of truth ──────────────────────────────────────────
+
+pub(crate) static FLAGS: &[FlagDef] = &[
+    // ── Request ─────────────────────────────────────────────────────────
+    FlagDef::new("--data", Some(FlagCategory::Request), |c| c.data.is_some()).with_from_curl(),
+    FlagDef::new("--json", Some(FlagCategory::Request), |c| c.json.is_some()).with_from_curl(),
+    FlagDef::new("--xml", Some(FlagCategory::Request), |c| c.xml.is_some())
+        .with_from_curl()
+        .with_ws_always(),
+    FlagDef::new("--form", Some(FlagCategory::Request), |c| {
+        !c.form.is_empty()
+    })
+    .with_from_curl()
+    .with_ws_always(),
+    FlagDef::new("--multipart", Some(FlagCategory::Request), |c| {
+        !c.multipart.is_empty()
+    })
+    .with_from_curl()
+    .with_ws_always(),
+    FlagDef::new("--grpc", Some(FlagCategory::Request), |c| c.grpc)
+        .with_from_curl()
+        .with_ws_always(),
+    FlagDef::new("--grpc-describe", Some(FlagCategory::Request), |c| {
+        c.grpc_describe.is_some()
+    })
+    .with_from_curl()
+    .with_ws_always(),
+    FlagDef::new("--grpc-list", Some(FlagCategory::Request), |c| c.grpc_list)
+        .with_from_curl()
+        .with_ws_always(),
+    FlagDef::new("--proto-desc", Some(FlagCategory::Request), |c| {
+        c.proto_desc.is_some()
+    }),
+    FlagDef::new("--proto-file", Some(FlagCategory::Request), |c| {
+        !c.proto_files.is_empty()
+    }),
+    FlagDef::new("--proto-import", Some(FlagCategory::Request), |c| {
+        !c.proto_imports.is_empty()
+    }),
+    FlagDef::new("--output", Some(FlagCategory::Request), |c| {
+        c.output.is_some()
+    })
+    .with_from_curl()
+    .with_ws_always(),
+    FlagDef::new("--remote-name", Some(FlagCategory::Request), |c| {
+        c.remote_name
+    })
+    .with_from_curl()
+    .with_ws_always(),
+    FlagDef::new("--remote-header-name", Some(FlagCategory::Request), |c| {
+        c.remote_header_name
+    })
+    .with_from_curl()
+    .with_ws_always(),
+    FlagDef::new("--copy", Some(FlagCategory::Request), |c| c.copy).with_ws_always(),
+    FlagDef::new("--clobber", Some(FlagCategory::Request), |c| c.clobber).with_ws_always(),
+    FlagDef::new("--method", Some(FlagCategory::Request), |c| {
+        c.method.is_some()
+    })
+    .with_from_curl(),
+    FlagDef::new("--header", Some(FlagCategory::Request), |c| {
+        !c.headers.is_empty()
+    })
+    .with_from_curl(),
+    FlagDef::new("--query", Some(FlagCategory::Request), |c| {
+        !c.query.is_empty()
+    })
+    .with_from_curl(),
+    FlagDef::new("--edit", Some(FlagCategory::Request), |c| c.edit).with_ws_always(),
+    FlagDef::new("--session", Some(FlagCategory::Request), |c| {
+        c.session.is_some()
+    }),
+    FlagDef::new("--retry", Some(FlagCategory::Request), |c| {
+        c.retry.is_some()
+    })
+    .with_from_curl()
+    .with_ws_always()
+    .with_ws_conflict(|c| c.retry() > 0),
+    FlagDef::new("--retry-delay", Some(FlagCategory::Request), |c| {
+        c.retry_delay.is_some()
+    })
+    .with_from_curl()
+    .with_ws_always(),
+    FlagDef::new("--redirects", Some(FlagCategory::Request), |c| {
+        c.redirects.is_some()
+    })
+    .with_from_curl(),
+    FlagDef::new("--range", Some(FlagCategory::Request), |c| {
+        !c.ranges.is_empty()
+    })
+    .with_from_curl(),
+    FlagDef::new("--timing", Some(FlagCategory::Request), |c| c.timing),
+    FlagDef::new("--proxy", Some(FlagCategory::Request), |c| {
+        c.proxy.is_some()
+    })
+    .with_from_curl(),
+    FlagDef::new("--discard", Some(FlagCategory::Request), |c| c.discard).with_ws_always(),
+    FlagDef::new("--unix", Some(FlagCategory::Request), |c| c.unix.is_some()).with_from_curl(),
+    // ── Auth ────────────────────────────────────────────────────────────
+    FlagDef::new("--basic", Some(FlagCategory::Auth), |c| c.basic.is_some()).with_from_curl(),
+    FlagDef::new("--bearer", Some(FlagCategory::Auth), |c| c.bearer.is_some()).with_from_curl(),
+    FlagDef::new("--digest", Some(FlagCategory::Auth), |c| c.digest.is_some())
+        .with_from_curl()
+        .with_ws_always(),
+    FlagDef::new("--aws-sigv4", Some(FlagCategory::Auth), |c| {
+        c.aws_sigv4.is_some()
+    })
+    .with_from_curl(),
+    // ── Response ────────────────────────────────────────────────────────
+    FlagDef::new("--compress", Some(FlagCategory::Response), |c| {
+        c.compress.is_some()
+    }),
+    FlagDef::new("--no-encode", Some(FlagCategory::Response), |c| c.no_encode),
+    FlagDef::new("--format", Some(FlagCategory::Response), |c| {
+        c.format.is_some()
+    }),
+    FlagDef::new("--image", Some(FlagCategory::Response), |c| {
+        c.image.is_some()
+    }),
+    FlagDef::new("--pager", Some(FlagCategory::Response), |c| {
+        c.pager.is_some()
+    }),
+    FlagDef::new("--ignore-status", Some(FlagCategory::Response), |c| {
+        c.ignore_status
+    }),
+    FlagDef::new("--sort-headers", Some(FlagCategory::Response), |c| {
+        c.sort_headers
+    }),
+    FlagDef::new("--ws-interactive", Some(FlagCategory::Response), |c| {
+        c.ws_interactive.is_some()
+    }),
+    FlagDef::new("--ws-message-mode", Some(FlagCategory::Response), |c| {
+        c.ws_message_mode.is_some()
+    }),
+    FlagDef::new("--dry-run", Some(FlagCategory::Response), |c| c.dry_run),
+    // ── Resolver (not in any ignored group; used by inspection) ───────
+    FlagDef::new("--dns-server", None, |c| c.dns_server.is_some()).with_from_curl(),
+    // ── TLS ────────────────────────────────────────────────────────────
+    FlagDef::new("--insecure", Some(FlagCategory::Tls), |c| c.insecure)
+        .with_from_curl()
+        .with_ws_plain(),
+    FlagDef::new("--max-tls", Some(FlagCategory::Tls), |c| {
+        c.max_tls.is_some()
+    })
+    .with_from_curl()
+    .with_ws_plain(),
+    FlagDef::new("--min-tls", Some(FlagCategory::Tls), |c| {
+        c.min_tls.is_some()
+    })
+    .with_from_curl()
+    .with_ws_plain(),
+    FlagDef::new("--tls", Some(FlagCategory::Tls), |c| c.tls.is_some())
+        .with_from_curl()
+        .with_ws_plain(),
+    FlagDef::new("--cert", Some(FlagCategory::Tls), |c| c.cert.is_some())
+        .with_from_curl()
+        .with_ws_plain(),
+    FlagDef::new("--key", Some(FlagCategory::Tls), |c| c.key.is_some())
+        .with_from_curl()
+        .with_ws_plain(),
+    FlagDef::new("--ca-cert", Some(FlagCategory::Tls), |c| {
+        !c.ca_cert.is_empty()
+    })
+    .with_from_curl()
+    .with_ws_plain(),
+    FlagDef::new("--ech", Some(FlagCategory::Tls), |c| c.ech.is_some())
+        .with_from_curl()
+        .with_ws_plain(),
+    // ── HTTP version ───────────────────────────────────────────────────
+    FlagDef::new("--http", Some(FlagCategory::HttpVersion), |c| {
+        c.http.is_some()
+    })
+    .with_from_curl(),
+    FlagDef::new("--http1", Some(FlagCategory::HttpVersion), |c| c.http1).with_from_curl(),
+    FlagDef::new("--http2", Some(FlagCategory::HttpVersion), |c| c.http2).with_from_curl(),
+    FlagDef::new("--http3", Some(FlagCategory::HttpVersion), |c| c.http3).with_from_curl(),
+    // ── Timeout ────────────────────────────────────────────────────────
+    FlagDef::new("--timeout", None, |c| c.timeout.is_some()).with_from_curl(),
+    FlagDef::new("--connect-timeout", None, |c| c.connect_timeout.is_some()).with_from_curl(),
+];
+
+// ── convenience iterators ──────────────────────────────────────────────
+
+/// Push names of all flags in `category` that are set on `cli` into `ignored`.
+pub(crate) fn append_ignored_of_category(
+    cli: &Cli,
+    category: FlagCategory,
+    ignored: &mut Vec<&'static str>,
+) {
+    for def in FLAGS {
+        if def.category == Some(category) && (def.is_set)(cli) {
+            ignored.push(def.name);
+        }
+    }
+}
+
+/// Return the conflict name (without `--`) of the first flag that is set
+/// and conflicts with `--from-curl`, or `None`.
+pub(crate) fn first_from_curl_conflicting_flag(cli: &Cli) -> Option<&'static str> {
+    FLAGS
+        .iter()
+        .find(|def| def.conflicts_from_curl && (def.is_set)(cli))
+        .map(|def| def.conflict_name())
+}
+
+/// Return the conflict name (without `--`) of the first flag that
+/// unconditionally conflicts with WebSocket, or `None`.
+pub(crate) fn first_websocket_always_conflicting_flag(cli: &Cli) -> Option<&'static str> {
+    FLAGS
+        .iter()
+        .find(|def| def.conflicts_websocket_always && def.ws_is_conflict(cli))
+        .map(|def| def.conflict_name())
+}
+
+/// Return the conflict name (without `--`) of the first TLS flag that
+/// conflicts with plain `ws://` WebSocket, or `None`.
+pub(crate) fn first_websocket_plain_conflicting_flag(cli: &Cli) -> Option<&'static str> {
+    FLAGS
+        .iter()
+        .find(|def| def.conflicts_websocket_plain && def.ws_is_conflict(cli))
+        .map(|def| def.conflict_name())
+}

--- a/src/inspection.rs
+++ b/src/inspection.rs
@@ -1,130 +1,28 @@
 use crate::cli::Cli;
+use crate::flag_registry::FlagCategory;
 
+/// Append ignored request-related flag names (with `--` prefix) to `ignored`.
 pub(crate) fn append_shared_ignored_request_flags(cli: &Cli, ignored: &mut Vec<&'static str>) {
-    if cli.data.is_some() || cli.json.is_some() || cli.xml.is_some() {
-        ignored.push("--data/--json/--xml");
-    }
-    if !cli.form.is_empty() {
-        ignored.push("--form");
-    }
-    if !cli.multipart.is_empty() {
-        ignored.push("--multipart");
-    }
-    if cli.grpc {
-        ignored.push("--grpc");
-    }
-    if cli.grpc_describe.is_some() {
-        ignored.push("--grpc-describe");
-    }
-    if cli.grpc_list {
-        ignored.push("--grpc-list");
-    }
-    if cli.proto_desc.is_some() {
-        ignored.push("--proto-desc");
-    }
-    if !cli.proto_files.is_empty() {
-        ignored.push("--proto-file");
-    }
-    if !cli.proto_imports.is_empty() {
-        ignored.push("--proto-import");
-    }
-    if cli.output.is_some() {
-        ignored.push("--output");
-    }
-    if cli.remote_name {
-        ignored.push("--remote-name");
-    }
-    if cli.remote_header_name {
-        ignored.push("--remote-header-name");
-    }
-    if cli.copy {
-        ignored.push("--copy");
-    }
-    if cli.clobber {
-        ignored.push("--clobber");
-    }
-    if cli.method.is_some() {
-        ignored.push("--method");
-    }
-    if !cli.headers.is_empty() {
-        ignored.push("--header");
-    }
-    if !cli.query.is_empty() {
-        ignored.push("--query");
-    }
-    if cli.edit {
-        ignored.push("--edit");
-    }
-    if cli.session.is_some() {
-        ignored.push("--session");
-    }
-    if cli.retry() > 0 {
-        ignored.push("--retry");
-    }
-    if cli.retry_delay.is_some() {
-        ignored.push("--retry-delay");
-    }
-    if cli.redirects.is_some() {
-        ignored.push("--redirects");
-    }
-    if !cli.ranges.is_empty() {
-        ignored.push("--range");
-    }
-    if cli.timing {
-        ignored.push("--timing");
-    }
-    if cli.proxy.is_some() {
-        ignored.push("--proxy");
-    }
-    if cli.discard {
-        ignored.push("--discard");
-    }
-    if cli.unix.is_some() {
-        ignored.push("--unix");
-    }
+    crate::flag_registry::append_ignored_of_category(cli, FlagCategory::Request, ignored);
 }
 
+/// Append ignored auth flag names (with `--` prefix) to `ignored`.
 pub(crate) fn append_shared_ignored_auth_flags(cli: &Cli, ignored: &mut Vec<&'static str>) {
-    if cli.bearer.is_some() {
-        ignored.push("--bearer");
-    }
-    if cli.basic.is_some() {
-        ignored.push("--basic");
-    }
-    if cli.digest.is_some() {
-        ignored.push("--digest");
-    }
-    if cli.aws_sigv4.is_some() {
-        ignored.push("--aws-sigv4");
-    }
+    crate::flag_registry::append_ignored_of_category(cli, FlagCategory::Auth, ignored);
 }
 
+/// Append ignored response flag names (with `--` prefix) to `ignored`.
 pub(crate) fn append_shared_ignored_response_flags(cli: &Cli, ignored: &mut Vec<&'static str>) {
-    if cli.compress.is_some() || cli.no_encode {
-        ignored.push("--compress/--no-encode");
-    }
-    if cli.format.is_some() {
-        ignored.push("--format");
-    }
-    if cli.image.is_some() {
-        ignored.push("--image");
-    }
-    if cli.pager.is_some() {
-        ignored.push("--pager");
-    }
-    if cli.ignore_status {
-        ignored.push("--ignore-status");
-    }
-    if cli.sort_headers {
-        ignored.push("--sort-headers");
-    }
-    if cli.ws_interactive.is_some() {
-        ignored.push("--ws-interactive");
-    }
-    if cli.ws_message_mode.is_some() {
-        ignored.push("--ws-message-mode");
-    }
-    if cli.dry_run {
-        ignored.push("--dry-run");
-    }
+    crate::flag_registry::append_ignored_of_category(cli, FlagCategory::Response, ignored);
+}
+
+/// Append ignored TLS flag names (with `--` prefix) to `ignored`.
+/// Used by DNS inspection (but not TLS inspection, where TLS flags are meaningful).
+pub(crate) fn append_shared_ignored_tls_flags(cli: &Cli, ignored: &mut Vec<&'static str>) {
+    crate::flag_registry::append_ignored_of_category(cli, FlagCategory::Tls, ignored);
+}
+
+/// Append ignored HTTP-version flag names (with `--` prefix) to `ignored`.
+pub(crate) fn append_shared_ignored_http_version_flags(cli: &Cli, ignored: &mut Vec<&'static str>) {
+    crate::flag_registry::append_ignored_of_category(cli, FlagCategory::HttpVersion, ignored);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod dns;
 pub(crate) mod duration;
 pub mod error;
 pub mod fileutil;
+pub(crate) mod flag_registry;
 pub mod format;
 pub mod grpc;
 pub mod http;

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -932,7 +932,7 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
         assert_eq!(
             ignored_inspection_flags(&cli),
             [
-                "--data/--json/--xml",
+                "--data",
                 "--grpc",
                 "--proto-file",
                 "--proto-import",
@@ -944,7 +944,7 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
                 "--timing",
                 "--proxy",
                 "--bearer",
-                "--compress/--no-encode",
+                "--compress",
                 "--format",
                 "--image",
                 "--pager",

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -1297,8 +1297,8 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
         res.stderr
             .contains("No HTTP request will be sent; these flags have no effect")
     );
-    assert!(res.stderr.contains("--data/--json/--xml"));
-    assert!(res.stderr.contains("--compress/--no-encode"));
+    assert!(res.stderr.contains("--data"));
+    assert!(res.stderr.contains("--compress"));
     assert!(!res.stderr.contains("--inspect-dns ignores"));
 
     let dir = TempDir::new().unwrap();
@@ -1739,7 +1739,7 @@ fn tls_certificate_validation_inspection_and_bounds_cases() {
         res.stderr
             .contains("No HTTP request will be sent; these flags have no effect")
     );
-    assert!(res.stderr.contains("--data/--json/--xml"));
+    assert!(res.stderr.contains("--data"));
     assert!(res.stderr.contains("--bearer"));
     assert!(res.stderr.contains("--format"));
     assert!(!res.stderr.contains("--insecure"));


### PR DESCRIPTION
## Summary

Replace ~250 lines of duplicated flag-checking code spread across 5 functions with a single declarative flag registry.

### Before
Three nearly-identical "iterate over Cli fields and check if set" patterns existed:

| Function | Location | Lines |
|---|---|---|
| `append_shared_ignored_request_flags` | inspection.rs | ~30 flags |
| `append_shared_ignored_auth_flags` | inspection.rs | ~5 flags |
| `append_shared_ignored_response_flags` | inspection.rs | ~10 flags |
| `validate_from_curl_exclusives` | app.rs | ~40 ConflictRule entries |
| `validate_websocket_exclusives` | app.rs | ~50 ConflictRule entries |

Each structurally identical — check `cli.field.is_some()`, push a string.

### After
A single `src/flag_registry.rs` defines every flag once with name, category, predicate, and per-context boolean inclusion tags. Each use case filters the same registry.

- **inspection.rs**: 117 → 28 lines (-76%)
- **app.rs**: ConflictRule enum + both validators 210 → 42 lines (-80%)
- **dns/inspect.rs**: manual TLS/http-version checks replaced by registry categories

### Details
- Preserves WebSocket-specific `--retry 0` behavior via optional `is_ws_conflict` predicate
- Excludes `--dns-server` from DNS inspection ignored flags (it selects the resolver)
- Adds regression test for `--inspect-dns --dns-server` not being reported as ignored
- Flag names in inspection warnings now list individual flags (`--data`) instead of combined groups (`--data/--json/--xml`)

### Validation
- ✅ `cargo fmt --check` — clean
- ✅ `cargo clippy --locked --all-targets --all-features -- -D warnings` — clean
- ✅ 829 unit tests passed
- ✅ All 8 integration test suites passed