### PR TITLE
Harden install.sh replacement with atomic staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,4 @@ jobs:
         run: choco install protoc -y
 
       - name: Rust integration tests against Rust binary
-        run: cargo test --locked --all-features --test cli --test formatting --test grpc --test http --test network --test terminal --test update --test websocket -- --test-threads=1
+        run: cargo test --locked --all-features --test cli --test formatting --test grpc --test http --test install --test network --test terminal --test update --test websocket -- --test-threads=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Then run the narrowest relevant test, e.g.:
 ```bash
 cargo test --locked --all-features --test http request_construction_and_data_sources
 cargo test --locked --all-features image::
+cargo test --locked --all-features --test install
 ```
 
 Full CI-equivalent before PRs, shared transport/request/response changes, or unclear scope:
@@ -29,7 +30,7 @@ Full CI-equivalent before PRs, shared transport/request/response changes, or unc
 cargo fmt --check
 cargo clippy --locked --all-targets --all-features -- -D warnings
 cargo test --locked --all-features --lib --bins
-cargo test --locked --all-features --test cli --test formatting --test grpc --test http --test network --test terminal --test update --test websocket
+cargo test --locked --all-features --test cli --test formatting --test grpc --test http --test install --test network --test terminal --test update --test websocket
 ```
 
 The integration test suite uses `TcpListener::bind("127.0.0.1:0")` and
@@ -128,7 +129,7 @@ Request flow: CLI parse → config merge → request build (gRPC may load/reflec
 - `--inspect-tls --http 3` uses QUIC/TLS with `h3`; inspection honors `--dns-server`. Verified chain rendering may append/replace trusted roots for expiry display; `--insecure` shows raw peer chain.
 - Session saves lock per session, reload latest JSON, merge only local cookie changes, atomically replace, and warn on bounded lock wait. Update locks use `fileutil::FileLock`; background checks are nonblocking.
 - Self-update metadata/artifact/checksum/redirect URLs require HTTPS except internal test overrides; update networking must not inherit origin-specific TLS/version/Unix-socket config, but may keep proxy/DNS/timeouts/verbosity/custom CA. Artifacts stream with SHA-256; tar extracts streaming, zip uses temp archive; Unix replacement preserves atomic parent-dir sync.
-- `install.sh` verifies `.sha256`; completion install is opt-in (`--completions` or `FETCH_INSTALL_COMPLETIONS=1`) and must not auto-edit shell startup files by default.
+- `install.sh` verifies `.sha256`, validates a same-directory staged binary, and atomically renames it over the destination; completion install is opt-in (`--completions` or `FETCH_INSTALL_COMPLETIONS=1`) and must not auto-edit shell startup files by default.
 - Agent Skill files live under `skills/fetch/` and are embedded by `src/skill.rs`. User/project installs support generic `.agents/skills/fetch` plus distinct Codex, Claude, Gemini, and Pi directories, record `.fetch-skill.json` in each copy, use atomic file helpers and a parent-directory operation lock, revalidate before writes/deletions, refuse modified installs without `--force`, reject unrelated CLI options rather than silently ignoring them, and leave no lock/directory artifacts when uninstall targets are all missing. Never add network downloads or agent-config edits to skill installation.
 - Ctrl-C/SIGINT exits 130, including streaming modes. Output downloads keep `*.download` temps under a drop guard.
 - Rust is pinned to 1.97.0 (`rust-toolchain.toml`); keep `Cargo.toml` rust-version and CI aligned. Windows config search prefers XDG/HOME paths before AppData; Windows mTLS fixtures use RSA certs.

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,7 @@ Options:
 
 Environment:
   FETCH_INSTALL_COMPLETIONS=1 is equivalent to --completions.
+  FETCH_INSTALL_DIR overrides the installation directory.
 EOF
 }
 
@@ -247,7 +248,17 @@ fi
 
 # Create temporary directory.
 TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
+STAGED_PATH=""
+cleanup() {
+  rm -rf "$TMP_DIR"
+  if [ -n "$STAGED_PATH" ]; then
+    rm -f "$STAGED_PATH"
+  fi
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 BINARY_PATH="${TMP_DIR}/fetch"
 ARCHIVE_PATH="${BINARY_PATH}.tar.gz"
 CHECKSUM_PATH="${ARCHIVE_PATH}.sha256"
@@ -297,17 +308,51 @@ mv "$EXTRACTED" "$BINARY_PATH"
 chmod 755 "$BINARY_PATH"
 
 # Determine installation directory.
-if [ -w "/usr/local/bin" ]; then
+if [ -n "${FETCH_INSTALL_DIR:-}" ]; then
+  INSTALL_DIR="$FETCH_INSTALL_DIR"
+elif [ -w "/usr/local/bin" ]; then
   # Can write to /usr/local/bin.
   INSTALL_DIR="/usr/local/bin"
 else
   # Use home directory.
   INSTALL_DIR="$HOME/.local/bin"
-  mkdir -p "$INSTALL_DIR"
 fi
 
-mv "$BINARY_PATH" "$INSTALL_DIR/fetch"
-info "fetch successfully installed to '${DIM}${INSTALL_DIR}/fetch${RESET}'"
+if ! mkdir -p "$INSTALL_DIR"; then
+  error "unable to create installation directory '${INSTALL_DIR}'"
+  exit 1
+fi
+
+# Stage on the destination filesystem so replacing an existing installation is
+# one atomic rename. Keep STAGED_PATH set until the rename succeeds so the exit
+# trap removes partial copies after errors or interruption.
+if ! STAGED_PATH=$(mktemp "${INSTALL_DIR}/.fetch.install.XXXXXX"); then
+  error "unable to create temporary file in installation directory '${INSTALL_DIR}'"
+  exit 1
+fi
+if ! cp "$BINARY_PATH" "$STAGED_PATH"; then
+  error "unable to stage fetch in installation directory '${INSTALL_DIR}'"
+  exit 1
+fi
+if ! chmod 755 "$STAGED_PATH"; then
+  error "unable to make staged fetch executable"
+  exit 1
+fi
+if ! "$STAGED_PATH" --version > /dev/null 2>&1; then
+  error "downloaded fetch binary failed validation"
+  exit 1
+fi
+TARGET_PATH="$INSTALL_DIR/fetch"
+if [ -d "$TARGET_PATH" ]; then
+  error "installation destination '${TARGET_PATH}' is a directory"
+  exit 1
+fi
+if ! mv -f "$STAGED_PATH" "$TARGET_PATH"; then
+  error "unable to replace '${TARGET_PATH}'"
+  exit 1
+fi
+STAGED_PATH=""
+info "fetch successfully installed to '${DIM}${TARGET_PATH}${RESET}'"
 
 if [ "$INSTALL_COMPLETIONS" = true ]; then
   install_completions

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -1,0 +1,216 @@
+#![cfg(unix)]
+
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+const NEW_FETCH: &str =
+    "#!/bin/sh\nif [ \"${1:-}\" = --version ]; then\n  echo 'fetch test'\n  exit 0\nfi\n";
+
+struct InstallerFixture {
+    _temp: TempDir,
+    archive: PathBuf,
+    checksum: PathBuf,
+    home: PathBuf,
+    install_dir: PathBuf,
+    mock_bin: PathBuf,
+}
+
+impl InstallerFixture {
+    fn new(fail_stage_copy: bool) -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let payload = temp.path().join("payload");
+        let archive = temp.path().join("fetch.tar.gz");
+        let checksum = temp.path().join("fetch.tar.gz.sha256");
+        let home = temp.path().join("home");
+        let install_dir = temp.path().join("install");
+        let mock_bin = temp.path().join("bin");
+        fs::create_dir_all(&payload).unwrap();
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&install_dir).unwrap();
+        fs::create_dir_all(&mock_bin).unwrap();
+        write_executable(&payload.join("fetch"), NEW_FETCH);
+
+        let status = Command::new("tar")
+            .args(["-czf"])
+            .arg(&archive)
+            .arg("-C")
+            .arg(&payload)
+            .arg("fetch")
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        let digest = Sha256::digest(fs::read(&archive).unwrap());
+        let digest = digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        fs::write(&checksum, format!("{digest}  fetch.tar.gz\n")).unwrap();
+
+        write_executable(
+            &mock_bin.join("curl"),
+            r#"#!/bin/sh
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    out="$2"
+    shift 2
+  else
+    url="$1"
+    shift
+  fi
+done
+if [ -z "$out" ]; then
+  printf '%s\n' '{"tag_name":"vtest","assets":[]}'
+elif [ "${url##*.}" = "sha256" ]; then
+  command cat "$MOCK_CHECKSUM" > "$out"
+else
+  command cat "$MOCK_ARCHIVE" > "$out"
+fi
+"#,
+        );
+        write_executable(
+            &mock_bin.join("jq"),
+            r#"#!/bin/sh
+case "$*" in
+  *tag_name*) printf '%s\n' vtest ;;
+  *)
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--arg" ] && [ "$2" = "name" ]; then
+        printf 'https://example.invalid/%s\n' "$3"
+        exit 0
+      fi
+      shift
+    done
+    ;;
+esac
+"#,
+        );
+        if fail_stage_copy {
+            write_executable(
+                &mock_bin.join("cp"),
+                "#!/bin/sh\nprintf partial > \"$2\"\nexit 1\n",
+            );
+        }
+
+        Self {
+            _temp: temp,
+            archive,
+            checksum,
+            home,
+            install_dir,
+            mock_bin,
+        }
+    }
+
+    fn run(&self) -> Output {
+        let path = format!(
+            "{}:{}",
+            self.mock_bin.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        Command::new("bash")
+            .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+            .env("FETCH_INSTALL_DIR", &self.install_dir)
+            .env("FETCH_INSTALL_COMPLETIONS", "0")
+            .env("HOME", &self.home)
+            .env("MOCK_ARCHIVE", &self.archive)
+            .env("MOCK_CHECKSUM", &self.checksum)
+            .env("PATH", path)
+            .output()
+            .unwrap()
+    }
+
+    fn staged_files(&self) -> Vec<PathBuf> {
+        fs::read_dir(&self.install_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| {
+                path.file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .starts_with(".fetch.install.")
+            })
+            .collect()
+    }
+}
+
+#[test]
+fn installer_atomically_replaces_existing_binary() {
+    let fixture = InstallerFixture::new(false);
+    fs::write(fixture.install_dir.join("fetch"), "old fetch\n").unwrap();
+
+    let output = fixture.run();
+
+    assert!(
+        output.status.success(),
+        "installer failed: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.install_dir.join("fetch")).unwrap(),
+        NEW_FETCH
+    );
+    assert!(fixture.staged_files().is_empty());
+}
+
+#[test]
+fn staging_failure_preserves_existing_binary() {
+    let fixture = InstallerFixture::new(true);
+    let installed = fixture.install_dir.join("fetch");
+    fs::write(&installed, "old fetch\n").unwrap();
+
+    let output = fixture.run();
+
+    assert!(!output.status.success());
+    assert_eq!(fs::read_to_string(installed).unwrap(), "old fetch\n");
+    assert!(fixture.staged_files().is_empty());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("unable to stage fetch"));
+}
+
+#[test]
+fn directory_destination_is_rejected_and_staging_is_cleaned_up() {
+    let fixture = InstallerFixture::new(false);
+    let installed = fixture.install_dir.join("fetch");
+    fs::create_dir(&installed).unwrap();
+
+    let output = fixture.run();
+
+    assert!(!output.status.success());
+    assert!(installed.is_dir());
+    assert_eq!(fs::read_dir(installed).unwrap().count(), 0);
+    assert!(fixture.staged_files().is_empty());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("is a directory"));
+}
+
+#[test]
+fn symlink_to_directory_destination_is_rejected_and_staging_is_cleaned_up() {
+    let fixture = InstallerFixture::new(false);
+    let destination = fixture.install_dir.join("destination");
+    let installed = fixture.install_dir.join("fetch");
+    fs::create_dir(&destination).unwrap();
+    symlink(&destination, &installed).unwrap();
+
+    let output = fixture.run();
+
+    assert!(!output.status.success());
+    assert!(
+        fs::symlink_metadata(&installed)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(fs::read_dir(destination).unwrap().count(), 0);
+    assert!(fixture.staged_files().is_empty());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("is a directory"));
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+}


### PR DESCRIPTION
## Summary
- Stage the downloaded binary on the destination filesystem, validate it, and replace the target with a single atomic rename
- Allow overriding the install directory with `FETCH_INSTALL_DIR`
- Add installer integration tests for replacement, cleanup, and directory/symlink edge cases
- Update CI and contributor guidance to include the install test suite

## Testing
- Added integration coverage for atomic replacement and cleanup behavior in `tests/install.rs`
- Not run (not requested)