### PR TITLE
refactor: remove custom main thread stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ cargo build --release --locked
 
 | Area | Files | Notes |
 | --- | --- | --- |
-| Entry | `src/main.rs`, `src/app.rs`, `src/cli.rs` | `main` uses a larger-stack Tokio thread; `app` heap-pins the top-level future. Do not revert. |
+| Entry | `src/main.rs`, `src/app.rs`, `src/cli.rs` | `main` runs the Tokio runtime on a spawned thread without overriding the platform default stack size; this avoids Windows' small process-main stack while removing the custom 16 MiB stack. Do not move stack-heavy entry futures back to the process main thread. |
 | Core IO | `src/core.rs`, `src/output`, `src/fileutil.rs` | Central printer/color/format/stdout policy, atomic writes, `~/` expansion, cross-platform locks. Prefer `core::write_stdout`, `core::stdio`, `core::color_enabled`, `core::format_enabled`; avoid direct `print!`/`println!` and ad-hoc terminal checks. |
 | Config | `src/config` | INI with host overlays. Config-backed options belong in `config_options!`; duplicate host sections are errors. Metadata commands parse config best-effort only. |
 | HTTP | `src/http`, `src/http/response`, `src/http/transport`, `src/net.rs` | Request building/execution, response orchestration, retries, proxies, TLS, Unix sockets, timing. Transport code owns DNS/TCP/TLS/QUIC setup; reuse `src/net.rs` dialing/proxy helpers. |

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,9 @@ use clap::{
 };
 use serde::Serialize;
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::io::Read;
+use std::pin::Pin;
 
 use crate::cli::{Cli, from_curl};
 use crate::core;
@@ -15,7 +17,13 @@ const MAX_MATERIALIZED_CURL_DATA_BYTES: usize = 16 * 1024 * 1024;
 const INTERRUPTED_EXIT_CODE: i32 = 130;
 const VERBOSE_HELP: &str = include_str!("../docs/cli-reference.md");
 
-pub async fn main_entry() -> i32 {
+type MainFuture = Pin<Box<dyn Future<Output = i32>>>;
+
+pub fn main_entry() -> MainFuture {
+    Box::pin(main_entry_inner())
+}
+
+async fn main_entry_inner() -> i32 {
     crate::tls::install_default_crypto_provider();
 
     if let Some(code) = crate::update::maybe_run_self_delete_helper() {
@@ -371,7 +379,7 @@ async fn run_inner(cli: &mut Cli) -> Result<i32, FetchError> {
         return Box::pin(crate::grpc::reflection::execute_discovery(cli)).await;
     }
 
-    Box::pin(crate::http::execute(cli)).await
+    crate::http::execute(cli).await
 }
 
 fn normalize_extra_args(cli: &mut Cli) -> Result<(), FetchError> {

--- a/src/dns/doh.rs
+++ b/src/dns/doh.rs
@@ -251,19 +251,19 @@ impl DohClient {
         body: Option<Vec<u8>>,
     ) -> Result<DohResponseBody, DnsError> {
         self.budget
-            .run(async {
+            .run(Box::pin(async {
                 let mut request = self.client.request(method, url).headers(headers);
                 if let Some(body) = body {
                     request = request.body(body);
                 }
                 let response = Box::pin(request.send()).await?;
-                buffer_response_with_limit(
+                Box::pin(buffer_response_with_limit(
                     response,
                     DOH_RESPONSE_MAX_BYTES,
                     DOH_RESPONSE_LIMIT_ERROR,
-                )
+                ))
                 .await
-            })
+            }))
             .await
             .map_err(|err| DnsError(err.to_string()))
     }

--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
+use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 use futures_util::future::join_all;
@@ -187,7 +189,13 @@ enum ResolverTarget {
     },
 }
 
-pub async fn execute(cli: &Cli, ignored_flags: &[&'static str]) -> Result<i32, FetchError> {
+type InspectFuture<'a> = Pin<Box<dyn Future<Output = Result<i32, FetchError>> + 'a>>;
+
+pub fn execute<'a>(cli: &'a Cli, ignored_flags: &'a [&'static str]) -> InspectFuture<'a> {
+    Box::pin(execute_inner(cli, ignored_flags))
+}
+
+async fn execute_inner(cli: &Cli, ignored_flags: &[&'static str]) -> Result<i32, FetchError> {
     let request_start = Instant::now();
     let url = crate::http::normalize_url(cli.url.as_deref().expect("URL checked by app"))?;
     if !ignored_flags.is_empty() && !cli.silent {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,5 +1,6 @@
 use std::error::Error as StdError;
 use std::fmt;
+use std::future::Future;
 use std::io::{ErrorKind, Read, Write};
 use std::path::Path;
 use std::pin::Pin;
@@ -92,7 +93,13 @@ use transport::{Body, Client, RequestBuilder, Response};
 
 type AsyncReadBox = Pin<Box<dyn AsyncRead + Send>>;
 
-pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
+type HttpFuture<'a> = Pin<Box<dyn Future<Output = Result<i32, FetchError>> + 'a>>;
+
+pub fn execute(cli: &Cli) -> HttpFuture<'_> {
+    Box::pin(execute_inner(cli))
+}
+
+async fn execute_inner(cli: &Cli) -> Result<i32, FetchError> {
     let http_version = crate::cli::selected_http_version(cli).map_err(FetchError::Message)?;
     let http_version = effective_http_version(cli, http_version);
     let mut url = normalize_url(cli.url.as_deref().expect("URL checked by app"))?;
@@ -136,7 +143,8 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     };
     let mut initial_client = None;
     if cli.grpc && grpc_method.is_none() {
-        let reflection_client = client::build_client_for_url(cli, &url, &client_build).await?;
+        let reflection_client =
+            Box::pin(client::build_client_for_url(cli, &url, &client_build)).await?;
         let request_requires_schema = grpc_request_requires_schema(cli);
         match Box::pin(crate::grpc::reflection::schema_for_call(
             cli,
@@ -209,7 +217,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
 
     let initial_client = match initial_client {
         Some(client) => client,
-        None => client::build_client_for_url(cli, &url, &client_build).await?,
+        None => Box::pin(client::build_client_for_url(cli, &url, &client_build)).await?,
     };
 
     let retry_count = cli.retry();
@@ -273,7 +281,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
             let req = apply_request_timeout(req, request_timeout, request_start)?;
             request_client.clear_runtime_dns_resolution();
             connect_timing.clear();
-            match req.send().await {
+            match Box::pin(req.send()).await {
                 Ok(response) => {
                     record_request_dns_timing(cli, &request_client, &mut timing);
                     if let Some(redirect) = redirect_target(cli, &response, redirect_count)? {
@@ -295,9 +303,12 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                         request_body = redirected.body;
                         strip_entity_headers |= redirected.strip_entity_headers;
                         if refresh_client {
-                            request_client =
-                                client::build_client_for_url(cli, &request_url, &client_build)
-                                    .await?;
+                            request_client = Box::pin(client::build_client_for_url(
+                                cli,
+                                &request_url,
+                                &client_build,
+                            ))
+                            .await?;
                         }
                         redirect_count += 1;
                         continue;
@@ -327,7 +338,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                         connect_debug_target(&response, &request_url, dns_resolution.as_ref());
                     timing::print_debug_lines(&timing, &connect_target, cli.color.as_deref());
                 }
-                let response = apply_digest_challenge(
+                let response = Box::pin(apply_digest_challenge(
                     response,
                     DigestRetryContext {
                         client: &request_client.client,
@@ -341,7 +352,7 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
                         auth_allowed: same_origin(&url, &request_url),
                     },
                     digest_credentials.as_ref(),
-                )
+                ))
                 .await?;
                 let status = response.status();
                 let retry_sse_uncompressed =

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,9 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-const APP_THREAD_STACK_SIZE: usize = 16 * 1024 * 1024;
-
 fn main() {
     let code = std::thread::Builder::new()
         .name("fetch-main".to_string())
-        .stack_size(APP_THREAD_STACK_SIZE)
         .spawn(|| {
             let runtime = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()


### PR DESCRIPTION
## Summary
- remove the custom larger-stack thread from main
- heap-pin the top-level app future before Tokio block_on
- update agent guidance for the entrypoint invariant

## Validation
- cargo fmt
- cargo check --locked --all-features