### PR TITLE
fix: simplify binary response warning message

### DIFF
--- a/docs/output-formatting.md
+++ b/docs/output-formatting.md
@@ -375,8 +375,7 @@ To force output:
 
 ```sh
 fetch -o file.dat example.com/binary.dat
-fetch -o - example.com/binary.dat > file.dat
-fetch --image off example.com/image.png
+fetch -o - example.com/binary.dat
 ```
 
 ## Configuration

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -298,7 +298,7 @@ fetch --grpc --proto-file service.proto \
 
 2. **Force output to stdout**:
    ```sh
-   fetch -o - example.com/file.bin > output.bin
+   fetch -o - example.com/file.bin
    ```
 
 ### Large Response Truncated

--- a/src/http/response/stdout.rs
+++ b/src/http/response/stdout.rs
@@ -164,7 +164,7 @@ pub(super) fn response_header_content_type_label(headers: &HeaderMap) -> String 
 
 pub(super) fn binary_response_warning(content_type: &str) -> String {
     format!(
-        "the response body appears to be binary (content type: {content_type})\n\nUse '-o file' to save it, '-o - > file' to redirect raw bytes, or '--image off' to disable terminal image rendering."
+        "the response body appears to be binary (content type: {content_type})\n\nUse '-o <file>' to save to a file, or '-o -' to force raw stdout output."
     )
 }
 
@@ -217,9 +217,8 @@ mod tests {
     fn binary_response_warning_includes_content_type_and_alternatives() {
         let warning = binary_response_warning("application/octet-stream");
         assert!(warning.contains("content type: application/octet-stream"));
-        assert!(warning.contains("-o file"));
-        assert!(warning.contains("-o - > file"));
-        assert!(warning.contains("--image off"));
+        assert!(warning.contains("-o <file>"));
+        assert!(warning.contains("-o -"));
     }
 
     #[test]

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -26,9 +26,8 @@ fn assert_binary_warning_output(output: &str) {
         output.contains("\x1b[1m\x1b[33mwarning\x1b[0m: "),
         "{output:?}"
     );
-    assert!(output.contains("-o file"), "{output:?}");
-    assert!(output.contains("-o - > file"), "{output:?}");
-    assert!(output.contains("--image off"), "{output:?}");
+    assert!(output.contains("-o <file>"), "{output:?}");
+    assert!(output.contains("-o -"), "{output:?}");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Replace the confusing '-o - > file to redirect raw bytes' workaround suggestion with clear '-o <file>' to save to a file, or '-o -' to force raw stdout output.

**Changes:**
- Simplified the `binary_response_warning` message text
- Updated docs: removed redundant shell redirection examples
- Updated tests (unit + integration) to match new wording

**Validation:** `cargo test --test terminal` — 11/11 passed