### PR TITLE
fix: include --http in --inspect-tls ignored flag warning

### DIFF
--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -586,6 +586,7 @@ fn alpn_protocols(http_version: Option<HttpVersion>) -> &'static [&'static str] 
 pub(crate) fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     let mut ignored = Vec::new();
     crate::inspection::append_shared_ignored_request_flags(cli, &mut ignored);
+    crate::inspection::append_shared_ignored_http_version_flags(cli, &mut ignored);
     crate::inspection::append_shared_ignored_auth_flags(cli, &mut ignored);
     crate::inspection::append_shared_ignored_response_flags(cli, &mut ignored);
     ignored


### PR DESCRIPTION
## Problem

`--inspect-tls --http 2` did not report `--http` as an ignored flag:



While `--inspect-dns --http 2` correctly warned about `--http`.

## Root cause

The TLS inspection's `ignored_inspection_flags()` in `src/tls/inspect.rs` was missing the call to `append_shared_ignored_http_version_flags()`, which reports `--http`/`--http1`/`--http2`/`--http3` as having no effect when no HTTP request is sent.

## Fix

Added the missing call, matching the pattern already present in the DNS inspection version at `src/dns/inspect.rs`.

## Validation

- All 18 `tls::inspect::tests` pass
- `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean