### PR TITLE
feat: thread DoH TLS config through transport and dialing stack

### DIFF
--- a/src/dns/doh.rs
+++ b/src/dns/doh.rs
@@ -99,8 +99,19 @@ pub(crate) fn client(timeout: Option<Duration>) -> Result<DohClient, DnsError> {
 }
 
 pub(crate) fn client_with_budget(budget: TimeoutBudget) -> Result<DohClient, DnsError> {
-    let tls_config =
-        crate::tls::rustls_platform_client_config().map_err(|err| DnsError(err.to_string()))?;
+    client_with_budget_and_tls_config(budget, None)
+}
+
+pub(crate) fn client_with_budget_and_tls_config(
+    budget: TimeoutBudget,
+    tls_config: Option<rustls::ClientConfig>,
+) -> Result<DohClient, DnsError> {
+    let tls_config = match tls_config {
+        Some(config) => config,
+        None => {
+            crate::tls::rustls_platform_client_config().map_err(|err| DnsError(err.to_string()))?
+        }
+    };
     let client = Client::builder()
         .tls_config(tls_config)
         .build()

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -166,6 +166,7 @@ pub(crate) async fn build_client_for_url(
         builder = builder.ech_hard_fail(hard_fail);
         builder = configure_tls(builder, cli, ech_mode)?;
     }
+    builder = configure_doh_tls(builder, cli)?;
     builder = configure_proxy(builder, cli.proxy.as_deref(), http_version, url)?;
     if let Some(timeout) =
         TimeoutBudget::started_at(context.request_timeout, context.request_start).remaining()?
@@ -309,7 +310,7 @@ async fn resolve_dns_for_client_inner(
                 .flatten()
                 .unwrap_or(Duration::from_secs(5));
             let https_records = lookup_ech_https_records(Some(dns_server), host, ech_timeout).await;
-            let addrs = custom::lookup_ips(dns_server, host, timeout.timeout()).await;
+            let addrs = lookup_custom_ips_with_doh_tls(cli, dns_server, host, timeout).await;
             (addrs?, https_records)
         } else if let Some(auto_http3_budget) = auto_http3_discovery {
             let https = spawn_auto_http3_https_records(
@@ -317,12 +318,12 @@ async fn resolve_dns_for_client_inner(
                 host.to_string(),
                 Some(auto_http3_budget),
             );
-            let addrs = custom::lookup_ips(dns_server, host, timeout.timeout()).await;
+            let addrs = lookup_custom_ips_with_doh_tls(cli, dns_server, host, timeout).await;
             let https_records = take_finished_auto_http3_https_records(https).await;
             (addrs?, https_records)
         } else {
             (
-                custom::lookup_ips(dns_server, host, timeout.timeout()).await?,
+                lookup_custom_ips_with_doh_tls(cli, dns_server, host, timeout).await?,
                 Vec::new(),
             )
         };
@@ -330,6 +331,7 @@ async fn resolve_dns_for_client_inner(
         let socket_addrs = custom::socket_addrs_for_override(&addrs);
         let auto_http3_config = auto_http3_config_for_records(
             Some(dns_server),
+            doh_tls_config_for_cli(cli)?,
             url,
             &https_records,
             &socket_addrs,
@@ -414,6 +416,7 @@ async fn resolve_dns_for_client_inner(
     };
     let addrs = dns_timing_addrs(socket_addrs.iter().map(|addr| addr.ip()));
     let auto_http3_config = auto_http3_config_for_records(
+        None,
         None,
         url,
         &https_records,
@@ -611,8 +614,15 @@ fn auto_http3_allowed(
             .is_some_and(|host| host.parse::<IpAddr>().is_err())
 }
 
+#[derive(Clone)]
+struct AutoHttp3ResolveConfig<'a> {
+    dns_server: Option<&'a str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
+}
+
 async fn auto_http3_config_for_records(
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     url: &Url,
     records: &[SvcbRecord],
     origin_addrs: &[SocketAddr],
@@ -631,7 +641,10 @@ async fn auto_http3_config_for_records(
         }
         let port = record.port.unwrap_or(origin_port);
         let record_addrs = auto_http3_record_addrs(
-            dns_server,
+            AutoHttp3ResolveConfig {
+                dns_server,
+                doh_tls_config: doh_tls_config.clone(),
+            },
             origin_host,
             record,
             origin_addrs,
@@ -647,7 +660,7 @@ async fn auto_http3_config_for_records(
 }
 
 async fn auto_http3_record_addrs(
-    dns_server: Option<&str>,
+    resolver: AutoHttp3ResolveConfig<'_>,
     origin_host: &str,
     record: &SvcbRecord,
     origin_addrs: &[SocketAddr],
@@ -678,7 +691,12 @@ async fn auto_http3_record_addrs(
     };
     let timeout = TimeoutBudget::new(Some(timeout));
     let Ok(mut addrs) = timeout
-        .run(crate::net::resolve_host(&target, dns_server, timeout))
+        .run(crate::net::resolve_host_with_doh_tls(
+            &target,
+            resolver.dns_server,
+            resolver.doh_tls_config,
+            timeout,
+        ))
         .await
     else {
         return Vec::new();
@@ -833,6 +851,65 @@ pub(crate) fn configure_tls(
         ech_mode,
     )?);
     Ok(builder)
+}
+
+fn configure_doh_tls(mut builder: ClientBuilder, cli: &Cli) -> Result<ClientBuilder, FetchError> {
+    if let Some(config) = doh_tls_config_for_cli(cli)? {
+        builder = builder.doh_tls_config(config);
+    }
+    Ok(builder)
+}
+
+async fn lookup_custom_ips_with_doh_tls(
+    cli: &Cli,
+    dns_server: &str,
+    host: &str,
+    timeout: TimeoutBudget,
+) -> Result<Vec<IpAddr>, FetchError> {
+    if dns_server.starts_with("http://") || dns_server.starts_with("https://") {
+        return crate::net::resolve_host_with_doh_tls(
+            host,
+            Some(dns_server),
+            doh_tls_config_for_cli(cli)?,
+            timeout,
+        )
+        .await
+        .map(|addrs| addrs.into_iter().map(|addr| addr.ip()).collect());
+    }
+    custom::lookup_ips(dns_server, host, timeout.timeout()).await
+}
+
+pub(crate) fn doh_tls_config_for_cli(
+    cli: &Cli,
+) -> Result<Option<rustls::ClientConfig>, FetchError> {
+    let Some(dns_server) = cli.dns_server.as_deref() else {
+        return Ok(None);
+    };
+    if !(dns_server.starts_with("http://") || dns_server.starts_with("https://")) {
+        return Ok(None);
+    }
+    let min_tls = cli.min_tls.as_deref().or(cli.tls.as_deref());
+    let min_tls_option = min_tls.map(|value| {
+        if cli.min_tls.is_some() {
+            ("min-tls", value)
+        } else {
+            ("tls", value)
+        }
+    });
+    crate::tls::ensure_rustls_supported_range(min_tls_option, cli.max_tls.as_deref())?;
+    // DoH uses request TLS trust/version options, but intentionally does not
+    // attach origin client certificates to the resolver.
+    Ok(Some(
+        crate::tls::rustls_platform_client_config_with_options(
+            &cli.ca_cert,
+            None,
+            None,
+            cli.insecure,
+            min_tls_option,
+            cli.max_tls.as_deref(),
+            None,
+        )?,
+    ))
 }
 
 fn should_configure_tls(cli: &Cli, url: &Url) -> bool {
@@ -1258,6 +1335,7 @@ mod tests {
 
         let got = auto_http3_config_for_records(
             None,
+            None,
             &url,
             &records,
             &origin_addrs,
@@ -1285,6 +1363,7 @@ mod tests {
 
         let ipv4_first = auto_http3_config_for_records(
             None,
+            None,
             &url,
             &[record.clone()],
             &[
@@ -1308,6 +1387,7 @@ mod tests {
         );
 
         let ipv6_first = auto_http3_config_for_records(
+            None,
             None,
             &url,
             &[record],
@@ -1339,6 +1419,7 @@ mod tests {
         assert!(
             auto_http3_config_for_records(
                 None,
+                None,
                 &url,
                 &[],
                 &origin_addrs,
@@ -1350,6 +1431,7 @@ mod tests {
         );
         assert!(
             auto_http3_config_for_records(
+                None,
                 None,
                 &url,
                 &[https_record(1, ".", &["h2"], None)],
@@ -1364,6 +1446,7 @@ mod tests {
         unsupported.unsupported_mandatory = vec![9];
         assert!(
             auto_http3_config_for_records(
+                None,
                 None,
                 &url,
                 &[unsupported],
@@ -1383,6 +1466,7 @@ mod tests {
 
         assert!(
             auto_http3_config_for_records(
+                None,
                 None,
                 &url,
                 &[https_record(1, "h3.example.com.", &["h3"], None)],

--- a/src/http/transport/client.rs
+++ b/src/http/transport/client.rs
@@ -56,6 +56,7 @@ pub(super) struct ClientConfig {
     pub(super) dns_overrides: HashMap<String, Vec<SocketAddr>>,
     pub(super) proxies: Vec<Proxy>,
     pub(super) tls_config: Option<rustls::ClientConfig>,
+    pub(super) doh_tls_config: Option<rustls::ClientConfig>,
     pub(super) request_timeout: Option<Duration>,
     pub(super) request_timeout_message: Option<String>,
     pub(super) connect_timeout: Option<Duration>,
@@ -90,6 +91,7 @@ impl Client {
                 dns_overrides: HashMap::new(),
                 proxies: Vec::new(),
                 tls_config: None,
+                doh_tls_config: None,
                 request_timeout: None,
                 request_timeout_message: None,
                 connect_timeout: None,
@@ -473,6 +475,11 @@ impl ClientBuilder {
         self
     }
 
+    pub(crate) fn doh_tls_config(mut self, config: rustls::ClientConfig) -> Self {
+        self.config.doh_tls_config = Some(config);
+        self
+    }
+
     pub(crate) fn connect_timeout(mut self, timeout: Duration) -> Self {
         self.config.connect_timeout = Some(timeout);
         self
@@ -606,7 +613,13 @@ pub(super) async fn connect_direct_tcp_config(
             tcp_duration: tcp_start.elapsed(),
         });
     }
-    crate::net::connect_tcp_traced(url, config.dns_server.as_deref(), timeout).await
+    crate::net::connect_tcp_traced_with_doh_tls(
+        url,
+        config.dns_server.as_deref(),
+        config.doh_tls_config.clone(),
+        timeout,
+    )
+    .await
 }
 
 pub(super) fn record_dns_trace(

--- a/src/http/transport/h3.rs
+++ b/src/http/transport/h3.rs
@@ -178,8 +178,12 @@ impl Client {
         discovery_start: std::time::Instant,
         timeout: TimeoutBudget,
     ) -> DynamicHttp3ConnectOutcome {
-        let origin_addrs_task =
-            spawn_auto_http3_origin_addrs(self.config.dns_server.clone(), host.clone(), timeout);
+        let origin_addrs_task = spawn_auto_http3_origin_addrs(
+            self.config.dns_server.clone(),
+            host.clone(),
+            self.config.doh_tls_config.clone(),
+            timeout,
+        );
         let records =
             lookup_auto_http3_https_records(self.config.dns_server.as_deref(), &host, timeout)
                 .await;
@@ -193,6 +197,7 @@ impl Client {
         let origin_addrs = take_finished_auto_http3_origin_addrs(origin_addrs_task).await;
         let addrs = auto_http3_addrs_for_records(
             self.config.dns_server.as_deref(),
+            self.config.doh_tls_config.clone(),
             url,
             &records,
             &origin_addrs,
@@ -472,10 +477,11 @@ fn record_dynamic_http3_outcome(
 pub(super) fn spawn_auto_http3_origin_addrs(
     dns_server: Option<String>,
     host: String,
+    doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> JoinHandle<Vec<SocketAddr>> {
     tokio::spawn(async move {
-        crate::net::resolve_host(&host, dns_server.as_deref(), timeout)
+        crate::net::resolve_host_with_doh_tls(&host, dns_server.as_deref(), doh_tls_config, timeout)
             .await
             .unwrap_or_default()
     })
@@ -527,6 +533,7 @@ fn auto_http3_lookup_timeout(timeout: TimeoutBudget) -> Option<Duration> {
 
 async fn auto_http3_addrs_for_records(
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     url: &Url,
     records: &[SvcbRecord],
     origin_addrs: &[SocketAddr],
@@ -556,12 +563,17 @@ async fn auto_http3_addrs_for_records(
                     .map(|addr| SocketAddr::new(addr.ip(), port))
                     .collect();
             } else if target.eq_ignore_ascii_case(origin_host) {
-                record_addrs = crate::net::resolve_host(origin_host, dns_server, timeout)
-                    .await
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|addr| SocketAddr::new(addr.ip(), port))
-                    .collect();
+                record_addrs = crate::net::resolve_host_with_doh_tls(
+                    origin_host,
+                    dns_server,
+                    doh_tls_config.clone(),
+                    timeout,
+                )
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|addr| SocketAddr::new(addr.ip(), port))
+                .collect();
             } else if let Ok(ip) = target.parse::<IpAddr>() {
                 record_addrs.push(SocketAddr::new(ip, port));
             }
@@ -573,6 +585,7 @@ async fn auto_http3_addrs_for_records(
 
 async fn auto_http3_addrs_for_cached_candidates(
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     candidates: &[Http3CacheCandidate],
     timeout: TimeoutBudget,
 ) -> Vec<SocketAddr> {
@@ -583,12 +596,17 @@ async fn auto_http3_addrs_for_cached_candidates(
         let record_addrs = if let Ok(ip) = candidate.alt_host.parse::<IpAddr>() {
             vec![SocketAddr::new(ip, candidate.alt_port)]
         } else {
-            crate::net::resolve_host(&candidate.alt_host, dns_server, timeout)
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .map(|addr| SocketAddr::new(addr.ip(), candidate.alt_port))
-                .collect()
+            crate::net::resolve_host_with_doh_tls(
+                &candidate.alt_host,
+                dns_server,
+                doh_tls_config.clone(),
+                timeout,
+            )
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|addr| SocketAddr::new(addr.ip(), candidate.alt_port))
+            .collect()
         };
         append_unique_socket_addrs(&mut addrs, record_addrs);
     }
@@ -796,6 +814,7 @@ impl Client {
         let cache = self.config.http3_cache.as_ref()?;
         let addrs = auto_http3_addrs_for_cached_candidates(
             self.config.dns_server.as_deref(),
+            self.config.doh_tls_config.clone(),
             &candidates,
             timeout,
         )
@@ -832,15 +851,20 @@ impl Client {
             (addrs, None)
         } else {
             let dns_start = std::time::Instant::now();
-            let addrs = crate::net::resolve_host(host, self.config.dns_server.as_deref(), timeout)
-                .await
-                .map_err(|err| Error::from_fetch(ErrorKind::Connect, err))?
-                .into_iter()
-                .map(|mut addr| {
-                    addr.set_port(port);
-                    addr
-                })
-                .collect();
+            let addrs = crate::net::resolve_host_with_doh_tls(
+                host,
+                self.config.dns_server.as_deref(),
+                self.config.doh_tls_config.clone(),
+                timeout,
+            )
+            .await
+            .map_err(|err| Error::from_fetch(ErrorKind::Connect, err))?
+            .into_iter()
+            .map(|mut addr| {
+                addr.set_port(port);
+                addr
+            })
+            .collect();
             (addrs, Some(dns_start.elapsed()))
         };
         if let Some(duration) = dns_duration {

--- a/src/http/transport/proxy.rs
+++ b/src/http/transport/proxy.rs
@@ -69,10 +69,16 @@ pub(super) async fn dial_stream_for_config(
                 .map(|stream| (stream, false, true, None, None))
                 .map_err(|err| Error::from_fetch(ErrorKind::Connect, err))
         }
-        Some(proxy) => crate::net::dial_proxy(&proxy.url, url, None, timeout)
-            .await
-            .map(|stream| (stream, false, true, None, None))
-            .map_err(|err| Error::from_fetch(ErrorKind::Connect, err)),
+        Some(proxy) => crate::net::dial_proxy(
+            &proxy.url,
+            url,
+            config.dns_server.as_deref(),
+            config.doh_tls_config.clone(),
+            timeout,
+        )
+        .await
+        .map(|stream| (stream, false, true, None, None))
+        .map_err(|err| Error::from_fetch(ErrorKind::Connect, err)),
         None if config.unix_socket.is_some() => {
             #[cfg(unix)]
             {

--- a/src/http/transport/tests.rs
+++ b/src/http/transport/tests.rs
@@ -154,6 +154,7 @@ async fn dynamic_auto_http3_origin_preference_lookup_allows_custom_dns() {
     let handle = spawn_auto_http3_origin_addrs(
         Some("https://dns.example/dns-query".to_string()),
         "192.0.2.1".to_string(),
+        None,
         TimeoutBudget::new(None),
     );
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -60,28 +60,31 @@ pub(crate) async fn dial_url(
     url: &Url,
     proxy: Option<&str>,
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<DialStream, FetchError> {
     if let Some(proxy) = proxy {
-        return dial_proxy(proxy, url, dns_server, timeout).await;
+        return dial_proxy(proxy, url, dns_server, doh_tls_config, timeout).await;
     }
-    let stream = connect_tcp(url, dns_server, timeout).await?;
+    let stream = connect_tcp_with_doh_tls(url, dns_server, doh_tls_config, timeout).await?;
     Ok(Box::pin(stream))
 }
 
-pub(crate) async fn connect_tcp(
+pub(crate) async fn connect_tcp_with_doh_tls(
     url: &Url,
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<TcpStream, FetchError> {
-    connect_tcp_traced(url, dns_server, timeout)
+    connect_tcp_traced_with_doh_tls(url, dns_server, doh_tls_config, timeout)
         .await
         .map(|trace| trace.stream)
 }
 
-pub(crate) async fn connect_tcp_traced(
+pub(crate) async fn connect_tcp_traced_with_doh_tls(
     url: &Url,
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<TcpConnectTrace, FetchError> {
     let host = url
@@ -107,16 +110,20 @@ pub(crate) async fn connect_tcp_traced(
 
     timeout_fetch(
         timeout,
-        connect_host_happy_eyeballs_traced(host, port, dns_server, timeout),
+        connect_host_happy_eyeballs_traced(host, port, dns_server, doh_tls_config, timeout),
     )
     .await
 }
 
-pub(crate) async fn resolve_host(
+pub(crate) async fn resolve_host_with_doh_tls(
     host: &str,
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<Vec<SocketAddr>, FetchError> {
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return Ok(vec![SocketAddr::new(ip, 0)]);
+    }
     let Some(dns_server) = dns_server else {
         return tokio::net::lookup_host((host, 0))
             .await
@@ -124,7 +131,12 @@ pub(crate) async fn resolve_host(
             .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")));
     };
 
-    let addrs = crate::dns::custom::lookup_ips(dns_server, host, timeout.remaining()?).await?;
+    let addrs = if is_doh_dns_server(dns_server) {
+        let shared_doh = shared_doh_resolver(dns_server, host, timeout, doh_tls_config.as_ref())?;
+        resolve_doh_ips(host, dns_server, Some(&shared_doh), timeout).await?
+    } else {
+        crate::dns::custom::lookup_ips(dns_server, host, timeout.remaining()?).await?
+    };
     Ok(addrs
         .into_iter()
         .map(|addr| SocketAddr::new(addr, 0))
@@ -234,17 +246,16 @@ async fn resolve_custom_host_family(
 }
 
 fn shared_doh_resolver(
-    dns_server: Option<&str>,
+    dns_server: &str,
     host: &str,
     timeout: TimeoutBudget,
-) -> Result<Option<SharedDohResolver>, FetchError> {
-    let Some(dns_server) = dns_server.filter(|server| is_doh_dns_server(server)) else {
-        return Ok(None);
-    };
+    doh_tls_config: Option<&rustls::ClientConfig>,
+) -> Result<SharedDohResolver, FetchError> {
     let server_url = parse_doh_dns_server(dns_server)?;
-    let client = crate::dns::doh::client_with_budget(timeout)
-        .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?;
-    Ok(Some(SharedDohResolver { server_url, client }))
+    let client =
+        crate::dns::doh::client_with_budget_and_tls_config(timeout, doh_tls_config.cloned())
+            .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?;
+    Ok(SharedDohResolver { server_url, client })
 }
 
 fn is_doh_dns_server(dns_server: &str) -> bool {
@@ -254,6 +265,46 @@ fn is_doh_dns_server(dns_server: &str) -> bool {
 fn parse_doh_dns_server(dns_server: &str) -> Result<Url, FetchError> {
     Url::parse(dns_server)
         .map_err(|err| FetchError::Message(format!("invalid dns-server '{dns_server}': {err}")))
+}
+
+async fn resolve_doh_ips(
+    host: &str,
+    dns_server: &str,
+    shared_doh: Option<&SharedDohResolver>,
+    timeout: TimeoutBudget,
+) -> Result<Vec<IpAddr>, FetchError> {
+    let (ipv4, ipv6) = tokio::join!(
+        resolve_doh_host_family(
+            host,
+            dns_server,
+            shared_doh,
+            "A",
+            crate::dns::wire::TYPE_A,
+            timeout,
+        ),
+        resolve_doh_host_family(
+            host,
+            dns_server,
+            shared_doh,
+            "AAAA",
+            crate::dns::wire::TYPE_AAAA,
+            timeout,
+        )
+    );
+
+    let mut addrs = Vec::new();
+    if let Ok(records) = &ipv4 {
+        addrs.extend(records.iter().copied());
+    }
+    if let Ok(records) = &ipv6 {
+        addrs.extend(records.iter().copied());
+    }
+    if !addrs.is_empty() {
+        return Ok(addrs);
+    }
+    ipv4?;
+    ipv6?;
+    Err(FetchError::Runtime(format!("lookup {host}: no such host")))
 }
 
 async fn resolve_doh_host_family(
@@ -479,9 +530,18 @@ pub(crate) async fn connect_host_happy_eyeballs_traced(
     host: &str,
     port: u16,
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<TcpConnectTrace, FetchError> {
-    let shared_doh = shared_doh_resolver(dns_server, host, timeout)?;
+    let shared_doh = match dns_server.filter(|s| is_doh_dns_server(s)) {
+        Some(server) => Some(shared_doh_resolver(
+            server,
+            host,
+            timeout,
+            doh_tls_config.as_ref(),
+        )?),
+        None => None,
+    };
     let dns_start = Instant::now();
     let mut ipv4 = Box::pin(resolve_host_family(
         host,
@@ -904,6 +964,7 @@ pub(crate) async fn dial_proxy(
     proxy: &str,
     target: &Url,
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<DialStream, FetchError> {
     let proxy_url = parse_proxy_url(proxy)?;
@@ -911,7 +972,9 @@ pub(crate) async fn dial_proxy(
         "http" | "https" => {
             dial_http_proxy_tunnel(proxy, &proxy_url, target, timeout, None, None).await
         }
-        "socks5" | "socks5h" => dial_socks5_proxy(&proxy_url, target, dns_server, timeout).await,
+        "socks5" | "socks5h" => {
+            dial_socks5_proxy(&proxy_url, target, dns_server, doh_tls_config, timeout).await
+        }
         scheme => Err(FetchError::Message(format!(
             "invalid proxy '{proxy}': unsupported proxy scheme '{scheme}'"
         ))),
@@ -1086,6 +1149,7 @@ pub(crate) async fn dial_socks5_proxy(
     proxy_url: &Url,
     target: &Url,
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<DialStream, FetchError> {
     let stream = connect_socks5_proxy(proxy_url, timeout).await?;
@@ -1097,6 +1161,7 @@ pub(crate) async fn dial_socks5_proxy(
             proxy_url.scheme() == "socks5h",
             target,
             dns_server,
+            doh_tls_config,
             timeout,
         ),
     )
@@ -1240,6 +1305,7 @@ async fn write_socks5_target(
     remote_dns: bool,
     target: &Url,
     dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<(), FetchError> {
     let host = target
@@ -1261,7 +1327,7 @@ async fn write_socks5_target(
     } else if let Ok(ip) = host.parse::<IpAddr>() {
         write_socks5_ip(request, ip);
     } else {
-        let addr = resolve_host(host, dns_server, timeout)
+        let addr = resolve_host_with_doh_tls(host, dns_server, doh_tls_config, timeout)
             .await?
             .into_iter()
             .next()

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -228,9 +228,14 @@ async fn dial_websocket(
         url,
         cli.proxy.as_deref(),
         cli.dns_server.as_deref(),
+        websocket_doh_tls_config(cli)?,
         timeout,
     ))
     .await
+}
+
+fn websocket_doh_tls_config(cli: &Cli) -> Result<Option<rustls::ClientConfig>, FetchError> {
+    crate::http::client::doh_tls_config_for_cli(cli)
 }
 
 fn websocket_request_timeout(cli: &Cli) -> Result<Option<Duration>, FetchError> {
@@ -1071,6 +1076,7 @@ mod tests {
         let stream = crate::net::dial_socks5_proxy(
             &proxy_url,
             &target,
+            None,
             None,
             TimeoutBudget::new(Some(Duration::from_secs(5))),
         )


### PR DESCRIPTION
## Summary

Propagate request-level TLS options (CA, min/max version, insecure) to DNS-over-HTTPS resolvers so custom DoH servers respect the same TLS trust and version policy as the origin connection.

## Changes

- **`src/dns/doh.rs`** — Add `client_with_budget_and_tls_config` accepting an optional `rustls::ClientConfig` for DoH clients
- **`src/http/client.rs`** — Add `doh_tls_config_for_cli` that builds a DoH TLS config from CLI options (CA, min/max TLS, insecure); thread it through auto HTTP/3 resolution and custom DNS lookup paths
- **`src/http/transport/client.rs`** — Add `doh_tls_config` field to `ClientConfig` and `ClientBuilder`
- **`src/http/transport/h3.rs`** — Pass DoH TLS config through H3/QUIC connection establishment and dynamic HTTP/3 discovery
- **`src/http/transport/proxy.rs`** — Pass DoH TLS config through proxy dialing
- **`src/net.rs`** — Refactor host resolution and TCP dialing to accept DoH TLS config; add `resolve_host_with_doh_tls`, `connect_tcp_with_doh_tls`, and `resolve_doh_ips` helpers
- **`src/websocket/mod.rs`** — Pass DoH TLS config for WebSocket connection dialing

## Validation

- `cargo fmt` ✅
- `cargo clippy --locked --all-targets --all-features -- -D warnings` ✅
- `cargo test --locked --all-features --lib --bins` — 838 passed, 0 failed ✅