### PR TITLE
fix: preserve fragments in curl GET query parsing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -623,7 +623,7 @@ fn apply_from_curl(cli: &mut Cli) -> Result<(), FetchError> {
 
     cli.redirects = Some(if parsed.follow_redirects {
         if parsed.max_redirects_set {
-            usize::try_from(parsed.max_redirects).unwrap_or(usize::MAX)
+            parsed.max_redirects
         } else {
             CURL_DEFAULT_MAX_REDIRECTS
         }
@@ -908,12 +908,15 @@ fn append_raw_query(url: &mut String, query: &str) {
     if query.is_empty() {
         return;
     }
-    if url.contains('?') {
-        url.push('&');
+
+    let fragment_start = url.find('#').unwrap_or(url.len());
+    let separator = if url[..fragment_start].contains('?') {
+        '&'
     } else {
-        url.push('?');
-    }
-    url.push_str(query);
+        '?'
+    };
+    url.insert(fragment_start, separator);
+    url.insert_str(fragment_start + separator.len_utf8(), query);
 }
 
 fn parse_aws_sigv4(value: &str) -> Result<String, FetchError> {
@@ -1295,6 +1298,30 @@ mod tests {
             cli.url.as_deref(),
             Some("https://example.com?q=search&limit=10")
         );
+    }
+
+    #[test]
+    fn from_curl_get_data_inserts_query_before_fragment() {
+        let cases = [
+            (
+                "curl -G -d a=1 'https://x/path#frag'",
+                "https://x/path?a=1#frag",
+            ),
+            (
+                "curl -G -d a=1 'https://x/path?old=1#frag'",
+                "https://x/path?old=1&a=1#frag",
+            ),
+            ("curl -G -d a=1 'x/path#frag'", "x/path?a=1#frag"),
+        ];
+
+        for (command, want) in cases {
+            let mut cli = Cli::try_parse_from(["fetch", "--from-curl", command]).unwrap();
+
+            apply_from_curl(&mut cli).unwrap();
+
+            assert_eq!(cli.data, None);
+            assert_eq!(cli.url.as_deref(), Some(want), "command: {command}");
+        }
     }
 
     fn curl_test_path(path: &std::path::Path) -> String {

--- a/src/cli/from_curl.rs
+++ b/src/cli/from_curl.rs
@@ -37,7 +37,7 @@ pub struct ParsedCurl {
     pub remote_name: bool,
     pub remote_header_name: bool,
     pub follow_redirects: bool,
-    pub max_redirects: i32,
+    pub max_redirects: usize,
     pub max_redirects_set: bool,
     pub timeout: f64,
     pub connect_timeout: f64,
@@ -413,24 +413,18 @@ fn parse_long_flag(
         }
         "max-redirs" => {
             let (value, consumed) = consume_arg(name)?;
-            parsed.max_redirects = value
-                .parse()
-                .map_err(|_| format!("invalid --max-redirs value: {value}"))?;
+            parsed.max_redirects = parse_nonnegative_usize("--max-redirs", &value)?;
             parsed.max_redirects_set = true;
             Ok(consumed)
         }
         "max-time" => {
             let (value, consumed) = consume_arg(name)?;
-            parsed.timeout = value
-                .parse()
-                .map_err(|_| format!("invalid --max-time value: {value}"))?;
+            parsed.timeout = parse_nonnegative_f64("--max-time", &value)?;
             Ok(consumed)
         }
         "connect-timeout" => {
             let (value, consumed) = consume_arg(name)?;
-            parsed.connect_timeout = value
-                .parse()
-                .map_err(|_| format!("invalid --connect-timeout value: {value}"))?;
+            parsed.connect_timeout = parse_nonnegative_f64("--connect-timeout", &value)?;
             Ok(consumed)
         }
         "proxy" => {
@@ -450,16 +444,12 @@ fn parse_long_flag(
         }
         "retry" => {
             let (value, consumed) = consume_arg(name)?;
-            parsed.retry = value
-                .parse()
-                .map_err(|_| format!("invalid --retry value: {value}"))?;
+            parsed.retry = parse_nonnegative_usize("--retry", &value)?;
             Ok(consumed)
         }
         "retry-delay" => {
             let (value, consumed) = consume_arg(name)?;
-            parsed.retry_delay = value
-                .parse()
-                .map_err(|_| format!("invalid --retry-delay value: {value}"))?;
+            parsed.retry_delay = parse_nonnegative_f64("--retry-delay", &value)?;
             Ok(consumed)
         }
         "range" => {
@@ -661,9 +651,7 @@ fn parse_short_flags(
             }
             'm' => {
                 let (value, consumed) = consume_arg(flag)?;
-                parsed.timeout = value
-                    .parse()
-                    .map_err(|_| format!("invalid -m value: {value}"))?;
+                parsed.timeout = parse_nonnegative_f64("-m", &value)?;
                 total += consumed;
             }
             'r' => {
@@ -714,6 +702,29 @@ fn parse_short_flags(
 
 fn next_arg(rest: &[String]) -> Result<(String, usize), ()> {
     rest.first().map(|value| (value.clone(), 1)).ok_or(())
+}
+
+fn parse_nonnegative_usize(flag: &str, value: &str) -> Result<usize, String> {
+    if value.starts_with('-') {
+        return Err(format!("invalid {flag} value: {value}"));
+    }
+    let value_to_parse = value.strip_prefix('+').unwrap_or(value);
+    if value_to_parse.is_empty() {
+        return Err(format!("invalid {flag} value: {value}"));
+    }
+    value_to_parse
+        .parse()
+        .map_err(|_| format!("invalid {flag} value: {value}"))
+}
+
+fn parse_nonnegative_f64(flag: &str, value: &str) -> Result<f64, String> {
+    let parsed = value
+        .parse::<f64>()
+        .map_err(|_| format!("invalid {flag} value: {value}"))?;
+    if !parsed.is_finite() || !(0.0..=crate::duration::MAX_DURATION_SECONDS).contains(&parsed) {
+        return Err(format!("invalid {flag} value: {value}"));
+    }
+    Ok(parsed)
 }
 
 fn parse_header(value: &str) -> Result<Header, String> {
@@ -1003,6 +1014,21 @@ mod tests {
         assert_eq!(parsed.connect_timeout, 0.25);
         assert_eq!(parsed.retry, 3);
         assert_eq!(parsed.retry_delay, 0.5);
+    }
+
+    #[test]
+    fn test_parse_rejects_negative_numeric_values() {
+        for command in [
+            "curl --max-redirs -1 https://example.com",
+            "curl --max-time -5 https://example.com",
+            "curl -m -5 https://example.com",
+            "curl --connect-timeout -5 https://example.com",
+            "curl --retry -1 https://example.com",
+            "curl --retry-delay -5 https://example.com",
+        ] {
+            let err = parse(command).unwrap_err();
+            assert!(err.contains("invalid"), "{command}: {err}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Insert --from-curl -G query data before URL fragments
- Preserve existing query strings when appending curl GET data
- Reject negative --from-curl numeric values consistently

## Validation
- cargo fmt
- cargo test --locked --all-features --lib from_curl -- --nocapture
- cargo test --locked --all-features --lib test_parse_rejects_negative_numeric_values -- --nocapture