### PR TITLE
fix: treat --timeout 0 and --connect-timeout 0 as no timeout (curl-compatible)

### DIFF
--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -230,6 +230,7 @@ fn inspection_request_timeout(cli: &Cli) -> Result<Option<Duration>, FetchError>
     cli.timeout
         .map(|seconds| duration_from_seconds("timeout", seconds))
         .transpose()
+        .map(|opt| opt.flatten())
 }
 
 fn inspection_connect_timeout(
@@ -240,7 +241,8 @@ fn inspection_connect_timeout(
     let connect_timeout = cli
         .connect_timeout
         .map(|seconds| duration_from_seconds("connect-timeout", seconds))
-        .transpose()?;
+        .transpose()?
+        .flatten();
     TimeoutBudget::for_connect(connect_timeout, request_timeout, request_start)
 }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -69,11 +69,17 @@ impl TimeoutBudget {
     }
 }
 
-pub(crate) fn duration_from_seconds(flag: &str, seconds: f64) -> Result<Duration, FetchError> {
+pub(crate) fn duration_from_seconds(
+    flag: &str,
+    seconds: f64,
+) -> Result<Option<Duration>, FetchError> {
     if !seconds.is_finite() || !(0.0..=MAX_DURATION_SECONDS).contains(&seconds) {
         return Err(format!("{flag} must be a non-negative number").into());
     }
-    Ok(Duration::from_secs_f64(seconds))
+    if seconds == 0.0 {
+        return Ok(None); // 0 means no timeout (curl-compatible)
+    }
+    Ok(Some(Duration::from_secs_f64(seconds)))
 }
 
 pub(crate) fn remaining_timeout(
@@ -284,10 +290,23 @@ mod tests {
     }
 
     #[test]
+    fn duration_from_seconds_handles_zero_as_no_timeout() {
+        // 0 means "no timeout" (curl-compatible)
+        assert_eq!(duration_from_seconds("timeout", 0.0).unwrap(), None);
+        assert_eq!(duration_from_seconds("connect-timeout", 0.0).unwrap(), None);
+
+        // Non-zero values still produce a duration
+        assert_eq!(
+            duration_from_seconds("timeout", 1.5).unwrap(),
+            Some(Duration::from_millis(1500))
+        );
+    }
+
+    #[test]
     fn duration_from_seconds_rejects_values_outside_supported_range() {
         assert_eq!(
             duration_from_seconds("timeout", 1.5).unwrap(),
-            Duration::from_millis(1500)
+            Some(Duration::from_millis(1500))
         );
 
         for seconds in [-1.0, f64::NAN, f64::INFINITY, 1e100] {

--- a/src/grpc/reflection.rs
+++ b/src/grpc/reflection.rs
@@ -45,11 +45,13 @@ pub async fn execute_discovery(cli: &Cli) -> Result<i32, FetchError> {
     let request_timeout = cli
         .timeout
         .map(|seconds| duration_from_seconds("timeout", seconds))
-        .transpose()?;
+        .transpose()?
+        .flatten();
     let connect_timeout = cli
         .connect_timeout
         .map(|seconds| duration_from_seconds("connect-timeout", seconds))
-        .transpose()?;
+        .transpose()?
+        .flatten();
     crate::tls::install_default_crypto_provider();
     let connect_timing = crate::http::client::ConnectionTiming::default();
     let client_build = crate::http::client::ClientBuildContext {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -116,11 +116,13 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     let request_timeout = cli
         .timeout
         .map(|seconds| duration_from_seconds("timeout", seconds))
-        .transpose()?;
+        .transpose()?
+        .flatten();
     let connect_timeout = cli
         .connect_timeout
         .map(|seconds| duration_from_seconds("connect-timeout", seconds))
-        .transpose()?;
+        .transpose()?
+        .flatten();
     crate::tls::install_default_crypto_provider();
 
     let connect_timing = client::ConnectionTiming::default();
@@ -211,7 +213,8 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     };
 
     let retry_count = cli.retry();
-    let retry_delay = duration_from_seconds("retry-delay", cli.retry_delay())?;
+    let retry_delay =
+        duration_from_seconds("retry-delay", cli.retry_delay())?.unwrap_or(Duration::ZERO);
     let total_attempts = total_attempts_for_retry(retry_count)?;
     let original_body_replayable = request_body_replayable(&body);
     let mut attempt = 0;

--- a/src/http/retry.rs
+++ b/src/http/retry.rs
@@ -269,7 +269,7 @@ pub(super) fn timeout_error_message(cli: &Cli, err: &transport::Error) -> Option
         return None;
     }
     let seconds = cli.timeout?;
-    let duration = duration_from_seconds("timeout", seconds).ok()?;
+    let duration = duration_from_seconds("timeout", seconds).ok().flatten()?;
     Some(request_timeout_message(duration))
 }
 

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -73,6 +73,7 @@ fn inspection_request_timeout(cli: &Cli) -> Result<Option<Duration>, FetchError>
     cli.timeout
         .map(|seconds| duration_from_seconds("timeout", seconds))
         .transpose()
+        .map(|opt| opt.flatten())
 }
 
 fn inspection_connect_timeout(
@@ -83,7 +84,8 @@ fn inspection_connect_timeout(
     let connect_timeout = cli
         .connect_timeout
         .map(|seconds| duration_from_seconds("connect-timeout", seconds))
-        .transpose()?;
+        .transpose()?
+        .flatten();
     TimeoutBudget::for_connect(connect_timeout, request_timeout, request_start)
 }
 

--- a/src/update/client.rs
+++ b/src/update/client.rs
@@ -96,11 +96,13 @@ impl UpdateClient {
         let timeout = cli
             .timeout
             .map(|seconds| duration_from_seconds("timeout", seconds))
-            .transpose()?;
+            .transpose()?
+            .flatten();
         let connect_timeout = cli
             .connect_timeout
             .map(|seconds| duration_from_seconds("connect-timeout", seconds))
-            .transpose()?;
+            .transpose()?
+            .flatten();
         Ok(Self {
             cli: Some(sanitized_update_cli(cli)),
             timeout,

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -237,6 +237,7 @@ fn websocket_request_timeout(cli: &Cli) -> Result<Option<Duration>, FetchError> 
     cli.timeout
         .map(|seconds| duration_from_seconds("timeout", seconds))
         .transpose()
+        .map(|opt| opt.flatten())
 }
 
 fn websocket_connect_timeout(
@@ -247,7 +248,8 @@ fn websocket_connect_timeout(
     let connect_timeout = cli
         .connect_timeout
         .map(|seconds| duration_from_seconds("connect-timeout", seconds))
-        .transpose()?;
+        .transpose()?
+        .flatten();
     TimeoutBudget::for_connect(connect_timeout, request_timeout, request_start)
 }
 


### PR DESCRIPTION
## Summary

In curl, `--connect-timeout 0` and `--max-time 0` mean "no timeout" (infinite). Previously, fetch treated zero as a zero-duration timeout that failed immediately:



This was surprising for users migrating from curl and also meant there was no ergonomic way to clear a timeout set by config or environment.

## Changes

- **`duration_from_seconds`** now returns `Option<Duration>`, where `None` means "no timeout" (triggered by `seconds == 0.0`)
- Updated all **14 call sites** across **8 files** (HTTP, WebSocket, DNS/TLS inspection, gRPC reflection, self-update client) to handle the new return type
- **`--retry-delay 0`** retains existing behavior (zero delay) via `.unwrap_or(Duration::ZERO)`

## Validation

- `cargo check --all-features` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test --locked --all-features --lib --bins` — all 830 unit tests pass ✓