### PR TITLE
fix: include config file path in missing config error

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -903,7 +903,9 @@ pub fn validate(cli: &Cli) -> Result<(), FetchError> {
 fn get_config_file(path: Option<&str>) -> Result<Option<(PathBuf, String)>, FetchError> {
     if let Some(path) = path {
         let path = absolute_path(crate::fileutil::expand_home(path))?;
-        let contents = std::fs::read_to_string(&path)?;
+        let contents = std::fs::read_to_string(&path).map_err(|err| {
+            FetchError::Message(format!("config file '{}': {err}", path.display()))
+        })?;
         return Ok(Some((path, contents)));
     }
 


### PR DESCRIPTION
When `--config /nonexistent/path` was specified, the error was a bare OS error with no file context:

```
error: No such file or directory (os error 2)
```

Now the error includes which config file was not found, matching the pattern used by other file-path errors like `--proto-file`:

```
error: config file '/nonexistent/config.ini': No such file or directory (os error 2)
```

**Validation:** The change is a 1-line addition in `get_config_file` — wraps the `std::fs::read_to_string` error with a `FetchError::Message` including the file path.