### PR TITLE
feat: add verbose help menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,14 @@ fetch httpbin.org/json
 
 # Make a request for an image
 fetch picsum.photos/1024/1024
+
+# Open the full command menu / detailed CLI reference
+fetch -v -h
 ```
+
+> Tip: `fetch -h` shows concise help. Add `-v` (`fetch -v -h` or
+> `fetch -v --help`) to open the full, colorized command menu with detailed
+> options, examples, and pager support.
 
 ## Output Model
 
@@ -58,11 +65,13 @@ in the pager from `$PAGER`; set `NO_PAGER` or use `--pager off` to write
 directly. If `$PAGER` is unset, fetch falls back to `less -FIRX` and honors
 `$LESS` instead of adding default flags. `$PAGER` is split with POSIX
 shell-style quoting, but fetch launches the pager directly and does not
-interpret shell operators such as pipes or redirects. When stdout is redirected
-or piped, formatting turns off by default; use `--format on` to force formatted
-output in a pipe. Binary-looking responses are not printed to a terminal unless
-you explicitly choose an output path with `-o file`, force raw stdout with
-`-o - > file`, or disable terminal image rendering with `--image off`.
+interpret shell operators such as pipes or redirects. Detailed help
+(`fetch -v --help`) is colorized and uses the same pager controls. When stdout
+is redirected or piped, formatting turns off by default; use `--format on` to
+force formatted output in a pipe. Binary-looking responses are not printed to a
+terminal unless you explicitly choose an output path with `-o file`, force raw
+stdout with `-o - > file`, or disable terminal image rendering with
+`--image off`.
 
 ## Examples
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -767,7 +767,9 @@ Unknown curl flags return an error.
 
 ### `-h, --help`
 
-Print help information.
+Print help information. Use `-v --help` or `--verbose --help` for the detailed,
+colorized CLI reference. Detailed help follows `--pager`; use `--pager off` to
+print directly and `--color off` to disable color.
 
 ### `-V, --version`
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,7 @@ use crate::error::{FetchError, write_cli_error_with_color, write_runtime_error_w
 const CURL_DEFAULT_MAX_REDIRECTS: usize = 50;
 const MAX_MATERIALIZED_CURL_DATA_BYTES: usize = 16 * 1024 * 1024;
 const INTERRUPTED_EXIT_CODE: i32 = 130;
+const VERBOSE_HELP: &str = include_str!("../docs/cli-reference.md");
 
 pub async fn main_entry() -> i32 {
     crate::tls::install_default_crypto_provider();
@@ -96,6 +97,30 @@ fn handle_parse_error(err: clap::Error, color: Option<&str>) -> i32 {
 
     write_cli_error_with_color(format_parse_error_message(&err), color);
     1
+}
+
+fn help_verbose_requested_from_args(args: impl IntoIterator<Item = String>) -> bool {
+    let mut has_help = false;
+    let mut has_verbose = false;
+
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--help" {
+            has_help = true;
+        } else if arg == "--verbose" {
+            has_verbose = true;
+        } else if let Some(shorts) = arg.strip_prefix('-')
+            && !shorts.is_empty()
+            && !shorts.starts_with('-')
+        {
+            has_help |= shorts.contains('h');
+            has_verbose |= shorts.contains('v');
+        }
+    }
+
+    has_help && has_verbose
 }
 
 fn color_setting_from_args(args: impl IntoIterator<Item = String>) -> Option<String> {
@@ -262,7 +287,8 @@ async fn run_inner(cli: &mut Cli) -> Result<i32, FetchError> {
     if cli.help || cli.version || cli.buildinfo {
         crate::config::apply_best_effort(cli);
         if cli.help {
-            print_help(cli)?;
+            let verbose_help = help_verbose_requested_from_args(std::env::args().skip(1));
+            print_help(cli, verbose_help)?;
             return Ok(0);
         }
         if cli.version {
@@ -449,7 +475,20 @@ fn check_file_exists(path: &str) -> Result<(), FetchError> {
     }
 }
 
-fn print_help(cli: &Cli) -> Result<(), FetchError> {
+fn print_help(cli: &Cli, verbose: bool) -> Result<(), FetchError> {
+    if verbose {
+        let stdout_is_terminal = core::stdio().stdout_is_terminal();
+        let mut printer =
+            core::Printer::with_color_setting(cli.color.as_deref(), stdout_is_terminal);
+        crate::format::markdown::format_markdown_to(VERBOSE_HELP.as_bytes(), &mut printer)
+            .map_err(|err| FetchError::Message(err.to_string()))?;
+        let mut help = printer.into_bytes();
+        if !help.ends_with(b"\n") {
+            help.push(b'\n');
+        }
+        return crate::output::pager::write_text(cli, &help);
+    }
+
     let mut command = Cli::command().color(clap_color_choice(cli.color.as_deref()));
     command.print_help()?;
     core::write_stdout(b"\n")?;
@@ -1017,6 +1056,29 @@ fn newline_terminated(mut bytes: Vec<u8>) -> Vec<u8> {
 mod tests {
     use super::*;
     use serde_json::Value;
+
+    #[test]
+    fn verbose_help_is_requested_only_by_explicit_help_and_verbose_flags() {
+        assert!(!help_verbose_requested_from_args(["--help".to_string()]));
+        assert!(help_verbose_requested_from_args([
+            "-v".to_string(),
+            "--help".to_string()
+        ]));
+        assert!(help_verbose_requested_from_args([
+            "--verbose".to_string(),
+            "--help".to_string()
+        ]));
+        assert!(help_verbose_requested_from_args(["-vh".to_string()]));
+        assert!(help_verbose_requested_from_args([
+            "-vv".to_string(),
+            "-h".to_string()
+        ]));
+        assert!(!help_verbose_requested_from_args([
+            "--".to_string(),
+            "--help".to_string(),
+            "-v".to_string()
+        ]));
+    }
 
     #[test]
     fn clap_parse_errors_are_rendered_like_go_parser() {

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -20,7 +20,7 @@ use metadata::{
     body_duration, check_grpc_status, exit_code, finalize_streamed_response,
     handle_clipboard_outcome, print_response_metadata, print_timing,
 };
-use stdout::{pager_command, stdout_stream_target, write_stdout_bytes};
+use stdout::{stdout_stream_target, write_stdout_bytes};
 use stream::{
     read_decoded_response_body_limited, stream_response_to_discard, stream_response_to_output,
     stream_response_to_stdout,

--- a/src/http/response/stdout.rs
+++ b/src/http/response/stdout.rs
@@ -1,12 +1,5 @@
 use super::*;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(super) struct PagerCommand {
-    pub(super) program: String,
-    pub(super) args: Vec<String>,
-    pub(super) is_fallback: bool,
-}
-
 pub(super) struct StdoutBody {
     pub(super) bytes: Vec<u8>,
     pub(super) content_type: ContentType,
@@ -37,43 +30,14 @@ pub(super) fn should_page_stdout(
     let pager_allowed = !bytes.is_empty() && content_type != ContentType::Image;
     pager_allowed
         && match crate::cli::PagerMode::from_cli(cli) {
-            crate::cli::PagerMode::Auto => stdout_is_terminal && !pager_disabled_by_env(),
+            crate::cli::PagerMode::Auto => stdout_is_terminal && !output::pager::disabled_by_env(),
             crate::cli::PagerMode::On => true,
             crate::cli::PagerMode::Off => false,
         }
 }
 
 pub(super) fn write_stdout_bytes_with_pager(bytes: &[u8]) -> Result<(), FetchError> {
-    let pager = pager_command();
-    let mut child = match std::process::Command::new(&pager.program)
-        .args(&pager.args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(err) if pager.is_fallback && err.kind() == ErrorKind::NotFound => {
-            core::write_stdout(bytes)?;
-            return Ok(());
-        }
-        Err(err) => return Err(err.into()),
-    };
-
-    if let Some(mut stdin) = child.stdin.take() {
-        match stdin.write_all(bytes) {
-            Ok(()) => {}
-            Err(err) if err.kind() == ErrorKind::BrokenPipe => {}
-            Err(err) => return Err(err.into()),
-        }
-    }
-
-    let status = child.wait()?;
-    if !status.success() {
-        return Err(FetchError::Runtime(format!("pager exited with {status}")));
-    }
-
-    Ok(())
+    output::pager::write_bytes(bytes)
 }
 
 #[derive(Clone, Copy)]
@@ -94,7 +58,7 @@ pub(super) fn stdout_stream_target(
     let is_image = response_header_content_type(headers) == ContentType::Image;
     match crate::cli::PagerMode::from_cli(cli) {
         crate::cli::PagerMode::Auto
-            if stdout_is_terminal && !is_image && !pager_disabled_by_env() =>
+            if stdout_is_terminal && !is_image && !output::pager::disabled_by_env() =>
         {
             Some(StdoutStreamTarget::Pager)
         }
@@ -102,44 +66,6 @@ pub(super) fn stdout_stream_target(
         crate::cli::PagerMode::Auto | crate::cli::PagerMode::Off | crate::cli::PagerMode::On => {
             Some(StdoutStreamTarget::Direct)
         }
-    }
-}
-
-pub(super) fn pager_command() -> PagerCommand {
-    pager_command_with_env(|name| std::env::var_os(name).and_then(os_string_to_string))
-}
-
-fn pager_disabled_by_env() -> bool {
-    std::env::var_os("NO_PAGER").is_some()
-}
-
-fn os_string_to_string(value: std::ffi::OsString) -> Option<String> {
-    value.into_string().ok()
-}
-
-fn pager_command_with_env<F>(mut get_env: F) -> PagerCommand
-where
-    F: FnMut(&str) -> Option<String>,
-{
-    if let Some(value) = get_env("PAGER") {
-        let args = shlex::split(&value).unwrap_or_default();
-        if let Some((program, args)) = args.split_first() {
-            return PagerCommand {
-                program: program.clone(),
-                args: args.to_vec(),
-                is_fallback: false,
-            };
-        }
-    }
-
-    PagerCommand {
-        program: "less".to_string(),
-        args: if get_env("LESS").is_some() {
-            Vec::new()
-        } else {
-            vec!["-FIRX".to_string()]
-        },
-        is_fallback: true,
     }
 }
 
@@ -219,77 +145,6 @@ mod tests {
         assert!(warning.contains("content type: application/octet-stream"));
         assert!(warning.contains("-o <file>"));
         assert!(warning.contains("-o -"));
-    }
-
-    #[test]
-    fn pager_command_uses_pager_or_less_fallback() {
-        let got = pager_command_with_env(|_| None);
-        assert_eq!(
-            got,
-            PagerCommand {
-                program: "less".to_string(),
-                args: vec!["-FIRX".to_string()],
-                is_fallback: true,
-            }
-        );
-
-        let got = pager_command_with_env(|name| match name {
-            "LESS" => Some("-SR".to_string()),
-            _ => None,
-        });
-        assert_eq!(
-            got,
-            PagerCommand {
-                program: "less".to_string(),
-                args: Vec::new(),
-                is_fallback: true,
-            }
-        );
-
-        let got = pager_command_with_env(|name| match name {
-            "PAGER" => Some(r#""/usr/local/bin/my pager" --plain"#.to_string()),
-            _ => None,
-        });
-        assert_eq!(
-            got,
-            PagerCommand {
-                program: "/usr/local/bin/my pager".to_string(),
-                args: vec!["--plain".to_string()],
-                is_fallback: false,
-            }
-        );
-    }
-
-    #[test]
-    fn pager_command_uses_shlex_for_pager_environment() {
-        let got = pager_command_with_env(|name| match name {
-            "PAGER" => Some(r#"less --prompt='fetch > ' --pattern=a\ b"#.to_string()),
-            _ => None,
-        });
-        assert_eq!(
-            got,
-            PagerCommand {
-                program: "less".to_string(),
-                args: vec!["--prompt=fetch > ".to_string(), "--pattern=a b".to_string(),],
-                is_fallback: false,
-            }
-        );
-    }
-
-    #[test]
-    fn pager_command_falls_back_for_invalid_pager_environment() {
-        let got = pager_command_with_env(|name| match name {
-            "PAGER" => Some(r#"less "unterminated"#.to_string()),
-            _ => None,
-        });
-        assert_eq!(
-            got,
-            PagerCommand {
-                program: "less".to_string(),
-                args: vec!["-FIRX".to_string()],
-                is_fallback: true,
-            }
-        );
     }
 
     #[test]

--- a/src/http/response/stream.rs
+++ b/src/http/response/stream.rs
@@ -495,7 +495,7 @@ async fn stream_async_reader_to_pager(
     prefix: &[u8],
     capture: Option<&mut clipboard::Capture>,
 ) -> Result<i64, FetchError> {
-    let pager = pager_command();
+    let pager = output::pager::command();
     let mut child = match tokio::process::Command::new(&pager.program)
         .args(&pager.args)
         .stdin(Stdio::piped())

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -16,6 +16,7 @@ use crate::output::progress::{
 };
 
 pub mod clipboard;
+pub mod pager;
 pub mod progress;
 
 #[derive(Debug, Error)]

--- a/src/output/pager.rs
+++ b/src/output/pager.rs
@@ -1,0 +1,178 @@
+use std::io::{ErrorKind, Write};
+use std::process::Stdio;
+
+use crate::cli::{Cli, PagerMode};
+use crate::core;
+use crate::error::FetchError;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PagerCommand {
+    pub(crate) program: String,
+    pub(crate) args: Vec<String>,
+    pub(crate) is_fallback: bool,
+}
+
+fn should_page_text(cli: &Cli, bytes: &[u8], stdout_is_terminal: bool) -> bool {
+    !bytes.is_empty()
+        && match PagerMode::from_cli(cli) {
+            PagerMode::Auto => stdout_is_terminal && !disabled_by_env(),
+            PagerMode::On => true,
+            PagerMode::Off => false,
+        }
+}
+
+pub(crate) fn write_text(cli: &Cli, bytes: &[u8]) -> Result<(), FetchError> {
+    if should_page_text(cli, bytes, core::stdio().stdout_is_terminal()) {
+        write_bytes(bytes)
+    } else {
+        core::write_stdout(bytes)?;
+        Ok(())
+    }
+}
+
+pub(crate) fn write_bytes(bytes: &[u8]) -> Result<(), FetchError> {
+    let pager = command();
+    let mut child = match std::process::Command::new(&pager.program)
+        .args(&pager.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(err) if pager.is_fallback && err.kind() == ErrorKind::NotFound => {
+            core::write_stdout(bytes)?;
+            return Ok(());
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        match stdin.write_all(bytes) {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::BrokenPipe => {}
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    let status = child.wait()?;
+    if !status.success() {
+        return Err(FetchError::Runtime(format!("pager exited with {status}")));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn command() -> PagerCommand {
+    command_with_env(|name| std::env::var_os(name).and_then(os_string_to_string))
+}
+
+pub(crate) fn disabled_by_env() -> bool {
+    std::env::var_os("NO_PAGER").is_some()
+}
+
+fn os_string_to_string(value: std::ffi::OsString) -> Option<String> {
+    value.into_string().ok()
+}
+
+pub(crate) fn command_with_env<F>(mut get_env: F) -> PagerCommand
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    if let Some(value) = get_env("PAGER") {
+        let args = shlex::split(&value).unwrap_or_default();
+        if let Some((program, args)) = args.split_first() {
+            return PagerCommand {
+                program: program.clone(),
+                args: args.to_vec(),
+                is_fallback: false,
+            };
+        }
+    }
+
+    PagerCommand {
+        program: "less".to_string(),
+        args: if get_env("LESS").is_some() {
+            Vec::new()
+        } else {
+            vec!["-FIRX".to_string()]
+        },
+        is_fallback: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pager_command_uses_pager_or_less_fallback() {
+        let got = command_with_env(|_| None);
+        assert_eq!(
+            got,
+            PagerCommand {
+                program: "less".to_string(),
+                args: vec!["-FIRX".to_string()],
+                is_fallback: true,
+            }
+        );
+
+        let got = command_with_env(|name| match name {
+            "LESS" => Some("-SR".to_string()),
+            _ => None,
+        });
+        assert_eq!(
+            got,
+            PagerCommand {
+                program: "less".to_string(),
+                args: Vec::new(),
+                is_fallback: true,
+            }
+        );
+
+        let got = command_with_env(|name| match name {
+            "PAGER" => Some(r#""/usr/local/bin/my pager" --plain"#.to_string()),
+            _ => None,
+        });
+        assert_eq!(
+            got,
+            PagerCommand {
+                program: "/usr/local/bin/my pager".to_string(),
+                args: vec!["--plain".to_string()],
+                is_fallback: false,
+            }
+        );
+    }
+
+    #[test]
+    fn pager_command_uses_shlex_for_pager_environment() {
+        let got = command_with_env(|name| match name {
+            "PAGER" => Some(r#"less --prompt='fetch > ' --pattern=a\ b"#.to_string()),
+            _ => None,
+        });
+        assert_eq!(
+            got,
+            PagerCommand {
+                program: "less".to_string(),
+                args: vec!["--prompt=fetch > ".to_string(), "--pattern=a b".to_string(),],
+                is_fallback: false,
+            }
+        );
+    }
+
+    #[test]
+    fn pager_command_falls_back_for_invalid_pager_environment() {
+        let got = command_with_env(|name| match name {
+            "PAGER" => Some(r#"less "unterminated"#.to_string()),
+            _ => None,
+        });
+        assert_eq!(
+            got,
+            PagerCommand {
+                program: "less".to_string(),
+                args: vec!["-FIRX".to_string()],
+                is_fallback: true,
+            }
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -24,6 +24,25 @@ fn help_matches_go_harness_expectations() {
 }
 
 #[test]
+fn verbose_help_prints_cli_reference() {
+    let res = run_fetch(&["-v", "--help", "--pager", "off"]);
+    assert_exit(&res, 0);
+    assert!(res.stderr.is_empty(), "stderr: {}", res.stderr);
+    assert!(res.stdout.contains("# CLI Reference"));
+    assert!(res.stdout.contains("## Usage"));
+    assert!(res.stdout.contains("### -v, --verbose"));
+}
+
+#[test]
+fn verbose_help_colorizes_markdown_when_color_is_forced() {
+    let res = run_fetch(&["-v", "--help", "--pager", "off", "--color", "on"]);
+    assert_exit(&res, 0);
+    assert!(res.stderr.is_empty(), "stderr: {}", res.stderr);
+    assert!(res.stdout.contains("\x1b["), "stdout was not colorized");
+    assert!(res.stdout.contains("CLI Reference"));
+}
+
+#[test]
 fn cli_parse_errors_match_go_harness() {
     let cases = [
         (vec![], "<URL> must be provided"),


### PR DESCRIPTION
## Summary
- add verbose help mode via `fetch -v --help` / `fetch -v -h`
- render detailed CLI reference with markdown colorization and pager support
- share pager helpers between response output and verbose help
- document the full command menu in README and CLI reference

## Validation
- `cargo test --locked --all-features --test cli verbose_help`
- `cargo test --locked --all-features --lib --bins verbose_help_is_requested_only_by_explicit_help_and_verbose_flags`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`