### PR TITLE
fix: reject non-regular request body files

### DIFF
--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -7,7 +7,7 @@ use std::task::{Context, Poll};
 use bytes::Bytes;
 use futures_util::Stream;
 use thiserror::Error;
-use tokio::io::{AsyncRead, ReadBuf};
+use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 
 use crate::format::content_type;
 
@@ -15,8 +15,8 @@ use crate::format::content_type;
 pub enum MultipartError {
     #[error("file does not exist: '{0}'")]
     FileDoesNotExist(String),
-    #[error("file is a directory: '{0}'")]
-    FileIsDirectory(String),
+    #[error("file is not a regular file; use @- to stream stdin: '{0}'")]
+    FileIsNotRegular(String),
     #[error("invalid multipart {kind}: value contains ASCII control character")]
     InvalidDispositionValue { kind: &'static str },
     #[error("multipart body is too large to compute Content-Length")]
@@ -109,9 +109,10 @@ impl Multipart {
                     append_preview(&mut out, limit, field.header.as_bytes());
                     if out.len() < limit {
                         let remaining = limit - out.len();
-                        let mut input = std::fs::File::open(&file.path)?;
+                        let mut input = open_file_part(file)?;
+                        let read_limit = file.len.min(u64::try_from(remaining).unwrap_or(u64::MAX));
                         Read::by_ref(&mut input)
-                            .take(u64::try_from(remaining).unwrap_or(u64::MAX))
+                            .take(read_limit)
                             .read_to_end(&mut out)?;
                     }
                     append_preview(&mut out, limit, b"\r\n");
@@ -143,8 +144,8 @@ impl Multipart {
                 }
                 FieldValue::File(file) => {
                     out.write_all(field.header.as_bytes())?;
-                    let mut file = std::fs::File::open(&file.path)?;
-                    std::io::copy(&mut file, &mut out)?;
+                    let input = open_file_part(file)?;
+                    std::io::copy(&mut input.take(file.len), &mut out)?;
                     out.write_all(b"\r\n")?;
                 }
             }
@@ -225,10 +226,40 @@ fn validate_file_path(path: &Path) -> Result<std::fs::Metadata, MultipartError> 
         }
         Err(err) => return Err(err.into()),
     };
-    if metadata.is_dir() {
-        return Err(MultipartError::FileIsDirectory(path.display().to_string()));
+    if !metadata.file_type().is_file() {
+        return Err(MultipartError::FileIsNotRegular(path.display().to_string()));
     }
     Ok(metadata)
+}
+
+fn validate_opened_file_part(
+    file: &FilePart,
+    metadata: &std::fs::Metadata,
+) -> Result<(), MultipartError> {
+    if !metadata.file_type().is_file() {
+        return Err(MultipartError::FileIsNotRegular(
+            file.path.display().to_string(),
+        ));
+    }
+    if metadata.len() != file.len {
+        return Err(MultipartError::Io(std::io::Error::other(format!(
+            "file '{}' changed size while preparing the multipart body",
+            file.path.display()
+        ))));
+    }
+    Ok(())
+}
+
+fn open_file_part(file: &FilePart) -> Result<std::fs::File, MultipartError> {
+    let opened = std::fs::File::open(&file.path)?;
+    validate_opened_file_part(file, &opened.metadata()?)?;
+    Ok(opened)
+}
+
+async fn open_file_part_async(file: &FilePart) -> Result<tokio::fs::File, MultipartError> {
+    let opened = tokio::fs::File::open(&file.path).await?;
+    validate_opened_file_part(file, &opened.metadata().await?)?;
+    Ok(opened)
 }
 
 fn escape_multipart_string(value: &str) -> String {
@@ -316,12 +347,18 @@ pub struct MultipartStream {
     state: MultipartStreamState,
 }
 
-type OpenFileFuture = Pin<Box<dyn Future<Output = std::io::Result<tokio::fs::File>> + Send>>;
+type OpenFileFuture = Pin<Box<dyn Future<Output = Result<tokio::fs::File, MultipartError>> + Send>>;
 
 enum MultipartStreamState {
     Field,
-    OpeningFile { header: Bytes, open: OpenFileFuture },
-    File(tokio::fs::File),
+    OpeningFile {
+        header: Bytes,
+        open: OpenFileFuture,
+    },
+    File {
+        file: tokio::io::Take<tokio::fs::File>,
+        remaining: u64,
+    },
     FileCrlf,
     Done,
 }
@@ -358,9 +395,12 @@ impl Stream for MultipartStream {
                             chunk.extend_from_slice(self.multipart.boundary.as_bytes());
                             chunk.extend_from_slice(b"\r\n");
                             chunk.extend_from_slice(field.header.as_bytes());
+                            let file_part = file.clone();
                             self.state = MultipartStreamState::OpeningFile {
                                 header: Bytes::from(chunk),
-                                open: Box::pin(tokio::fs::File::open(file.path.clone())),
+                                open: Box::pin(
+                                    async move { open_file_part_async(&file_part).await },
+                                ),
                             };
                             continue;
                         }
@@ -369,21 +409,36 @@ impl Stream for MultipartStream {
                 MultipartStreamState::OpeningFile { header, open } => {
                     let file = match open.as_mut().poll(cx) {
                         Poll::Ready(Ok(file)) => file,
-                        Poll::Ready(Err(err)) => return Poll::Ready(Some(Err(err.into()))),
+                        Poll::Ready(Err(err)) => return Poll::Ready(Some(Err(err))),
                         Poll::Pending => return Poll::Pending,
                     };
                     let header = std::mem::replace(header, Bytes::new());
-                    self.state = MultipartStreamState::File(file);
+                    let file_len = match &self.multipart.fields[self.index].value {
+                        FieldValue::File(file) => file.len,
+                        FieldValue::Text(_) => 0,
+                    };
+                    self.state = MultipartStreamState::File {
+                        file: file.take(file_len),
+                        remaining: file_len,
+                    };
                     return Poll::Ready(Some(Ok(header)));
                 }
-                MultipartStreamState::File(file) => {
+                MultipartStreamState::File { file, remaining } => {
+                    if *remaining == 0 {
+                        self.state = MultipartStreamState::FileCrlf;
+                        continue;
+                    }
                     let mut bytes = [0_u8; 8192];
-                    let mut read_buf = ReadBuf::new(&mut bytes);
+                    let read_len = bytes
+                        .len()
+                        .min(usize::try_from(*remaining).unwrap_or(usize::MAX));
+                    let mut read_buf = ReadBuf::new(&mut bytes[..read_len]);
                     match Pin::new(file).poll_read(cx, &mut read_buf) {
                         Poll::Ready(Ok(())) if read_buf.filled().is_empty() => {
                             self.state = MultipartStreamState::FileCrlf;
                         }
                         Poll::Ready(Ok(())) => {
+                            *remaining = remaining.saturating_sub(read_buf.filled().len() as u64);
                             return Poll::Ready(Some(Ok(Bytes::copy_from_slice(
                                 read_buf.filled(),
                             ))));
@@ -491,6 +546,21 @@ mod tests {
     }
 
     #[test]
+    fn multipart_preview_rechecks_captured_file_len() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("payload.txt");
+        std::fs::write(&path, b"old").unwrap();
+        let multipart = Multipart::from_cli_fields(&[format!("file=@{}", path.display())])
+            .unwrap()
+            .unwrap();
+        std::fs::write(&path, b"new contents").unwrap();
+
+        let err = multipart.preview(1024).unwrap_err();
+
+        assert!(err.to_string().contains("changed size"));
+    }
+
+    #[test]
     fn multipart_content_len_reports_body_too_large_on_overflow() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("payload.txt");
@@ -528,7 +598,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let err =
             Multipart::from_cli_fields(&[format!("file=@{}", dir.path().display())]).unwrap_err();
-        assert!(err.to_string().contains("file is a directory"));
+        assert!(err.to_string().contains("file is not a regular file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn multipart_rejects_non_regular_file_fields() {
+        let err = Multipart::from_cli_fields(&["file=@/dev/null".to_string()]).unwrap_err();
+
+        assert!(err.to_string().contains("file is not a regular file"));
     }
 
     #[test]

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -407,8 +407,9 @@ pub(crate) fn request_body_sha256_hex(body: &RequestBody) -> Result<String, Fetc
     let mut hasher = Sha256::new();
     match &body.source {
         RequestBodySource::Bytes(bytes) => hasher.update(bytes),
-        RequestBodySource::File { path, .. } => {
-            hash_reader(&mut hasher, std::fs::File::open(path)?)?;
+        RequestBodySource::File { path, len } => {
+            let file = open_regular_file_at_len(path, *len)?;
+            hash_reader(&mut hasher, file.take(*len))?;
         }
         RequestBodySource::Multipart(multipart) => {
             let mut writer = Sha256Writer(&mut hasher);
@@ -525,9 +526,11 @@ pub(super) fn inferred_request_body_content_len(
 pub(crate) fn request_body_to_transport_body(body: RequestBodyPayload) -> Result<Body, FetchError> {
     match body.source {
         RequestBodySource::Bytes(bytes) => Ok(Body::from(bytes)),
-        RequestBodySource::File { path, .. } => {
-            let file = std::fs::File::open(&path)?;
-            Ok(Body::from(tokio::fs::File::from_std(file)))
+        RequestBodySource::File { path, len } => {
+            let file = open_regular_file_at_len(&path, len)?;
+            Ok(Body::wrap_stream(ReaderStream::new(
+                tokio::fs::File::from_std(file).take(len),
+            )))
         }
         RequestBodySource::Stdin => Ok(Body::wrap_stream(ReaderStream::new(tokio::io::stdin()))),
         RequestBodySource::Multipart(multipart) => Ok(Body::wrap_stream(multipart.stream())),
@@ -550,9 +553,9 @@ pub(crate) fn request_body_source_to_async_reader(
 ) -> Result<AsyncReadBox, FetchError> {
     match source {
         RequestBodySource::Bytes(bytes) => Ok(Box::pin(Cursor::new(bytes))),
-        RequestBodySource::File { path, .. } => {
-            let file = std::fs::File::open(&path)?;
-            Ok(Box::pin(tokio::fs::File::from_std(file)))
+        RequestBodySource::File { path, len } => {
+            let file = open_regular_file_at_len(&path, len)?;
+            Ok(Box::pin(tokio::fs::File::from_std(file).take(len)))
         }
         RequestBodySource::Stdin => Ok(Box::pin(tokio::io::stdin())),
         RequestBodySource::Multipart(multipart) => Ok(Box::pin(StreamReader::new(
@@ -598,7 +601,12 @@ pub(crate) fn request_body_source_to_bytes(
 ) -> Result<Vec<u8>, FetchError> {
     match source {
         RequestBodySource::Bytes(bytes) => Ok(bytes.to_vec()),
-        RequestBodySource::File { path, .. } => Ok(std::fs::read(path)?),
+        RequestBodySource::File { path, len } => {
+            let file = open_regular_file_at_len(&path, len)?;
+            let mut out = Vec::with_capacity(usize::try_from(len).unwrap_or(0));
+            file.take(len).read_to_end(&mut out)?;
+            Ok(out)
+        }
         RequestBodySource::Stdin => {
             let mut buf = Vec::new();
             std::io::stdin().read_to_end(&mut buf)?;
@@ -627,8 +635,8 @@ fn request_body_source_to_bytes_limited(
         }
         RequestBodySource::File { path, len } => {
             ensure_materialized_len_u64(len, max_bytes, limit_error)?;
-            let file = std::fs::File::open(path)?;
-            read_to_end_limited(file, max_bytes, limit_error)
+            let file = open_regular_file_at_len(&path, len)?;
+            read_to_end_limited(file.take(len), max_bytes, limit_error)
         }
         RequestBodySource::Stdin => {
             let stdin = std::io::stdin();
@@ -723,6 +731,7 @@ impl Write for LimitedBytesWriter<'_> {
     }
 }
 
+#[derive(Debug)]
 struct DryRunBodyPreview {
     bytes: Vec<u8>,
     truncated: bool,
@@ -744,10 +753,16 @@ fn dry_run_source_preview(
             bytes: bytes.slice(..bytes.len().min(limit)).to_vec(),
             truncated: bytes.len() > limit,
         }),
-        RequestBodySource::File { path, len } => Ok(DryRunBodyPreview {
-            bytes: read_file_prefix(path, limit)?,
-            truncated: *len > u64::try_from(limit).unwrap_or(u64::MAX),
-        }),
+        RequestBodySource::File { path, len } => {
+            let file = open_regular_file_at_len(path, *len)?;
+            let mut bytes = Vec::new();
+            file.take(u64::try_from(limit).unwrap_or(u64::MAX))
+                .read_to_end(&mut bytes)?;
+            Ok(DryRunBodyPreview {
+                bytes,
+                truncated: *len > u64::try_from(limit).unwrap_or(u64::MAX),
+            })
+        }
         RequestBodySource::Stdin => read_prefix_preview(std::io::stdin().lock(), limit),
         RequestBodySource::Multipart(multipart) => {
             let (bytes, truncated) = multipart
@@ -902,9 +917,7 @@ pub(super) fn body_value_source(
                 err.into()
             }
         })?;
-        if metadata.is_dir() {
-            return Err(format!("file '{path}' is a directory").into());
-        }
+        validate_regular_file_metadata(path, &metadata)?;
         let content_type = if detect_content_type {
             Some(detect_body_file_content_type(&expanded)?)
         } else {
@@ -922,6 +935,36 @@ pub(super) fn body_value_source(
         RequestBodySource::Bytes(Bytes::copy_from_slice(value.as_bytes())),
         detect_content_type.then(|| sniff_content_type_like_go(value.as_bytes())),
     ))
+}
+
+fn validate_regular_file_metadata(
+    display_path: impl std::fmt::Display,
+    metadata: &std::fs::Metadata,
+) -> Result<(), FetchError> {
+    if !metadata.file_type().is_file() {
+        return Err(
+            format!("file '{display_path}' is not a regular file; use @- to stream stdin").into(),
+        );
+    }
+    Ok(())
+}
+
+fn open_regular_file_at_len(
+    path: impl AsRef<Path>,
+    expected_len: u64,
+) -> Result<std::fs::File, FetchError> {
+    let path = path.as_ref();
+    let file = std::fs::File::open(path)?;
+    let metadata = file.metadata()?;
+    validate_regular_file_metadata(path.display(), &metadata)?;
+    if metadata.len() != expected_len {
+        return Err(format!(
+            "file '{}' changed size while preparing the request body",
+            path.display()
+        )
+        .into());
+    }
+    Ok(file)
 }
 
 pub(super) fn detect_body_file_content_type(path: &Path) -> Result<String, FetchError> {
@@ -1098,7 +1141,43 @@ mod tests {
         let err = request_body(&cli).unwrap_err().to_string();
         assert_eq!(
             err,
-            format!("file '{}' is a directory", dir.path().display())
+            format!(
+                "file '{}' is not a regular file; use @- to stream stdin",
+                dir.path().display()
+            )
+        );
+    }
+
+    #[test]
+    fn dry_run_file_preview_rechecks_captured_file_len() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("payload.txt");
+        std::fs::write(&path, b"old").unwrap();
+        let body = RequestBodyPayload {
+            source: RequestBodySource::File {
+                path: path.display().to_string(),
+                len: 3,
+            },
+            content_type: None,
+        };
+        std::fs::write(&path, b"new contents").unwrap();
+
+        let err = dry_run_body_preview(&body, 1024).unwrap_err();
+
+        assert!(err.to_string().contains("changed size"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn request_body_rejects_non_regular_body_file() {
+        let cli =
+            Cli::try_parse_from(["fetch", "--data", "@/dev/null", "https://example.com"]).unwrap();
+
+        let err = request_body(&cli).unwrap_err().to_string();
+
+        assert_eq!(
+            err,
+            "file '/dev/null' is not a regular file; use @- to stream stdin"
         );
     }
 


### PR DESCRIPTION
## Summary
- Reject non-regular @file request bodies and multipart file parts
- Re-check file type and size at open time to catch TOCTOU changes
- Bound file reads/sends/previews to the captured regular-file length

## Validation
- cargo fmt
- cargo test --locked --all-features --lib dry_run_file_preview_rechecks_captured_file_len
- cargo test --locked --all-features --lib multipart_preview_rechecks_captured_file_len
- cargo test --locked --all-features --lib request_body_rejects_non_regular_body_file
- cargo test --locked --all-features --lib multipart_rejects_non_regular_file_fields
- cargo clippy --locked --all-targets --all-features -- -D warnings