### PR TITLE
fix: preserve methods across 301 and 302 redirects

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -231,7 +231,6 @@ async fn execute_inner(cli: &Cli) -> Result<i32, FetchError> {
         let mut request_url = url.clone();
         let mut request_body = body.clone();
         let mut request_client = initial_client.clone();
-        let mut redirect_statuses = Vec::new();
         let mut redirect_count = 0_usize;
         let mut protocol_nack_retries = 0_usize;
         let mut strip_entity_headers = false;
@@ -288,7 +287,6 @@ async fn execute_inner(cli: &Cli) -> Result<i32, FetchError> {
                         timing.mark_response_headers();
                         timing.set_transport(connect_timing.timing());
                         print_redirect_status(cli, &response);
-                        redirect_statuses.push(response.status());
                         let redirected =
                             redirected_request(request_method, request_body, response.status())?;
                         let refresh_client = redirect_requires_client_refresh(
@@ -347,7 +345,6 @@ async fn execute_inner(cli: &Cli) -> Result<i32, FetchError> {
                         headers: headers.clone(),
                         body: request_body.clone(),
                         cli,
-                        redirect_statuses,
                         strip_entity_headers,
                         auth_allowed: same_origin(&url, &request_url),
                     },

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -198,7 +198,6 @@ pub(super) struct DigestRetryContext<'a> {
     pub(super) headers: HeaderMap,
     pub(super) body: RequestBody,
     pub(super) cli: &'a Cli,
-    pub(super) redirect_statuses: Vec<StatusCode>,
     pub(super) strip_entity_headers: bool,
     pub(super) auth_allowed: bool,
 }
@@ -231,8 +230,8 @@ pub(super) async fn apply_digest_challenge(
     let challenge = digest::parse_challenge(&challenge).map_err(digest_challenge_error)?;
 
     let challenged_url = response.url().clone();
-    let (challenged_method, challenged_body) =
-        digest_challenged_request(context.method, context.body, &context.redirect_statuses);
+    let challenged_method = context.method;
+    let challenged_body = context.body;
     let auth = match digest::response(
         challenged_method.as_str(),
         &request_target(&challenged_url),
@@ -320,30 +319,6 @@ pub(super) fn response_connection_close(response: &Response) -> bool {
         .filter_map(|value| value.to_str().ok())
         .flat_map(|value| value.split(','))
         .any(|token| token.trim().eq_ignore_ascii_case("close"))
-}
-
-pub(super) fn digest_challenged_request(
-    original_method: Method,
-    original_body: RequestBody,
-    redirect_statuses: &[StatusCode],
-) -> (Method, RequestBody) {
-    let mut method = original_method;
-    let mut body = original_body;
-
-    for status in redirect_statuses {
-        match *status {
-            StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND | StatusCode::SEE_OTHER => {
-                if method != Method::GET && method != Method::HEAD {
-                    method = Method::GET;
-                }
-                body = None;
-            }
-            StatusCode::TEMPORARY_REDIRECT | StatusCode::PERMANENT_REDIRECT => {}
-            _ => {}
-        }
-    }
-
-    (method, body)
 }
 
 pub(super) fn digest_credentials(
@@ -1212,38 +1187,6 @@ mod tests {
         );
         assert!(digest_credentials(Some("nocolon")).is_err());
         assert_eq!(digest_credentials(None).unwrap(), None);
-    }
-
-    #[test]
-    fn digest_challenge_after_redirect_uses_go_redirect_method_and_body() {
-        let original_body = Some(RequestBodyPayload::from_bytes(
-            b"payload".to_vec(),
-            Some("text/plain".to_string()),
-        ));
-
-        let (method, body) = digest_challenged_request(
-            Method::POST,
-            original_body.clone(),
-            &[StatusCode::SEE_OTHER],
-        );
-        assert_eq!(method, Method::GET);
-        assert!(body.is_none());
-
-        let (method, body) = digest_challenged_request(
-            Method::POST,
-            original_body.clone(),
-            &[StatusCode::TEMPORARY_REDIRECT],
-        );
-        assert_eq!(method, Method::POST);
-        assert_eq!(request_body_bytes(&body), Some(b"payload".as_slice()));
-
-        let (method, body) = digest_challenged_request(
-            Method::HEAD,
-            original_body,
-            &[StatusCode::MOVED_PERMANENTLY],
-        );
-        assert_eq!(method, Method::HEAD);
-        assert!(body.is_none());
     }
 
     #[test]

--- a/src/http/retry.rs
+++ b/src/http/retry.rs
@@ -187,14 +187,22 @@ pub(super) fn redirected_request(
 ) -> Result<RedirectedRequest, FetchError> {
     let mut strip_entity_headers = false;
     match status {
-        StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND | StatusCode::SEE_OTHER => {
-            if method != Method::GET && method != Method::HEAD {
+        StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND if method == Method::POST => {
+            method = Method::GET;
+            body = None;
+            strip_entity_headers = true;
+        }
+        StatusCode::SEE_OTHER => {
+            if method != Method::HEAD {
                 method = Method::GET;
             }
             body = None;
             strip_entity_headers = true;
         }
-        StatusCode::TEMPORARY_REDIRECT | StatusCode::PERMANENT_REDIRECT
+        StatusCode::MOVED_PERMANENTLY
+        | StatusCode::FOUND
+        | StatusCode::TEMPORARY_REDIRECT
+        | StatusCode::PERMANENT_REDIRECT
             if !request_body_replayable(&body) =>
         {
             return Err(FetchError::Runtime(
@@ -509,23 +517,97 @@ pub(crate) fn total_attempts_for_retry(retry_count: usize) -> Result<usize, Fetc
 mod tests {
     use super::*;
 
-    #[test]
-    fn redirected_post_to_get_marks_entity_headers_for_stripping() {
-        let original_body = Some(RequestBodyPayload::from_bytes(
+    fn test_body() -> RequestBody {
+        Some(RequestBodyPayload::from_bytes(
             b"payload".to_vec(),
             Some("text/plain".to_string()),
-        ));
+        ))
+    }
 
+    #[test]
+    fn redirect_method_and_body_semantics() {
+        for status in [StatusCode::MOVED_PERMANENTLY, StatusCode::FOUND] {
+            let redirected = redirected_request(Method::POST, test_body(), status).unwrap();
+            assert_eq!(redirected.method, Method::GET);
+            assert!(redirected.body.is_none());
+            assert!(redirected.strip_entity_headers);
+
+            for method in [Method::PUT, Method::PATCH, Method::DELETE, Method::GET] {
+                let redirected = redirected_request(method.clone(), test_body(), status).unwrap();
+                assert_eq!(redirected.method, method);
+                assert!(redirected.body.is_some());
+                assert!(!redirected.strip_entity_headers);
+            }
+        }
+
+        for method in [Method::POST, Method::PUT, Method::PATCH, Method::DELETE] {
+            let redirected =
+                redirected_request(method, test_body(), StatusCode::SEE_OTHER).unwrap();
+            assert_eq!(redirected.method, Method::GET);
+            assert!(redirected.body.is_none());
+            assert!(redirected.strip_entity_headers);
+        }
         let redirected =
-            redirected_request(Method::POST, original_body, StatusCode::FOUND).unwrap();
-        assert_eq!(redirected.method, Method::GET);
+            redirected_request(Method::HEAD, test_body(), StatusCode::SEE_OTHER).unwrap();
+        assert_eq!(redirected.method, Method::HEAD);
         assert!(redirected.body.is_none());
         assert!(redirected.strip_entity_headers);
 
-        let preserved =
-            redirected_request(Method::POST, None, StatusCode::TEMPORARY_REDIRECT).unwrap();
-        assert_eq!(preserved.method, Method::POST);
-        assert!(!preserved.strip_entity_headers);
+        for status in [
+            StatusCode::TEMPORARY_REDIRECT,
+            StatusCode::PERMANENT_REDIRECT,
+        ] {
+            for method in [
+                Method::GET,
+                Method::POST,
+                Method::PUT,
+                Method::PATCH,
+                Method::DELETE,
+                Method::HEAD,
+            ] {
+                let redirected = redirected_request(method.clone(), test_body(), status).unwrap();
+                assert_eq!(redirected.method, method);
+                assert!(redirected.body.is_some());
+                assert!(!redirected.strip_entity_headers);
+            }
+        }
+    }
+
+    #[test]
+    fn redirect_rejects_stdin_when_body_must_be_preserved() {
+        for status in [
+            StatusCode::MOVED_PERMANENTLY,
+            StatusCode::FOUND,
+            StatusCode::TEMPORARY_REDIRECT,
+            StatusCode::PERMANENT_REDIRECT,
+        ] {
+            let body = Some(RequestBodyPayload {
+                source: RequestBodySource::Stdin,
+                content_type: None,
+            });
+            let err = redirected_request(Method::PUT, body, status)
+                .err()
+                .expect("stdin-backed redirect should fail");
+            assert!(err.to_string().contains("cannot be replayed for redirect"));
+        }
+
+        // Rewrites do not need to replay stdin.
+        for status in [
+            StatusCode::MOVED_PERMANENTLY,
+            StatusCode::FOUND,
+            StatusCode::SEE_OTHER,
+        ] {
+            let body = Some(RequestBodyPayload {
+                source: RequestBodySource::Stdin,
+                content_type: None,
+            });
+            let method = if status == StatusCode::SEE_OTHER {
+                Method::PUT
+            } else {
+                Method::POST
+            };
+            assert!(redirected_request(method, body, status).is_ok());
+        }
     }
 
     #[test]

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -463,6 +463,47 @@ fn digest_auth_replays_after_challenge() {
 }
 
 #[test]
+fn digest_auth_preserves_put_body_after_found_redirect() {
+    let server = TestServer::start(|req| match req.path.as_str() {
+        "/start" => TestResponse::status(302, "Found", "").header("Location", "/target"),
+        "/target" if req.header("authorization").is_empty() => {
+            TestResponse::status(401, "Unauthorized", "").header(
+                "WWW-Authenticate",
+                r#"Digest realm="test", nonce="abc123", qop="auth", algorithm="MD5""#,
+            )
+        }
+        "/target" => TestResponse::ok("authenticated"),
+        _ => TestResponse::status(404, "Not Found", ""),
+    });
+
+    let res = run_fetch(&[
+        &format!("{}/start", server.url),
+        "--method",
+        "PUT",
+        "--data",
+        "payload",
+        "--digest",
+        "user:pass",
+    ]);
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "authenticated");
+
+    let requests = server.requests.lock().unwrap();
+    assert_eq!(requests.len(), 3, "requests: {requests:?}");
+    assert_eq!(requests[0].path, "/start");
+    for request in &requests[1..] {
+        assert_eq!(request.path, "/target");
+        assert_eq!(request.method, "PUT");
+        assert_eq!(request.body_string(), "payload");
+    }
+    assert!(requests[1].header("authorization").is_empty());
+    assert!(
+        requests[2].header("authorization").starts_with("Digest "),
+        "requests: {requests:?}"
+    );
+}
+
+#[test]
 fn digest_auth_reports_unsupported_qop_challenge() {
     let challenged = Arc::new(AtomicUsize::new(0));
     let challenged_for_handler = Arc::clone(&challenged);


### PR DESCRIPTION
## Summary
- rewrite only POST requests to GET for 301 and 302 redirects
- preserve non-POST methods and replayable bodies across redirects
- keep final redirected method and body during Digest authentication retries
- add redirect semantics and Digest integration regression coverage

## Validation
- `cargo fmt --check`
- `cargo test --locked --all-features --lib --bins`
- `cargo test --locked --all-features --test http digest_auth_preserves_put_body_after_found_redirect`