### PR TITLE
Enforce timeout for system DNS resolution

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -122,53 +122,47 @@ pub(crate) async fn resolve_host_with_doh_tls(
     doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<Vec<SocketAddr>, FetchError> {
-    resolve_host_with_doh_tls_using(
-        host,
-        dns_server,
-        doh_tls_config,
-        timeout,
-        |host| async move {
-            tokio::net::lookup_host((host, 0))
-                .await
-                .map(|addrs| addrs.collect())
-        },
-    )
-    .await
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return Ok(vec![SocketAddr::new(ip, 0)]);
+    }
+    let Some(dns_server) = dns_server else {
+        return resolve_system_host_with(
+            host,
+            timeout,
+            Box::pin(async move {
+                tokio::net::lookup_host((host, 0))
+                    .await
+                    .map(|addrs| addrs.collect())
+            }),
+        )
+        .await;
+    };
+
+    let addrs = if is_doh_dns_server(dns_server) {
+        let shared_doh = shared_doh_resolver(dns_server, host, timeout, doh_tls_config.as_ref())?;
+        resolve_doh_ips(host, dns_server, Some(&shared_doh), timeout).await?
+    } else {
+        crate::dns::custom::lookup_ips(dns_server, host, timeout.remaining()?).await?
+    };
+    Ok(addrs
+        .into_iter()
+        .map(|addr| SocketAddr::new(addr, 0))
+        .collect())
 }
 
-async fn resolve_host_with_doh_tls_using<F, Fut>(
+type SystemLookupFuture<'a> =
+    Pin<Box<dyn Future<Output = std::io::Result<Vec<SocketAddr>>> + Send + 'a>>;
+
+async fn resolve_system_host_with(
     host: &str,
-    dns_server: Option<&str>,
-    doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
-    system_lookup: F,
-) -> Result<Vec<SocketAddr>, FetchError>
-where
-    F: FnOnce(String) -> Fut,
-    Fut: Future<Output = std::io::Result<Vec<SocketAddr>>>,
-{
+    system_lookup: SystemLookupFuture<'_>,
+) -> Result<Vec<SocketAddr>, FetchError> {
     timeout
         .run(async move {
-            if let Ok(ip) = host.parse::<IpAddr>() {
-                return Ok(vec![SocketAddr::new(ip, 0)]);
-            }
-            let Some(dns_server) = dns_server else {
-                return system_lookup(host.to_owned())
-                    .await
-                    .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")));
-            };
-
-            let addrs = if is_doh_dns_server(dns_server) {
-                let shared_doh =
-                    shared_doh_resolver(dns_server, host, timeout, doh_tls_config.as_ref())?;
-                resolve_doh_ips(host, dns_server, Some(&shared_doh), timeout).await?
-            } else {
-                crate::dns::custom::lookup_ips(dns_server, host, timeout.remaining()?).await?
-            };
-            Ok(addrs
-                .into_iter()
-                .map(|addr| SocketAddr::new(addr, 0))
-                .collect())
+            system_lookup
+                .await
+                .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))
         })
         .await
 }
@@ -1440,12 +1434,10 @@ mod tests {
     #[tokio::test]
     async fn system_host_resolution_honors_timeout_budget() {
         let timeout = Duration::from_millis(10);
-        let err = resolve_host_with_doh_tls_using(
+        let err = resolve_system_host_with(
             "example.com",
-            None,
-            None,
             TimeoutBudget::new(Some(timeout)),
-            |_| std::future::pending::<std::io::Result<Vec<SocketAddr>>>(),
+            Box::pin(std::future::pending::<std::io::Result<Vec<SocketAddr>>>()),
         )
         .await
         .unwrap_err();

--- a/src/net.rs
+++ b/src/net.rs
@@ -122,26 +122,55 @@ pub(crate) async fn resolve_host_with_doh_tls(
     doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<Vec<SocketAddr>, FetchError> {
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        return Ok(vec![SocketAddr::new(ip, 0)]);
-    }
-    let Some(dns_server) = dns_server else {
-        return tokio::net::lookup_host((host, 0))
-            .await
-            .map(|addrs| addrs.collect())
-            .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")));
-    };
+    resolve_host_with_doh_tls_using(
+        host,
+        dns_server,
+        doh_tls_config,
+        timeout,
+        |host| async move {
+            tokio::net::lookup_host((host, 0))
+                .await
+                .map(|addrs| addrs.collect())
+        },
+    )
+    .await
+}
 
-    let addrs = if is_doh_dns_server(dns_server) {
-        let shared_doh = shared_doh_resolver(dns_server, host, timeout, doh_tls_config.as_ref())?;
-        resolve_doh_ips(host, dns_server, Some(&shared_doh), timeout).await?
-    } else {
-        crate::dns::custom::lookup_ips(dns_server, host, timeout.remaining()?).await?
-    };
-    Ok(addrs
-        .into_iter()
-        .map(|addr| SocketAddr::new(addr, 0))
-        .collect())
+async fn resolve_host_with_doh_tls_using<F, Fut>(
+    host: &str,
+    dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
+    timeout: TimeoutBudget,
+    system_lookup: F,
+) -> Result<Vec<SocketAddr>, FetchError>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = std::io::Result<Vec<SocketAddr>>>,
+{
+    timeout
+        .run(async move {
+            if let Ok(ip) = host.parse::<IpAddr>() {
+                return Ok(vec![SocketAddr::new(ip, 0)]);
+            }
+            let Some(dns_server) = dns_server else {
+                return system_lookup(host.to_owned())
+                    .await
+                    .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")));
+            };
+
+            let addrs = if is_doh_dns_server(dns_server) {
+                let shared_doh =
+                    shared_doh_resolver(dns_server, host, timeout, doh_tls_config.as_ref())?;
+                resolve_doh_ips(host, dns_server, Some(&shared_doh), timeout).await?
+            } else {
+                crate::dns::custom::lookup_ips(dns_server, host, timeout.remaining()?).await?
+            };
+            Ok(addrs
+                .into_iter()
+                .map(|addr| SocketAddr::new(addr, 0))
+                .collect())
+        })
+        .await
 }
 
 async fn resolve_host_family(
@@ -1407,6 +1436,22 @@ async fn timeout_fetch<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn system_host_resolution_honors_timeout_budget() {
+        let timeout = Duration::from_millis(10);
+        let err = resolve_host_with_doh_tls_using(
+            "example.com",
+            None,
+            None,
+            TimeoutBudget::new(Some(timeout)),
+            |_| std::future::pending::<std::io::Result<Vec<SocketAddr>>>(),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "request timed out after 10ms");
+    }
 
     #[test]
     fn host_header_value_brackets_ipv6_literals() {


### PR DESCRIPTION
## Summary

- enforce the supplied `TimeoutBudget` around the system `lookup_host` branch of `resolve_host_with_doh_tls`
- ensure a stalled system resolver cannot exceed `--connect-timeout`
- retain caller-level outer timeouts as defense in depth
- keep DoH and custom DNS on their existing internal timeout budgets
- add a boxed, injectable system resolver future for deterministic timeout testing without growing the request future stack

## Root cause

The system-resolver branch awaited `tokio::net::lookup_host` directly, even though `resolve_host_with_doh_tls` received a timeout budget. Callers such as explicit HTTP/3 setup and QUIC TLS inspection await this resolver directly, allowing a stalled system resolver to run beyond the configured connect timeout.

An initial implementation wrapped the complete resolver state machine in `TimeoutBudget::run`. That enlarged the stack-resident request future enough to overflow the default-sized `fetch-main` runtime thread in several network integration tests. The corrected implementation wraps only a boxed system lookup future, leaving the larger DoH/custom resolver paths unchanged.

## Impact

System DNS resolution now terminates with the normal request timeout diagnostic when it stalls. Explicit HTTP/3 connections and QUIC TLS inspection honor the configured connect timeout without increasing request stack usage.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins` (872 passed)
- full CI-equivalent integration suite with `--test-threads=2`
- `cargo test --locked --all-features --test network -- --test-threads=2` (27 passed)
- deterministic focused test with a permanently pending injected resolver
- locally reproduced the prior stack overflow, then verified the failing HTTP/3 cache case passes after the fix