### PR TITLE
fix: retain digest retry client through response body

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -249,15 +249,17 @@ pub(super) async fn apply_digest_challenge(
     }
 
     let retry_before_drain = digest_retry_before_drain(&response);
-    let retry_client;
-    let client = if retry_before_drain {
-        retry_client =
+    let retry_client = if retry_before_drain {
+        Some(
             client::build_client_for_url(context.cli, &challenged_url, context.client_build)
-                .await?;
-        &retry_client.client
+                .await?,
+        )
     } else {
-        context.client
+        None
     };
+    let client = retry_client
+        .as_ref()
+        .map_or(context.client, |client| &client.client);
     let retry_request = build_request(
         client,
         challenged_method,
@@ -277,7 +279,16 @@ pub(super) async fn apply_digest_challenge(
         let retry_response: Result<Response, FetchError> =
             retry_request.send().await.map_err(Into::into);
         drop(response);
-        retry_response
+        retry_response.map(|mut response| {
+            // The temporary client's pool owns the connection task. Retain it until the
+            // response body is consumed so dropping the pool cannot cancel that body.
+            response.keep_client_alive(
+                retry_client
+                    .expect("retry-before-drain builds a fresh client")
+                    .client,
+            );
+            response
+        })
     } else {
         drain_response_body_bounded(response).await;
         retry_request.send().await.map_err(Into::into)

--- a/src/http/transport/body.rs
+++ b/src/http/transport/body.rs
@@ -135,6 +135,7 @@ pub(crate) struct Response {
     body: Body,
     body_deadline: Option<BodyDeadline>,
     remote_addr: Option<SocketAddr>,
+    _client_keepalive: Option<super::client::Client>,
 }
 
 impl Response {
@@ -166,6 +167,7 @@ impl Response {
             body: Body::map_incoming(body),
             body_deadline,
             remote_addr,
+            _client_keepalive: None,
         }
     }
 
@@ -196,6 +198,7 @@ impl Response {
             }),
             body_deadline,
             remote_addr: Some(remote_addr),
+            _client_keepalive: None,
         }
     }
 
@@ -224,6 +227,10 @@ impl Response {
 
     pub(crate) fn remote_addr(&self) -> Option<SocketAddr> {
         self.remote_addr
+    }
+
+    pub(in crate::http) fn keep_client_alive(&mut self, client: super::client::Client) {
+        self._client_keepalive = Some(client);
     }
 
     pub(crate) async fn chunk(&mut self) -> Result<Option<Bytes>, Error> {

--- a/src/http/transport/body.rs
+++ b/src/http/transport/body.rs
@@ -46,6 +46,7 @@ impl BodyDeadline {
 
 pub struct Body {
     inner: UnsyncBoxBody<Bytes, Error>,
+    _client_keepalive: Option<Box<super::client::Client>>,
 }
 
 impl Body {
@@ -66,7 +67,12 @@ impl Body {
     {
         Self {
             inner: BodyExt::boxed_unsync(body),
+            _client_keepalive: None,
         }
+    }
+
+    fn keep_client_alive(&mut self, client: super::client::Client) {
+        self._client_keepalive = Some(Box::new(client));
     }
 
     pub(super) fn map_incoming(body: Incoming) -> Self {
@@ -135,7 +141,6 @@ pub(crate) struct Response {
     body: Body,
     body_deadline: Option<BodyDeadline>,
     remote_addr: Option<SocketAddr>,
-    _client_keepalive: Option<super::client::Client>,
 }
 
 impl Response {
@@ -167,7 +172,6 @@ impl Response {
             body: Body::map_incoming(body),
             body_deadline,
             remote_addr,
-            _client_keepalive: None,
         }
     }
 
@@ -198,7 +202,6 @@ impl Response {
             }),
             body_deadline,
             remote_addr: Some(remote_addr),
-            _client_keepalive: None,
         }
     }
 
@@ -230,7 +233,7 @@ impl Response {
     }
 
     pub(in crate::http) fn keep_client_alive(&mut self, client: super::client::Client) {
-        self._client_keepalive = Some(client);
+        self.body.keep_client_alive(client);
     }
 
     pub(crate) async fn chunk(&mut self) -> Result<Option<Bytes>, Error> {


### PR DESCRIPTION
## Summary
- retain the temporary digest retry client until the authenticated response body is consumed
- prevent Hyper from canceling the retry connection when the temporary client pool is dropped
- preserve bounded cleanup for large digest challenge bodies

## Validation
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- digest drain integration test passed 20 consecutive runs