### PR TITLE
fix: harden WebSocket handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tower-service",
+ "unicode-width",
  "url",
  "wait-timeout",
  "webpki-roots 1.0.9",
@@ -2952,6 +2953,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ tokio-rustls = { version = "=0.26.4", default-features = false, features = ["aws
 tokio-tungstenite = { version = "=0.30.0", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 tokio-util = { version = "=0.7.19", features = ["io"] }
 tower-service = "=0.3.3"
+unicode-width = "=0.2.2"
 url = "=2.5.8"
 webpki-roots = "=1.0.9"
 zip = { version = "=8.6.0", default-features = false, features = ["deflate"] }

--- a/docs/websocket-audit.md
+++ b/docs/websocket-audit.md
@@ -1,0 +1,276 @@
+# Historical WebSocket implementation audit
+
+> **Status:** Historical pre-fix audit. The findings below describe the
+> implementation before the WebSocket hardening work and are retained as design
+> context. They are not a current issue list, and their source line references
+> may no longer match the code. Regression coverage now tracks the resolved
+> behavior.
+
+At the time of this audit, the existing WebSocket unit and integration tests
+passed, but the implementation had several correctness, security, and
+resource-management issues.
+
+## 1. Remote terminal escape injection — High severity
+
+**Locations:**
+
+- `src/websocket/mod.rs:757-767`
+- `src/websocket/mod.rs:775-786`
+- `src/core.rs:172-218`
+
+Incoming text messages are written directly to a terminal when formatting is disabled or JSON parsing fails. A malicious server can send ANSI/OSC escape sequences to change terminal titles, manipulate clipboard contents, overwrite terminal output, or trigger terminal-emulator vulnerabilities.
+
+Binary output has the same problem. `bytes_appear_printable()` explicitly treats `ESC` as safe, so binary data containing terminal escape sequences may be emitted directly to the terminal. It also fails to count trailing incomplete UTF-8 sequences as unsafe.
+
+### Recommended fix
+
+- Sanitize unformatted text with `interactive::sanitize_message_text()` when stdout is a terminal.
+- Never write binary WebSocket frames directly to a terminal; display a binary indicator instead.
+- If printable binary output is retained, use a stricter predicate that rejects all terminal control sequences, especially `ESC`.
+- Fix `bytes_appear_printable()` to count incomplete trailing UTF-8 as unsafe.
+- Add tests for text and binary payloads containing ANSI, OSC, BEL, carriage return, and incomplete UTF-8 sequences.
+
+## 2. Interactive history has an unbounded byte footprint — High severity
+
+**Locations:**
+
+- `src/websocket/interactive.rs:115-134`
+- `src/websocket/interactive.rs:495-496`
+- `src/websocket/interactive.rs:641-645`
+
+Interactive history is capped at 10,000 messages, but not by bytes. Each message may be up to 16 MiB, so the theoretical retained history is roughly 160 GiB. A server can exhaust client memory by sending many maximum-sized messages.
+
+History replay also clones entries with `to_vec()`, which can temporarily increase memory usage further.
+
+### Recommended fix
+
+- Use a byte-bounded `VecDeque` history.
+- Track total retained bytes and evict oldest entries until under a fixed budget.
+- Represent a single message larger than the history budget with a truncated or placeholder entry.
+- Avoid cloning replay slices; iterate by reference.
+- Cache sanitized/formatted output rather than retaining and reformatting full payloads repeatedly.
+
+## 3. `--ws-message-mode` is ignored in interactive mode — High severity
+
+**Locations:**
+
+- `src/websocket/mod.rs:117-123`
+- `src/websocket/interactive.rs:649-757`
+
+Interactive mode does not receive the selected message mode and always sends text using `String::from_utf8_lossy()`.
+
+Consequences:
+
+- `--ws-message-mode binary` still sends interactive input as text.
+- `--ws-message-mode binary` sends the initial message as text.
+- Invalid UTF-8 in an initial binary payload is silently replaced with U+FFFD.
+- `--ws-message-mode text` does not reject invalid initial data as noninteractive mode does.
+
+### Recommended fix
+
+Pass `WebSocketMessageMode` into `run_terminal()` and use the shared `outgoing_message()` helper for both the initial message and interactive input. This preserves invalid bytes in auto/binary modes and provides consistent behavior across modes.
+
+## 4. Empty initial messages are inconsistently handled — Medium severity
+
+**Location:**
+
+- `src/websocket/interactive.rs:675`
+
+Interactive mode filters out empty initial messages, while noninteractive mode sends them. Therefore `fetch ws://example.test -d ""` behaves differently depending on the selected mode.
+
+### Recommended fix
+
+Send the message whenever `initial_message` is `Some`, including zero-length messages. Only `None` should mean that no initial message was supplied.
+
+## 5. Close frames are not flushed and close status is discarded — High severity
+
+**Locations:**
+
+- `src/websocket/mod.rs:747`
+- `src/websocket/mod.rs:134-146`
+- `src/websocket/interactive.rs:699-725`
+
+When a peer sends a close frame, the code immediately returns. Tungstenite queues the close response internally, but it must be flushed with `flush()` or `Sink::close()`. Dropping the split stream can terminate the TCP connection without completing the WebSocket close handshake.
+
+The close code and reason are also ignored. Server closures such as 1008 Policy Violation or 1011 Internal Error still result in exit code 0.
+
+Interactive Ctrl-D and stdin EOF also return without sending a close frame.
+
+### Recommended fix
+
+- Return a structured read outcome containing the received close frame.
+- Flush the queued close response before dropping the connection.
+- Send a close frame on interactive stdin EOF.
+- Expose the close code and reason.
+- Treat abnormal close codes as failures while treating 1000/1001 as normal.
+- Sanitize close reasons before printing them because they are server-controlled.
+
+Add tests verifying that the client sends a close response and returns a failure for abnormal close codes.
+
+## 6. Interactive input is unbounded and inefficient — High severity
+
+**Locations:**
+
+- `src/websocket/interactive.rs:288-375`
+- `src/websocket/interactive.rs:549-582`
+
+The interactive editor has no maximum input size. `LineEditor::insert()` and `Vec::insert()` are O(n), and the input line is redrawn after every character. Large pasted input can therefore cause quadratic CPU behavior and excessive memory use.
+
+### Recommended fix
+
+- Enforce the same 16 MiB maximum as other outgoing messages.
+- Use a gap buffer or another efficient editable buffer.
+- Batch redraws for large pasted input.
+- Reject oversized input with a clear status message.
+
+## 7. Noninteractive stdin buffering is bounded by messages, not bytes — Medium severity
+
+**Locations:**
+
+- `src/websocket/mod.rs:41`
+- `src/websocket/mod.rs:371-374`
+
+The channel capacity is 16 messages, but each text message can be 16 MiB. A slow server can therefore cause approximately 256 MiB of queued input, in addition to the current message and tungstenite buffers.
+
+### Recommended fix
+
+Use a byte-budgeted queue, or reduce the queue to one message and apply backpressure before reading additional large lines. Also configure a finite `max_write_buffer_size` in `WebSocketConfig`.
+
+## 8. Environment and system proxies are bypassed — Medium severity
+
+**Locations:**
+
+- `src/websocket/mod.rs:229`
+- `src/http/client.rs:994-1030`
+
+WebSocket dialing only uses `cli.proxy.as_deref()`. HTTP requests use environment and system proxy configuration when `--proxy` is absent, including `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`.
+
+HTTP and WebSocket requests therefore behave differently. In a corporate environment, WebSocket traffic may bypass the configured proxy or fail unexpectedly.
+
+### Recommended fix
+
+Centralize proxy selection and reuse it for WebSockets. Honor:
+
+- Explicit `--proxy`
+- `HTTP_PROXY`/`HTTPS_PROXY`
+- `ALL_PROXY`
+- `NO_PROXY`
+- System proxy configuration, if supported
+
+Map `ws://` to HTTP proxy selection and `wss://` to HTTPS proxy selection.
+
+## 9. Several CLI options are silently ignored — Medium severity
+
+**Locations:**
+
+- `src/flag_registry.rs`
+- `src/app.rs:741-800`
+
+The WebSocket validator rejects only some unsupported options. These options currently have no effect:
+
+- `--unix`
+- `--redirects`
+- `--range`
+- `--compress`
+- `--no-encode`
+- `--image`
+- `--ignore-status`
+- `--proto-desc`
+- `--proto-file`
+- `--proto-import`
+
+`--compress` is particularly misleading: HTTP content encoding and WebSocket per-message compression are different mechanisms, and no WebSocket compression extension is negotiated or decoded.
+
+### Recommended fix
+
+Either implement each feature or reject it explicitly with a WebSocket-specific diagnostic. At minimum, add these flags to the WebSocket conflict registry. `--pager` should either produce the same warning style as `--timing` or be explicitly documented as ignored.
+
+## 10. `-d @-` is read before the WebSocket connection is established — Medium severity
+
+**Locations:**
+
+- `src/websocket/mod.rs:85`
+- `src/websocket/mod.rs:315`
+- `src/websocket/mod.rs:96-109`
+
+Initial message materialization happens before dialing. Consequently, `fetch ws://example.test -d @-` waits for all stdin input before performing the handshake. This prevents interactive server-driven workflows and contradicts the documented behavior that the client connects before reading piped input.
+
+The read also occurs outside the request timeout budget.
+
+### Recommended fix
+
+Keep the body descriptor until after the handshake. Establish the WebSocket first, then materialize `@-` and send the initial message. Use `spawn_blocking` for blocking stdin/file reads.
+
+## 11. `--ws-interactive on` can silently fall back to noninteractive mode — Medium severity
+
+**Locations:**
+
+- `src/websocket/mod.rs:117-123`
+- `src/websocket/interactive.rs:1440-1441`
+
+`--ws-interactive on` verifies that stdio are terminals, but `execute()` only enters interactive mode if terminal-size detection succeeds and the terminal has at least five rows. Otherwise it silently falls through to noninteractive mode.
+
+This contradicts the meaning of `on` and the documented “require the prompt” behavior.
+
+### Recommended fix
+
+For explicit `on`, return an error when terminal-size detection fails or the terminal is too small. Only `auto` should fall back.
+
+## 12. Interactive JSON formatting parses every message twice — Low/Medium severity
+
+**Location:**
+
+- `src/websocket/interactive.rs:457-470`
+
+The code first parses JSON only to check whether parsing succeeds, then parses it again in `format_json_line_to()`.
+
+### Recommended fix
+
+Call `format_json_line_to()` once and use its success/failure result. Cache the formatted/sanitized representation in message history to avoid reformatting on resize and replay.
+
+## 13. Interactive stdin errors are silently treated as clean EOF — Low/Medium severity
+
+**Location:**
+
+- `src/websocket/interactive.rs:757-773`
+
+`spawn_stdin_reader()` discards all stdin read errors. The receiving loop then interprets channel closure as normal stdin completion and exits successfully.
+
+### Recommended fix
+
+Send `Result<Vec<u8>, io::Error>` through the channel, distinguish EOF from read failure, report the error, and perform a graceful close.
+
+## 14. Interactive terminal width calculations are incomplete — Low severity
+
+**Locations:**
+
+- `src/websocket/interactive.rs:549-582`
+- `src/websocket/interactive.rs:1028-1056`
+
+The custom width logic does not correctly handle combining characters, variation selectors, newer emoji, grapheme clusters, or zero-width characters. This can cause cursor and wrapping misalignment.
+
+### Recommended fix
+
+Use a Unicode width/grapheme library such as `unicode-width`, and consider grapheme-aware editing for cursor movement and deletion.
+
+## 15. Verbose and dry-run output exposes credentials — Security hardening
+
+**Locations:**
+
+- `src/websocket/mod.rs:535-558`
+- `src/websocket/mod.rs:615-714`
+
+`-v`, `-vv`, and `--dry-run` print all handshake headers, including `Authorization`, `Cookie`, `Set-Cookie`, AWS signing headers, and session tokens. This is risky in CI logs and shared terminals.
+
+### Recommended fix
+
+Redact sensitive headers by default, with an explicit opt-in flag for displaying them. At minimum redact `authorization`, `cookie`, `set-cookie`, `proxy-authorization`, and AWS security-token headers.
+
+## Validation performed
+
+The following commands were run successfully:
+
+```bash
+cargo test --locked --all-features --lib --bins websocket:: -- --nocapture
+cargo test --locked --all-features --test websocket -- --test-threads=2
+```

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -54,7 +54,9 @@ Text and auto stdin modes cap each line at 16 MiB before a newline. Use
 delimiters.
 
 If stdin, stdout, and stderr are terminals, `fetch` opens an interactive prompt.
-Type a message and press Enter to send it. Press Ctrl+C or Ctrl+D to exit.
+Type a message and press Enter to send it. Press Ctrl+C or Ctrl+D to exit. Prompt
+input is capped at 16 MiB. Interactive history is byte-bounded, so old messages
+are evicted rather than allowing server traffic to grow memory without limit.
 
 Control this behavior with `--ws-interactive`:
 
@@ -74,8 +76,10 @@ fetch ws://api.example.com/stream --ws-interactive off
 - **Text messages**: `fetch` writes text messages to stdout. On a terminal, it
   automatically formats JSON messages.
 - **Binary messages**: `fetch` writes raw bytes if stdout is redirected or
-  piped. On a terminal, it gives a warning and does not print binary-looking
-  data.
+  piped. It never writes binary frames directly to a terminal and gives a
+  warning instead.
+- **Terminal safety**: Unformatted server text is escaped before terminal
+  output so control sequences cannot be interpreted by the terminal.
 - **Formatting**: Use `--format on` to force JSON formatting, or `--format off` to disable it.
 
 Incoming server frames and assembled messages are capped at 16 MiB. Larger
@@ -100,6 +104,10 @@ fetch -v ws://echo.websocket.events -d "hello"
 # Show request and response headers with prefixes
 fetch -vv ws://echo.websocket.events -d "hello"
 ```
+
+Sensitive handshake headers such as `Authorization`, `Cookie`, `Set-Cookie`,
+`Proxy-Authorization`, and AWS session tokens are redacted in verbose and
+`--dry-run` output.
 
 ## Authentication
 
@@ -132,9 +140,16 @@ WebSocket connections honor `--dns-server` for direct TCP connections and for
 local target resolution through plain `socks5://` proxies. Use `socks5h://` to
 make the SOCKS proxy resolve the target hostname.
 
+When `--proxy` is absent, WebSocket dialing uses the same environment and system
+proxy selection as HTTP, including `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and
+`NO_PROXY`. `ws://` uses HTTP proxy selection and `wss://` uses HTTPS proxy
+selection.
+
 ## Timeout
 
-The `--timeout` flag applies to the WebSocket handshake only. The connection stays open until the server closes or stdin EOF:
+The `--timeout` flag applies to connection setup, the WebSocket handshake, and
+materializing an initial `-d`/`-j` message. The established connection stays
+open until the server closes or stdin EOF:
 
 ```sh
 fetch --timeout 5 ws://api.example.com/ws
@@ -152,8 +167,8 @@ fetch --connect-timeout 2 --timeout 10 wss://api.example.com/ws
 ## Limitations
 
 - WebSocket requires HTTP/1.1 for the upgrade handshake. Using `--http 2` or `--http 3` with WebSocket is not supported.
-- WebSocket (`ws://` / `wss://`) cannot be combined with `--grpc`, `--form`, `--multipart`, `--xml`, `--edit`, output-file/clipboard flags, or retry flags.
-- The pager is disabled for WebSocket output.
+- WebSocket (`ws://` / `wss://`) cannot be combined with HTTP/gRPC-only options, including `--grpc`, protobuf schema flags, `--form`, `--multipart`, `--xml`, `--edit`, `--unix`, redirects, ranges, compression/content-encoding options, image/status handling, output-file/clipboard flags, or retry flags.
+- The pager is disabled for WebSocket output; explicitly setting `--pager` produces a warning.
 
 ## See Also
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -170,50 +170,25 @@ pub fn write_stdout(bytes: impl AsRef<[u8]>) -> std::io::Result<StdoutWriteStatu
 }
 
 pub fn bytes_appear_printable(bytes: &[u8]) -> bool {
-    if bytes.contains(&0) {
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        // Malformed UTF-8 can encode C1 terminal controls such as the 8-bit
+        // CSI byte (0x9b), so it is never safe for direct terminal output.
         return false;
-    }
+    };
+    terminal_text_controls_safe(text)
+}
 
-    let max_unsafe = (bytes.len() / 10).max(1);
-    let mut safe = 0usize;
-    let mut total = 0usize;
-    let mut remaining = bytes;
-    while !remaining.is_empty() {
-        match std::str::from_utf8(remaining) {
-            Ok(valid) => {
-                for ch in valid.chars() {
-                    total += 1;
-                    if ch.is_whitespace() || !ch.is_control() || ch == '\x1b' {
-                        safe += 1;
-                    }
-                }
-                break;
-            }
-            Err(err) => {
-                let valid_up_to = err.valid_up_to();
-                if valid_up_to > 0 {
-                    let valid = std::str::from_utf8(&remaining[..valid_up_to])
-                        .expect("valid prefix reported by utf8 error");
-                    for ch in valid.chars() {
-                        total += 1;
-                        if ch.is_whitespace() || !ch.is_control() || ch == '\x1b' {
-                            safe += 1;
-                        }
-                    }
-                }
-                if err.error_len().is_none() {
-                    break;
-                }
-                total += 1;
-                if total - safe > max_unsafe {
-                    return false;
-                }
-                remaining = &remaining[valid_up_to + err.error_len().unwrap()..];
-            }
+fn terminal_text_controls_safe(text: &str) -> bool {
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\r' if chars.peek() == Some(&'\n') => {}
+            '\n' | '\t' => {}
+            ch if ch.is_control() => return false,
+            _ => {}
         }
     }
-
-    total == 0 || (safe as f64 / total as f64) >= 0.9
+    true
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -551,6 +526,24 @@ mod tests {
         assert!(!format_enabled(None, false));
         assert!(format_enabled(Some("auto"), true));
         assert!(!format_enabled(Some("auto"), false));
+    }
+
+    #[test]
+    fn printable_bytes_reject_terminal_escapes_and_incomplete_utf8() {
+        assert!(bytes_appear_printable(b"plain text\n"));
+        assert!(!bytes_appear_printable(b"\x1b[31m"));
+        assert!(!bytes_appear_printable(b"\x07"));
+        assert!(!bytes_appear_printable(b"\xf0\x9f\x98"));
+        let padded_escape = format!(
+            "{}\x1b]52;c;clipboard\x07{}",
+            "a".repeat(100),
+            "b".repeat(100)
+        );
+        assert!(!bytes_appear_printable(padded_escape.as_bytes()));
+        assert!(bytes_appear_printable(b"line one\r\nline two\r\n"));
+        assert!(!bytes_appear_printable(b"overwrite\rtext"));
+        let padded_c1 = [b"a".repeat(100), vec![0x9b, b'2', b'J']].concat();
+        assert!(!bytes_appear_printable(&padded_c1));
     }
 
     #[test]

--- a/src/flag_registry.rs
+++ b/src/flag_registry.rs
@@ -124,13 +124,16 @@ pub(crate) static FLAGS: &[FlagDef] = &[
         .with_ws_always(),
     FlagDef::new("--proto-desc", Some(FlagCategory::Request), |c| {
         c.proto_desc.is_some()
-    }),
+    })
+    .with_ws_always(),
     FlagDef::new("--proto-file", Some(FlagCategory::Request), |c| {
         !c.proto_files.is_empty()
-    }),
+    })
+    .with_ws_always(),
     FlagDef::new("--proto-import", Some(FlagCategory::Request), |c| {
         !c.proto_imports.is_empty()
-    }),
+    })
+    .with_ws_always(),
     FlagDef::new("--output", Some(FlagCategory::Request), |c| {
         c.output.is_some()
     })
@@ -181,18 +184,22 @@ pub(crate) static FLAGS: &[FlagDef] = &[
     FlagDef::new("--redirects", Some(FlagCategory::Request), |c| {
         c.redirects.is_some()
     })
-    .with_from_curl(),
+    .with_from_curl()
+    .with_ws_always(),
     FlagDef::new("--range", Some(FlagCategory::Request), |c| {
         !c.ranges.is_empty()
     })
-    .with_from_curl(),
+    .with_from_curl()
+    .with_ws_always(),
     FlagDef::new("--timing", Some(FlagCategory::Request), |c| c.timing),
     FlagDef::new("--proxy", Some(FlagCategory::Request), |c| {
         c.proxy.is_some()
     })
     .with_from_curl(),
     FlagDef::new("--discard", Some(FlagCategory::Request), |c| c.discard).with_ws_always(),
-    FlagDef::new("--unix", Some(FlagCategory::Request), |c| c.unix.is_some()).with_from_curl(),
+    FlagDef::new("--unix", Some(FlagCategory::Request), |c| c.unix.is_some())
+        .with_from_curl()
+        .with_ws_always(),
     // ── Auth ────────────────────────────────────────────────────────────
     FlagDef::new("--basic", Some(FlagCategory::Auth), |c| c.basic.is_some()).with_from_curl(),
     FlagDef::new("--bearer", Some(FlagCategory::Auth), |c| c.bearer.is_some()).with_from_curl(),
@@ -207,20 +214,23 @@ pub(crate) static FLAGS: &[FlagDef] = &[
     FlagDef::new("--article", Some(FlagCategory::Response), |c| c.article).with_ws_always(),
     FlagDef::new("--compress", Some(FlagCategory::Response), |c| {
         c.compress.is_some()
-    }),
-    FlagDef::new("--no-encode", Some(FlagCategory::Response), |c| c.no_encode),
+    })
+    .with_ws_always(),
+    FlagDef::new("--no-encode", Some(FlagCategory::Response), |c| c.no_encode).with_ws_always(),
     FlagDef::new("--format", Some(FlagCategory::Response), |c| {
         c.format.is_some()
     }),
     FlagDef::new("--image", Some(FlagCategory::Response), |c| {
         c.image.is_some()
-    }),
+    })
+    .with_ws_always(),
     FlagDef::new("--pager", Some(FlagCategory::Response), |c| {
         c.pager.is_some()
     }),
     FlagDef::new("--ignore-status", Some(FlagCategory::Response), |c| {
         c.ignore_status
-    }),
+    })
+    .with_ws_always(),
     FlagDef::new("--sort-headers", Some(FlagCategory::Response), |c| {
         c.sort_headers
     }),

--- a/src/http/AGENTS.md
+++ b/src/http/AGENTS.md
@@ -3,6 +3,7 @@
 Applies to `src/http/` and its submodules.
 
 - Transport code owns DNS/TCP/TLS/QUIC setup. Reuse `src/net.rs` dialing, proxy, timeout, and address-racing helpers.
+- Keep the protocol-specific send futures heap-pinned in `Client::send`; inlining their large state machines can overflow the default Windows thread stack, especially for nested DoH requests.
 - Automatic HTTP/3 discovery applies only to eligible direct HTTPS requests. It must not delay normal TCP/TLS and must share the already-started connect-timeout budget.
 - Keep HTTP/3 cache entries bounded, origin/resolver scoped, authority-based, and expiring. Never learn Alt-Svc from insecure responses.
 - Retry protocol NACKs only when safe and when the request body is replayable.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -965,6 +965,36 @@ fn configure_proxy(
     Ok(configure_proxy_configs(builder, proxy_configs))
 }
 
+pub(crate) struct EffectiveWebSocketProxy {
+    pub(crate) url: String,
+    pub(crate) authorization: Option<String>,
+}
+
+pub(crate) fn effective_proxy_for_websocket(
+    proxy: Option<&str>,
+    websocket_url: &Url,
+) -> Result<Option<EffectiveWebSocketProxy>, FetchError> {
+    let mut url = websocket_url.clone();
+    let scheme = match url.scheme() {
+        "ws" => "http",
+        "wss" => "https",
+        _ => return Ok(None),
+    };
+    url.set_scheme(scheme)
+        .map_err(|_| FetchError::Message("invalid WebSocket URL scheme".to_string()))?;
+    let proxy_configs = proxy_configs(proxy)?;
+    proxy_configs
+        .iter()
+        .find_map(|candidate| candidate.selected_for_url(&url))
+        .map(|selected| {
+            Ok(EffectiveWebSocketProxy {
+                url: selected.url().to_string(),
+                authorization: selected.basic_auth()?,
+            })
+        })
+        .transpose()
+}
+
 pub(crate) fn effective_proxy_for_url(
     proxy: Option<&str>,
     version: Option<HttpVersion>,
@@ -1290,6 +1320,25 @@ mod tests {
 
     fn auto_http3_test_discovery_budget() -> Option<AutoHttp3DiscoveryBudget> {
         AutoHttp3DiscoveryBudget::new(TimeoutBudget::new(None))
+    }
+
+    #[test]
+    fn websocket_effective_proxy_preserves_authorization() {
+        let selected = effective_proxy_for_websocket(
+            Some("http://proxy-user:proxy-pass@proxy.example:8080"),
+            &Url::parse("wss://example.com/socket").unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            selected.url,
+            "http://proxy-user:proxy-pass@proxy.example:8080"
+        );
+        assert_eq!(
+            selected.authorization.as_deref(),
+            Some("Basic cHJveHktdXNlcjpwcm94eS1wYXNz")
+        );
     }
 
     #[test]

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -20,7 +20,7 @@ use metadata::{
     body_duration, check_grpc_status, exit_code, finalize_streamed_response,
     handle_clipboard_outcome, print_response_metadata, print_timing,
 };
-use stdout::{StdoutBody, stdout_stream_target, write_stdout_bytes};
+use stdout::{StdoutBody, TerminalOutputSafety, stdout_stream_target, write_stdout_bytes};
 use stream::{
     read_decoded_article_body_limited, read_decoded_response_body_limited,
     stream_response_to_discard, stream_response_to_output, stream_response_to_stdout,
@@ -358,23 +358,25 @@ async fn finish_article_response(
             .map_err(|err| FetchError::Message(err.to_string()))?;
     } else {
         let stdout_is_terminal = core::stdio().stdout_is_terminal();
-        let rendered = if core::format_enabled(cli.format.as_deref(), stdout_is_terminal) {
-            let use_color = core::color_enabled(cli.color.as_deref(), stdout_is_terminal);
-            let mut out = core::Printer::new(use_color);
-            if markdown::format_markdown_to(&article, &mut out).is_ok() {
-                out.into_bytes()
+        let (rendered, terminal_output_safety) =
+            if core::format_enabled(cli.format.as_deref(), stdout_is_terminal) {
+                let use_color = core::color_enabled(cli.color.as_deref(), stdout_is_terminal);
+                let mut out = core::Printer::new(use_color);
+                if markdown::format_markdown_to(&article, &mut out).is_ok() {
+                    (out.into_bytes(), TerminalOutputSafety::FormattedText)
+                } else {
+                    (article.clone(), TerminalOutputSafety::Untrusted)
+                }
             } else {
-                article.clone()
-            }
-        } else {
-            article.clone()
-        };
+                (article.clone(), TerminalOutputSafety::Untrusted)
+            };
         write_stdout_bytes(
             cli,
             &StdoutBody {
                 bytes: rendered,
                 content_type: ContentType::Markdown,
                 content_type_label: "text/markdown; charset=utf-8".to_string(),
+                terminal_output_safety,
             },
         )?;
     }

--- a/src/http/response/formatters.rs
+++ b/src/http/response/formatters.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-use super::stdout::{StdoutBody, response_header_content_type, response_header_content_type_label};
+use super::stdout::{
+    StdoutBody, TerminalOutputSafety, response_header_content_type,
+    response_header_content_type_label,
+};
 use super::stream::{MAX_BUFFERED_RESPONSE_BYTES, StdoutStreamFormatter, StreamedOutput};
 
 pub(super) fn should_stream_formatted_sse_stdout(
@@ -409,96 +412,85 @@ pub(super) fn format_stdout_bytes_with_terminal(
             bytes: bytes.to_vec(),
             content_type,
             content_type_label: response_header_content_type_label(headers),
+            terminal_output_safety: TerminalOutputSafety::Untrusted,
         });
     }
 
     let use_color = core::color_enabled(cli.color.as_deref(), stdout_is_terminal);
     let bytes = transcode_format_bytes(bytes, &charset, content_type);
-    let bytes = match content_type {
-        ContentType::Json => {
-            Ok(
-                format_printer_bytes(use_color, |out| json::format_json_to(&bytes, out))
-                    .unwrap_or_else(|_| bytes.to_vec()),
-            )
-        }
-        ContentType::Ndjson => {
-            Ok(
-                format_printer_bytes(use_color, |out| json::format_ndjson_to(&bytes, out))
-                    .unwrap_or_else(|_| bytes.to_vec()),
-            )
-        }
-        ContentType::Csv => Ok(format_printer_bytes(use_color, |out| {
-            csv::format_csv_to_with_terminal_cols(&bytes, out, terminal_cols)
-        })
-        .unwrap_or_else(|_| bytes.to_vec())),
-        ContentType::Xml => {
-            Ok(
-                format_printer_bytes(use_color, |out| xml::format_xml_to(&bytes, out))
-                    .unwrap_or_else(|_| bytes.to_vec()),
-            )
-        }
-        ContentType::Yaml => {
-            Ok(
-                format_printer_bytes(use_color, |out| yaml::format_yaml_to(&bytes, out))
-                    .unwrap_or_else(|_| bytes.to_vec()),
-            )
-        }
-        ContentType::Css => {
-            Ok(
-                format_printer_bytes(use_color, |out| css::format_css_to(&bytes, out))
-                    .unwrap_or_else(|_| bytes.to_vec()),
-            )
-        }
-        ContentType::Html => {
-            Ok(
-                format_printer_bytes(use_color, |out| html::format_html_to(&bytes, out))
-                    .unwrap_or_else(|_| bytes.to_vec()),
-            )
-        }
-        ContentType::Markdown => {
-            Ok(
-                format_printer_bytes(use_color, |out| markdown::format_markdown_to(&bytes, out))
-                    .unwrap_or_else(|_| bytes.to_vec()),
-            )
-        }
-        ContentType::MsgPack => {
-            Ok(
-                format_printer_bytes(use_color, |out| msgpack::format_msgpack_to(&bytes, out))
-                    .unwrap_or_else(|_| bytes.to_vec()),
-            )
-        }
+    let (bytes, terminal_output_safety) = match content_type {
+        ContentType::Json => formatted_or_raw(
+            format_printer_bytes(use_color, |out| json::format_json_to(&bytes, out)),
+            &bytes,
+        ),
+        ContentType::Ndjson => formatted_or_raw(
+            format_printer_bytes(use_color, |out| json::format_ndjson_to(&bytes, out)),
+            &bytes,
+        ),
+        ContentType::Csv => formatted_or_raw(
+            format_printer_bytes(use_color, |out| {
+                csv::format_csv_to_with_terminal_cols(&bytes, out, terminal_cols)
+            }),
+            &bytes,
+        ),
+        ContentType::Xml => formatted_or_raw(
+            format_printer_bytes(use_color, |out| xml::format_xml_to(&bytes, out)),
+            &bytes,
+        ),
+        ContentType::Yaml => formatted_or_raw(
+            format_printer_bytes(use_color, |out| yaml::format_yaml_to(&bytes, out)),
+            &bytes,
+        ),
+        ContentType::Css => formatted_or_raw(
+            format_printer_bytes(use_color, |out| css::format_css_to(&bytes, out)),
+            &bytes,
+        ),
+        ContentType::Html => formatted_or_raw(
+            format_printer_bytes(use_color, |out| html::format_html_to(&bytes, out)),
+            &bytes,
+        ),
+        ContentType::Markdown => formatted_or_raw(
+            format_printer_bytes(use_color, |out| markdown::format_markdown_to(&bytes, out)),
+            &bytes,
+        ),
+        ContentType::MsgPack => formatted_or_raw(
+            format_printer_bytes(use_color, |out| msgpack::format_msgpack_to(&bytes, out)),
+            &bytes,
+        ),
         ContentType::Protobuf => {
             if let Some(desc) = grpc_response_desc {
                 if let Ok(json_bytes) = proto::protobuf_to_json(&bytes, &desc) {
-                    Ok(format_printer_bytes(use_color, |out| {
+                    let formatted = format_printer_bytes(use_color, |out| {
                         json::format_json_to(&json_bytes, out)
-                    })
-                    .unwrap_or(json_bytes))
+                    });
+                    formatted_or_raw(formatted, &json_bytes)
                 } else {
-                    Ok(bytes.to_vec())
+                    (bytes.to_vec(), TerminalOutputSafety::Untrusted)
                 }
             } else {
-                Ok(protobuf::format_protobuf(&bytes)
-                    .map(|formatted| formatted.into_bytes())
-                    .unwrap_or_else(|_| bytes.to_vec()))
+                formatted_or_raw(
+                    protobuf::format_protobuf(&bytes).map(|formatted| formatted.into_bytes()),
+                    &bytes,
+                )
             }
         }
         ContentType::Image => {
             if cli.image.as_deref() == Some("off") {
-                Ok(bytes.to_vec())
+                (bytes.to_vec(), TerminalOutputSafety::Untrusted)
             } else {
                 let decode_mode = if cli.image.as_deref() == Some("external") {
                     crate::image::DecodeMode::External
                 } else {
                     crate::image::DecodeMode::BuiltIn
                 };
-                crate::image::render(&bytes, decode_mode)
-                    .map_err(|err| FetchError::Message(err.to_string()))
+                let rendered = crate::image::render(&bytes, decode_mode)
+                    .map_err(|err| FetchError::Message(err.to_string()))?;
+                (rendered, TerminalOutputSafety::Trusted)
             }
         }
         ContentType::Grpc => {
             let grpc_message_encoding = grpc_encoding::MessageEncoding::from_headers(headers);
-            if let Some(desc) = grpc_response_desc {
+            let formatted = if let Some(desc) = grpc_response_desc {
                 let mut out = core::Printer::new(use_color);
                 grpc_format::format_grpc_stream_with_descriptor_to(
                     &bytes,
@@ -507,24 +499,34 @@ pub(super) fn format_stdout_bytes_with_terminal(
                     &mut out,
                 )
                 .map(|()| out.into_bytes())
-                .map_err(|err| FetchError::Message(err.to_string()))
             } else {
                 grpc_format::format_grpc_stream(&bytes, &grpc_message_encoding)
                     .map(|formatted| formatted.into_bytes())
-                    .map_err(|err| FetchError::Message(err.to_string()))
             }
+            .map_err(|err| FetchError::Message(err.to_string()))?;
+            (formatted, TerminalOutputSafety::FormattedText)
         }
         ContentType::Sse => {
-            format_printer_bytes(use_color, |out| sse::format_event_stream_to(&bytes, out))
-                .map_err(|err| FetchError::Message(err.to_string()))
+            let formatted =
+                format_printer_bytes(use_color, |out| sse::format_event_stream_to(&bytes, out))
+                    .map_err(|err| FetchError::Message(err.to_string()))?;
+            (formatted, TerminalOutputSafety::FormattedText)
         }
-        _ => Ok(bytes.to_vec()),
-    }?;
+        _ => (bytes.to_vec(), TerminalOutputSafety::Untrusted),
+    };
     Ok(StdoutBody {
         bytes,
         content_type,
         content_type_label: response_header_content_type_label(headers),
+        terminal_output_safety,
     })
+}
+
+fn formatted_or_raw<E>(result: Result<Vec<u8>, E>, raw: &[u8]) -> (Vec<u8>, TerminalOutputSafety) {
+    match result {
+        Ok(formatted) => (formatted, TerminalOutputSafety::FormattedText),
+        Err(_) => (raw.to_vec(), TerminalOutputSafety::Untrusted),
+    }
 }
 
 fn format_printer_bytes<E>(

--- a/src/http/response/stdout.rs
+++ b/src/http/response/stdout.rs
@@ -1,14 +1,30 @@
 use super::*;
 
+#[derive(Clone, Copy)]
+pub(super) enum TerminalOutputSafety {
+    Untrusted,
+    /// Text passed through a local formatter. Only local-style SGR sequences
+    /// are accepted; server-controlled OSC and other controls remain blocked.
+    FormattedText,
+    /// Fully generated terminal protocol output, currently image renderers.
+    Trusted,
+}
+
 pub(super) struct StdoutBody {
     pub(super) bytes: Vec<u8>,
     pub(super) content_type: ContentType,
     pub(super) content_type_label: String,
+    pub(super) terminal_output_safety: TerminalOutputSafety,
 }
 
 pub(super) fn write_stdout_bytes(cli: &Cli, body: &StdoutBody) -> Result<(), FetchError> {
     let stdout_is_terminal = core::stdio().stdout_is_terminal();
-    if should_warn_for_terminal_binary_stdout(cli, &body.bytes, stdout_is_terminal) {
+    let safe_for_terminal = match body.terminal_output_safety {
+        TerminalOutputSafety::Untrusted => core::bytes_appear_printable(&body.bytes),
+        TerminalOutputSafety::FormattedText => formatted_text_appears_terminal_safe(&body.bytes),
+        TerminalOutputSafety::Trusted => true,
+    };
+    if terminal_binary_stdout_guard_enabled(cli, stdout_is_terminal) && !safe_for_terminal {
         write_warning(cli, &binary_response_warning(&body.content_type_label));
         return Ok(());
     }
@@ -19,6 +35,33 @@ pub(super) fn write_stdout_bytes(cli: &Cli, body: &StdoutBody) -> Result<(), Fet
 
     core::write_stdout(&body.bytes)?;
     Ok(())
+}
+
+fn formatted_text_appears_terminal_safe(bytes: &[u8]) -> bool {
+    let mut plain = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'\x1b' {
+            plain.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+        if bytes.get(index + 1) != Some(&b'[') {
+            return false;
+        }
+        let mut end = index + 2;
+        while bytes
+            .get(end)
+            .is_some_and(|byte| byte.is_ascii_digit() || *byte == b';')
+        {
+            end += 1;
+        }
+        if bytes.get(end) != Some(&b'm') {
+            return false;
+        }
+        index = end + 1;
+    }
+    core::bytes_appear_printable(&plain)
 }
 
 pub(super) fn should_page_stdout(
@@ -98,6 +141,7 @@ pub(super) fn terminal_binary_stdout_guard_enabled(cli: &Cli, stdout_is_terminal
     stdout_is_terminal && cli.output.as_deref() != Some("-")
 }
 
+#[cfg(test)]
 pub(super) fn should_warn_for_terminal_binary_stdout(
     cli: &Cli,
     bytes: &[u8],
@@ -111,6 +155,18 @@ mod tests {
     use super::*;
 
     use clap::Parser;
+
+    #[test]
+    fn formatted_terminal_text_allows_sgr_but_rejects_server_controls() {
+        assert!(formatted_text_appears_terminal_safe(
+            b"\x1b[32mformatted\x1b[0m\r\n"
+        ));
+        assert!(!formatted_text_appears_terminal_safe(
+            b"formatted\x1b]52;c;clipboard\x07"
+        ));
+        assert!(!formatted_text_appears_terminal_safe(b"formatted\x1b[2J"));
+        assert!(!formatted_text_appears_terminal_safe(b"overwrite\rtext"));
+    }
 
     #[test]
     fn terminal_binary_stdout_guard_requires_terminal_and_allows_forced_stdout() {

--- a/src/http/response/stream.rs
+++ b/src/http/response/stream.rs
@@ -424,7 +424,7 @@ async fn stream_response_to_stdout_with_binary_check(
     }
 
     let first_chunk = &first_chunk[..n];
-    if !is_printable(first_chunk) {
+    if !initial_stream_chunk_appears_printable(first_chunk) {
         write_warning(
             cli,
             &binary_response_warning(&response_header_content_type_label(response_headers)),
@@ -464,6 +464,11 @@ async fn stream_response_to_stdout_with_binary_check(
     }
 }
 
+fn initial_stream_chunk_appears_printable(bytes: &[u8]) -> bool {
+    let (complete, _carry) = split_incomplete_trailing_text(bytes);
+    is_printable(complete)
+}
+
 /// Like [`copy_async_reader_to_sink`] but checks every chunk with
 /// [`is_printable`] before writing.  If any chunk appears binary the
 /// function drains the remainder and sets `triggered` so the caller can
@@ -490,7 +495,8 @@ where
     // split multi-byte characters are classified on the combined bytes.
     let mut carry: Vec<u8> = Vec::with_capacity(4);
     if !prefix.is_empty() {
-        if !is_printable(prefix) {
+        let (complete, tail) = split_incomplete_trailing_text(prefix);
+        if !is_printable(complete) {
             *triggered = true;
             if let Some(capture) = capture.as_mut() {
                 capture.push(prefix);
@@ -501,7 +507,6 @@ where
             return Ok(written.saturating_add(drained));
         }
 
-        let (complete, tail) = split_incomplete_trailing_utf8(prefix);
         if !complete.is_empty()
             && write_stream_chunk(writer, complete, &mut capture, &mut written, broken_pipe).await?
                 == SinkWriteStatus::Closed
@@ -517,15 +522,12 @@ where
         let n = reader.read(&mut buf).await?;
         if n == 0 {
             if !carry.is_empty() {
-                // Flush an orphaned incomplete suffix. Writing it now
-                // preserves the original bytes; the classifier already
-                // approved the preceding chunk with this suffix present.
-                if write_stream_chunk(writer, &carry, &mut capture, &mut written, broken_pipe)
-                    .await?
-                    == SinkWriteStatus::Closed
-                {
-                    return Ok(written);
+                // An incomplete UTF-8 suffix or bare CR at EOF is unsafe.
+                *triggered = true;
+                if let Some(capture) = capture.as_mut() {
+                    capture.push(&carry);
                 }
+                written = written.saturating_add(i64::try_from(carry.len()).unwrap_or(i64::MAX));
                 carry.clear();
             }
             let _ = stream_sink_status(writer.flush().await, broken_pipe)?;
@@ -538,7 +540,10 @@ where
         combined.extend_from_slice(&carry);
         combined.extend_from_slice(&buf[..n]);
 
-        if !is_printable(&combined) {
+        // Classify only complete sequences. The trailing bytes remain
+        // undecided until the next read (or are rejected at EOF).
+        let (complete, tail) = split_incomplete_trailing_text(&combined);
+        if !is_printable(complete) {
             *triggered = true;
             if let Some(capture) = capture.as_mut() {
                 capture.push(&combined);
@@ -550,9 +555,8 @@ where
             return Ok(written.saturating_add(drained));
         }
 
-        // Classification passed.  Keep any trailing incomplete UTF-8
+        // Classification passed. Keep any trailing incomplete UTF-8 or CR
         // for the next chunk and write the complete portion now.
-        let (complete, tail) = split_incomplete_trailing_utf8(&combined);
         if !complete.is_empty()
             && write_stream_chunk(writer, complete, &mut capture, &mut written, broken_pipe).await?
                 == SinkWriteStatus::Closed
@@ -564,8 +568,22 @@ where
     }
 }
 
+/// Holds back bytes whose terminal-safety classification depends on the next
+/// read: either an incomplete UTF-8 sequence or a trailing carriage return
+/// that is safe only when followed by a newline.
+fn split_incomplete_trailing_text(bytes: &[u8]) -> (&[u8], &[u8]) {
+    let (complete, tail) = split_incomplete_trailing_utf8(bytes);
+    if tail.is_empty() && complete.ends_with(b"\r") {
+        return (
+            &complete[..complete.len() - 1],
+            &complete[complete.len() - 1..],
+        );
+    }
+    (complete, tail)
+}
+
 /// Splits `bytes` into a complete prefix and an incomplete trailing
-/// portion (at most 3 bytes).  The incomplete portion is the longest
+/// portion (at most 3 bytes). The incomplete portion is the longest
 /// suffix that by itself forms an invalid, truncated UTF-8 sequence.
 fn split_incomplete_trailing_utf8(bytes: &[u8]) -> (&[u8], &[u8]) {
     let len = bytes.len();
@@ -1056,6 +1074,14 @@ mod tests {
     }
 
     #[test]
+    fn initial_stream_chunk_defers_split_crlf_and_utf8_classification() {
+        assert!(initial_stream_chunk_appears_printable(b"line one\r"));
+        assert!(initial_stream_chunk_appears_printable(b"caf\xc3"));
+        assert!(!initial_stream_chunk_appears_printable(b"overwrite\rtext"));
+        assert!(!initial_stream_chunk_appears_printable(b"text\x1b[31m"));
+    }
+
+    #[test]
     fn trailing_utf8_detects_split_multibyte_characters() {
         // Complete sequences return no tail.
         assert_eq!(
@@ -1114,6 +1140,32 @@ mod tests {
         assert!(triggered, "guard must trigger on binary data after carry");
         assert_eq!(written, i64::try_from(prefix.len() + suffix.len()).unwrap());
         assert_eq!(writer.bytes, b"ok");
+    }
+
+    #[tokio::test]
+    async fn checked_copy_handles_crlf_split_after_initial_chunk() {
+        let prefix = b"line one\r";
+        let suffix = b"\nline two\r\n";
+        let mut body = prefix.to_vec();
+        body.extend_from_slice(suffix);
+        let mut reader: AsyncReadBox = Box::pin(std::io::Cursor::new(suffix));
+        let mut writer = RecordingAsyncWriter::default();
+        let mut triggered = false;
+
+        let written = copy_checked_async_reader_to_writer(
+            &mut reader,
+            &mut writer,
+            prefix,
+            None,
+            SinkBrokenPipePolicy::Propagate,
+            &mut triggered,
+        )
+        .await
+        .unwrap();
+
+        assert!(!triggered, "guard must allow CRLF split after prefix");
+        assert_eq!(written, i64::try_from(body.len()).unwrap());
+        assert_eq!(writer.bytes, body);
     }
 
     /// Valid UTF-8 text split between the initial prefix and the first

--- a/src/http/transport/client.rs
+++ b/src/http/transport/client.rs
@@ -189,22 +189,31 @@ impl Client {
         } else {
             body
         };
+        // Transport futures carry large protocol state machines. Keep the selected
+        // one on the heap so nested clients such as DoH do not exhaust Windows'
+        // default thread stack while polling a request.
         let response = match version {
             None if (self.config.auto_http3.is_some()
                 || self.config.auto_http3_discovery
                 || self.config.http3_cache.is_some())
                 && url.scheme() == "https" =>
             {
-                self.send_auto_http3(method, url.clone(), headers, body, body_deadline)
+                Box::pin(self.send_auto_http3(method, url.clone(), headers, body, body_deadline))
                     .await
             }
             None | Some(Version::HTTP_11 | Version::HTTP_10 | Version::HTTP_2) => {
-                self.send_pooled(method, url.clone(), headers, body, version, body_deadline)
-                    .await
+                Box::pin(self.send_pooled(
+                    method,
+                    url.clone(),
+                    headers,
+                    body,
+                    version,
+                    body_deadline,
+                ))
+                .await
             }
             Some(Version::HTTP_3) => {
-                self.send_http3(method, url.clone(), headers, body, body_deadline)
-                    .await
+                Box::pin(self.send_http3(method, url.clone(), headers, body, body_deadline)).await
             }
             Some(version) => Err(Error::request(format!(
                 "unsupported HTTP version: {version:?}"

--- a/src/http/transport/proxy.rs
+++ b/src/http/transport/proxy.rs
@@ -216,6 +216,10 @@ impl Proxy {
         self.selected_for(url)
     }
 
+    pub(crate) fn url(&self) -> &str {
+        &self.url
+    }
+
     pub(crate) fn uses_local_target_dns(&self) -> bool {
         self.scheme().is_ok_and(|scheme| scheme == "socks5")
     }
@@ -263,7 +267,7 @@ impl Proxy {
         crate::net::parse_proxy_url(&self.url).map(|url| url.scheme().to_string())
     }
 
-    pub(super) fn basic_auth(&self) -> Result<Option<String>, FetchError> {
+    pub(crate) fn basic_auth(&self) -> Result<Option<String>, FetchError> {
         if let Some(auth) = &self.basic_auth {
             return auth
                 .to_str()

--- a/src/net.rs
+++ b/src/net.rs
@@ -59,12 +59,21 @@ struct SharedDohResolver {
 pub(crate) async fn dial_url(
     url: &Url,
     proxy: Option<&str>,
+    proxy_authorization: Option<&str>,
     dns_server: Option<&str>,
     doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<DialStream, FetchError> {
     if let Some(proxy) = proxy {
-        return dial_proxy(proxy, url, dns_server, doh_tls_config, timeout).await;
+        return dial_proxy_with_authorization(
+            proxy,
+            url,
+            dns_server,
+            doh_tls_config,
+            timeout,
+            proxy_authorization,
+        )
+        .await;
     }
     let stream = connect_tcp_with_doh_tls(url, dns_server, doh_tls_config, timeout).await?;
     Ok(Box::pin(stream))
@@ -997,10 +1006,29 @@ pub(crate) async fn dial_proxy(
     doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<DialStream, FetchError> {
+    dial_proxy_with_authorization(proxy, target, dns_server, doh_tls_config, timeout, None).await
+}
+
+async fn dial_proxy_with_authorization(
+    proxy: &str,
+    target: &Url,
+    dns_server: Option<&str>,
+    doh_tls_config: Option<rustls::ClientConfig>,
+    timeout: TimeoutBudget,
+    proxy_authorization: Option<&str>,
+) -> Result<DialStream, FetchError> {
     let proxy_url = parse_proxy_url(proxy)?;
     match proxy_url.scheme() {
         "http" | "https" => {
-            dial_http_proxy_tunnel(proxy, &proxy_url, target, timeout, None, None).await
+            dial_http_proxy_tunnel(
+                proxy,
+                &proxy_url,
+                target,
+                timeout,
+                None,
+                proxy_authorization.map(str::to_string),
+            )
+            .await
         }
         "socks5" | "socks5h" => {
             dial_socks5_proxy(&proxy_url, target, dns_server, doh_tls_config, timeout).await

--- a/src/websocket/interactive.rs
+++ b/src/websocket/interactive.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::io::{self, Read, Write};
 use std::sync::mpsc;
 use std::thread;
@@ -6,88 +7,96 @@ use std::time::Duration;
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use tokio::sync::mpsc as tokio_mpsc;
 use tokio_tungstenite::tungstenite::{Error as WsError, Message};
+use unicode_width::UnicodeWidthChar;
 
 use crate::error::FetchError;
 use crate::format::json;
 
-use super::websocket_error;
+use super::{WebSocketMessageMode, close_outcome_result, outgoing_message, websocket_error};
 
 pub const PROMPT: &str = "❯ ";
 const MIN_ROWS: usize = 5;
 const READ_BUF_SIZE: usize = 256;
 const STDIN_CHAN_BUF: usize = 64;
 const MAX_MESSAGES: usize = 10_000;
+const MAX_HISTORY_BYTES: usize = 4 * 1024 * 1024;
+const MAX_INPUT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_ESCAPE_SEQUENCE_BYTES: usize = 1024;
+const MAX_PENDING_INPUT_BYTES: usize = MAX_ESCAPE_SEQUENCE_BYTES + READ_BUF_SIZE;
 const STATUS_GAP_ROWS: usize = 1;
 
 #[derive(Debug, Default)]
 pub struct LineEditor {
-    buf: Vec<char>,
-    pos: usize,
+    // A gap buffer: characters before the cursor and characters after it
+    // in reverse order. Common insertion, deletion, and cursor movement
+    // are O(1), including large pasted input.
+    left: Vec<char>,
+    right: Vec<char>,
+    byte_len: usize,
 }
 
 impl LineEditor {
     pub fn insert(&mut self, ch: char) {
-        self.buf.insert(self.pos, ch);
-        self.pos += 1;
+        self.left.push(ch);
+        self.byte_len += ch.len_utf8();
     }
 
     pub fn backspace(&mut self) -> bool {
-        if self.pos == 0 {
+        let Some(ch) = self.left.pop() else {
             return false;
-        }
-        self.pos -= 1;
-        self.buf.remove(self.pos);
+        };
+        self.byte_len -= ch.len_utf8();
         true
     }
 
     pub fn delete(&mut self) -> bool {
-        if self.pos >= self.buf.len() {
+        let Some(ch) = self.right.pop() else {
             return false;
-        }
-        self.buf.remove(self.pos);
+        };
+        self.byte_len -= ch.len_utf8();
         true
     }
 
     pub fn move_left(&mut self) -> bool {
-        if self.pos == 0 {
+        let Some(ch) = self.left.pop() else {
             return false;
-        }
-        self.pos -= 1;
+        };
+        self.right.push(ch);
         true
     }
 
     pub fn move_right(&mut self) -> bool {
-        if self.pos >= self.buf.len() {
+        let Some(ch) = self.right.pop() else {
             return false;
-        }
-        self.pos += 1;
+        };
+        self.left.push(ch);
         true
     }
 
     pub fn home(&mut self) {
-        self.pos = 0;
+        while let Some(ch) = self.left.pop() {
+            self.right.push(ch);
+        }
     }
 
     pub fn end(&mut self) {
-        self.pos = self.buf.len();
+        while let Some(ch) = self.right.pop() {
+            self.left.push(ch);
+        }
     }
 
     pub fn clear_line(&mut self) {
-        self.buf.clear();
-        self.pos = 0;
+        self.left.clear();
+        self.right.clear();
+        self.byte_len = 0;
     }
 
     pub fn delete_word(&mut self) {
-        if self.pos == 0 {
-            return;
+        while self.left.last() == Some(&' ') {
+            self.backspace();
         }
-        while self.pos > 0 && self.buf[self.pos - 1] == ' ' {
-            self.pos -= 1;
-            self.buf.remove(self.pos);
-        }
-        while self.pos > 0 && self.buf[self.pos - 1] != ' ' {
-            self.pos -= 1;
-            self.buf.remove(self.pos);
+        while self.left.last().is_some_and(|ch| *ch != ' ') {
+            self.backspace();
         }
     }
 
@@ -98,23 +107,28 @@ impl LineEditor {
     }
 
     pub fn text(&self) -> String {
-        self.buf.iter().collect()
+        self.left.iter().chain(self.right.iter().rev()).collect()
     }
 
     pub fn set_text(&mut self, text: &str) {
-        self.buf = text.chars().collect();
-        self.pos = self.buf.len();
+        self.left = text.chars().collect();
+        self.right.clear();
+        self.byte_len = text.len();
     }
 
     pub fn position(&self) -> usize {
-        self.pos
+        self.left.len()
+    }
+
+    pub fn byte_len(&self) -> usize {
+        self.byte_len
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MessageEntry {
     arrow: Option<&'static str>,
-    data: Option<Vec<u8>>,
+    data: Option<String>,
     binary_len: usize,
 }
 
@@ -122,7 +136,7 @@ impl MessageEntry {
     pub fn text(arrow: &'static str, data: impl Into<Vec<u8>>) -> Self {
         Self {
             arrow: Some(arrow),
-            data: Some(data.into()),
+            data: Some(String::from_utf8_lossy(&data.into()).into_owned()),
             binary_len: 0,
         }
     }
@@ -143,7 +157,8 @@ pub struct InteractiveMode {
     cols: usize,
     next_row: usize,
     status: String,
-    messages: Vec<MessageEntry>,
+    messages: VecDeque<MessageEntry>,
+    retained_message_bytes: usize,
     format_json: bool,
     color_json: bool,
 }
@@ -166,7 +181,8 @@ impl InteractiveMode {
             cols,
             next_row: 0,
             status: "connected".to_string(),
-            messages: Vec::new(),
+            messages: VecDeque::new(),
+            retained_message_bytes: 0,
             format_json,
             color_json,
         }
@@ -270,8 +286,7 @@ impl InteractiveMode {
     }
 
     pub fn render_binary_indicator<W: Write>(&mut self, out: &mut W, len: usize) -> io::Result<()> {
-        self.messages.push(MessageEntry::binary(len));
-        self.truncate_messages();
+        self.push_message(MessageEntry::binary(len));
         self.write_binary(out, len)?;
         self.draw_input_line(out)
     }
@@ -292,15 +307,27 @@ impl InteractiveMode {
     ) -> io::Result<(Vec<u8>, Vec<InputAction>)> {
         let mut actions = Vec::new();
         let mut index = 0;
+        let mut redraw = false;
+        let mut input_bytes = self.editor.byte_len();
         while index < buf.len() {
             let byte = buf[index];
 
             if byte == 0x1b {
                 let consumed = self.handle_escape(&buf[index..]);
                 if consumed == 0 {
+                    if buf.len() - index > MAX_ESCAPE_SEQUENCE_BYTES {
+                        self.status = "oversized terminal escape sequence discarded".to_string();
+                        self.draw_status(out)?;
+                        self.draw_input_line(out)?;
+                        return Ok((Vec::new(), actions));
+                    }
+                    if redraw {
+                        self.draw_input_line(out)?;
+                    }
                     return Ok((buf[index..].to_vec(), actions));
                 }
-                self.draw_input_line(out)?;
+                input_bytes = self.editor.byte_len();
+                redraw = true;
                 index += consumed;
                 continue;
             }
@@ -312,44 +339,35 @@ impl InteractiveMode {
                 }
                 0x0d => {
                     let text = self.editor.submit();
-                    self.draw_input_line(out)?;
-                    if !text.is_empty() {
-                        actions.push(InputAction::Send(text));
-                    }
+                    actions.push(InputAction::Send(text));
+                    input_bytes = 0;
+                    redraw = true;
                     index += 1;
                     continue;
                 }
                 0x7f | 0x08 => {
                     self.editor.backspace();
-                    self.draw_input_line(out)?;
+                    input_bytes = self.editor.byte_len();
+                    redraw = true;
                     index += 1;
                     continue;
                 }
-                0x01 => {
-                    self.editor.home();
-                    self.draw_input_line(out)?;
-                    index += 1;
-                    continue;
-                }
-                0x05 => {
-                    self.editor.end();
-                    self.draw_input_line(out)?;
-                    index += 1;
-                    continue;
-                }
+                0x01 => self.editor.home(),
+                0x05 => self.editor.end(),
                 0x15 => {
                     self.editor.clear_line();
-                    self.draw_input_line(out)?;
-                    index += 1;
-                    continue;
+                    input_bytes = 0;
                 }
                 0x17 => {
                     self.editor.delete_word();
-                    self.draw_input_line(out)?;
-                    index += 1;
-                    continue;
+                    input_bytes = self.editor.byte_len();
                 }
                 _ => {}
+            }
+            if matches!(byte, 0x01 | 0x05 | 0x15 | 0x17) {
+                redraw = true;
+                index += 1;
+                continue;
             }
 
             if byte >= 0x20 {
@@ -358,20 +376,35 @@ impl InteractiveMode {
                     continue;
                 };
                 if index + width > buf.len() {
+                    if redraw {
+                        self.draw_input_line(out)?;
+                    }
                     return Ok((buf[index..].to_vec(), actions));
                 }
                 let Ok(text) = std::str::from_utf8(&buf[index..index + width]) else {
                     index += 1;
                     continue;
                 };
+                if input_bytes + width > MAX_INPUT_BYTES {
+                    self.status = format!(
+                        "input exceeds maximum of {MAX_INPUT_BYTES} bytes; extra input rejected"
+                    );
+                    self.draw_status(out)?;
+                    index += width;
+                    continue;
+                }
                 let ch = text.chars().next().expect("non-empty UTF-8 sequence");
                 self.editor.insert(ch);
-                self.draw_input_line(out)?;
+                input_bytes += width;
+                redraw = true;
                 index += width;
                 continue;
             }
 
             index += 1;
+        }
+        if redraw {
+            self.draw_input_line(out)?;
         }
         Ok((Vec::new(), actions))
     }
@@ -451,11 +484,11 @@ impl InteractiveMode {
         let arrow = msg.arrow.unwrap_or("←");
         let prefix_width = display_width(&format!("{arrow} "));
         let width = self.cols.saturating_sub(prefix_width).max(1);
-        Ok(wrap_display_lines(&self.format_message(data)?, width).len())
+        Ok(wrap_display_lines(data, width).len())
     }
 
     pub fn format_message(&self, data: &[u8]) -> Result<String, FetchError> {
-        if self.format_json && serde_json::from_slice::<serde_json::Value>(data).is_ok() {
+        if self.format_json {
             let mut formatted = crate::core::Printer::new(self.color_json);
             if json::format_json_line_to(data, &mut formatted).is_ok() {
                 let formatted = formatted.into_bytes();
@@ -492,9 +525,13 @@ impl InteractiveMode {
         arrow: &'static str,
         data: &[u8],
     ) -> io::Result<()> {
-        self.messages.push(MessageEntry::text(arrow, data));
-        self.truncate_messages();
-        self.write_message(out, arrow, data)?;
+        let formatted = self.format_message(data).map_err(io::Error::other)?;
+        self.write_formatted_message(out, arrow, &formatted)?;
+        self.push_message(MessageEntry {
+            arrow: Some(arrow),
+            data: Some(formatted),
+            binary_len: 0,
+        });
         self.draw_input_line(out)
     }
 
@@ -517,14 +554,17 @@ impl InteractiveMode {
             start = index;
         }
 
-        let replay = self.messages[start..].to_vec();
-        for message in replay {
-            if let Some(data) = message.data {
-                self.write_message(out, message.arrow.unwrap_or("←"), &data)?;
+        // Temporarily move history out so replay can mutate screen state while
+        // iterating entries by reference, without cloning message payloads.
+        let messages = std::mem::take(&mut self.messages);
+        for message in messages.iter().skip(start) {
+            if let Some(data) = message.data.as_deref() {
+                self.write_formatted_message(out, message.arrow.unwrap_or("←"), data)?;
             } else {
                 self.write_binary(out, message.binary_len)?;
             }
         }
+        self.messages = messages;
         Ok(())
     }
 
@@ -551,60 +591,60 @@ impl InteractiveMode {
             return Ok(());
         }
         let input_row = self.rows - 1;
-        let text = self.editor.text();
-        let pos = self.editor.position();
         let available = self.cols.saturating_sub(display_width(PROMPT)).max(1);
-        let runes: Vec<char> = text.chars().collect();
+        // Bound work even when a paste contains millions of combining marks.
+        // Four code points per cell leaves room for ordinary grapheme clusters
+        // without allowing redraw cost to scale with the full editor buffer.
+        let max_visible_chars = available.saturating_mul(4).max(32);
 
-        let width_to_cursor = runes
-            .iter()
-            .take(pos)
-            .map(|ch| char_display_width(*ch).max(1))
-            .sum::<usize>();
-        let mut display_start = 0;
-        if width_to_cursor >= available {
-            let mut width = 0;
-            for index in (0..pos).rev() {
-                width += char_display_width(runes[index]).max(1);
-                if width >= available {
-                    display_start = index + 1;
-                    break;
-                }
+        let mut display_start = self.editor.left.len();
+        let mut width_before_cursor = 0;
+        for (seen, ch) in self.editor.left.iter().rev().enumerate() {
+            if seen >= max_visible_chars {
+                break;
             }
+            let width = char_display_width(*ch);
+            if width_before_cursor + width >= available && width > 0 {
+                break;
+            }
+            display_start -= 1;
+            width_before_cursor += width;
         }
-
-        let mut cursor_col = display_width(PROMPT);
-        for ch in runes.iter().take(pos).skip(display_start) {
-            cursor_col += char_display_width(*ch).max(1);
-        }
+        let cursor_col = display_width(PROMPT) + width_before_cursor;
 
         write!(out, "\x1b[{input_row};1H\x1b[2K")?;
         write!(out, "\x1b[1m{PROMPT}\x1b[0m")?;
 
         let mut displayed_width = 0;
-        for ch in runes.iter().skip(display_start) {
-            let char_width = char_display_width(*ch).max(1);
-            if displayed_width + char_width > available {
+        for (displayed_chars, ch) in self.editor.left[display_start..]
+            .iter()
+            .chain(self.editor.right.iter().rev())
+            .enumerate()
+        {
+            if displayed_chars >= max_visible_chars {
+                break;
+            }
+            let width = char_display_width(*ch);
+            if displayed_width + width > available {
                 break;
             }
             write!(out, "{ch}")?;
-            displayed_width += char_width;
+            displayed_width += width;
         }
 
         write!(out, "\x1b[{input_row};{}H", cursor_col + 1)
     }
 
-    fn write_message<W: Write>(
+    fn write_formatted_message<W: Write>(
         &mut self,
         out: &mut W,
         arrow: &'static str,
-        data: &[u8],
+        formatted: &str,
     ) -> io::Result<()> {
         let prefix = format!("{arrow} ");
         let continuation = "  ";
         let width = self.cols.saturating_sub(display_width(&prefix)).max(1);
-        let formatted = self.format_message(data).map_err(io::Error::other)?;
-        let lines = wrap_display_lines(&formatted, width);
+        let lines = wrap_display_lines(formatted, width);
         for (index, line) in lines.iter().enumerate() {
             self.write_physical_line(out)?;
             if index == 0 {
@@ -638,17 +678,33 @@ impl InteractiveMode {
         self.rows.saturating_sub(3 + STATUS_GAP_ROWS).max(1)
     }
 
-    fn truncate_messages(&mut self) {
-        if self.messages.len() > MAX_MESSAGES {
-            let keep_from = self.messages.len() - MAX_MESSAGES;
-            self.messages.drain(..keep_from);
+    fn push_message(&mut self, mut message: MessageEntry) {
+        let mut bytes = message.data.as_ref().map_or(0, String::len);
+        if bytes > MAX_HISTORY_BYTES {
+            message = MessageEntry::text(
+                message.arrow.unwrap_or("←"),
+                format!("[message omitted: {bytes} bytes exceeds history budget]"),
+            );
+            bytes = message.data.as_ref().map_or(0, String::len);
+        }
+        self.retained_message_bytes += bytes;
+        self.messages.push_back(message);
+        while self.messages.len() > MAX_MESSAGES || self.retained_message_bytes > MAX_HISTORY_BYTES
+        {
+            let Some(removed) = self.messages.pop_front() else {
+                break;
+            };
+            self.retained_message_bytes = self
+                .retained_message_bytes
+                .saturating_sub(removed.data.as_ref().map_or(0, String::len));
         }
     }
 }
 
-pub async fn run_terminal<S>(
+pub(super) async fn run_terminal<S>(
     stream: S,
     initial_message: Option<&[u8]>,
+    message_mode: WebSocketMessageMode,
     format_json: bool,
     color_json: bool,
     rows: usize,
@@ -672,8 +728,8 @@ where
     resize_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     resize_interval.tick().await;
 
-    if let Some(data) = initial_message.filter(|data| !data.is_empty()) {
-        if let Err(err) = send_text(&mut sink, data).await {
+    if let Some(data) = initial_message {
+        if let Err(err) = send_message(&mut sink, data, message_mode).await {
             teardown(&mut mode, &mut stdout)?;
             return Err(err);
         }
@@ -686,9 +742,26 @@ where
             raw = input_rx.recv() => {
                 let Some(raw) = raw else {
                     teardown(&mut mode, &mut stdout)?;
+                    graceful_close(&mut sink).await?;
                     return Ok(());
                 };
-                pending.extend_from_slice(&raw);
+                let raw = match raw {
+                    Ok(raw) => raw,
+                    Err(err) => {
+                        teardown(&mut mode, &mut stdout)?;
+                        let _ = graceful_close(&mut sink).await;
+                        return Err(err.into());
+                    }
+                };
+                if pending.len().saturating_add(raw.len()) > MAX_PENDING_INPUT_BYTES {
+                    pending.clear();
+                    mode.set_status(
+                        &mut stdout,
+                        "oversized incomplete terminal input discarded",
+                    )?;
+                } else {
+                    pending.extend_from_slice(&raw);
+                }
                 let (rest, actions) = mode.handle_input(&mut stdout, &pending)?;
                 pending = rest;
                 stdout.flush()?;
@@ -696,12 +769,12 @@ where
                     match action {
                         InputAction::Cancel => {
                             teardown(&mut mode, &mut stdout)?;
-                            let _ = sink.send(Message::Close(None)).await;
+                            graceful_close(&mut sink).await?;
                             return Ok(());
                         }
                         InputAction::Send(text) => {
                             let data = text.as_bytes().to_vec();
-                            match send_text(&mut sink, &data).await {
+                            match send_message(&mut sink, &data, message_mode).await {
                                 Ok(()) => mode.note_send_success(&mut stdout, &data)?,
                                 Err(err) => mode.note_send_failure(&mut stdout, &text, err)?,
                             }
@@ -718,9 +791,10 @@ where
                 match message.map_err(websocket_error)? {
                     Message::Text(text) => mode.render_received_message(&mut stdout, text.as_str().as_bytes())?,
                     Message::Binary(bytes) => mode.render_binary_indicator(&mut stdout, bytes.len())?,
-                    Message::Close(_) => {
+                    Message::Close(frame) => {
                         teardown(&mut mode, &mut stdout)?;
-                        return Ok(());
+                        sink.flush().await.map_err(websocket_error)?;
+                        return close_outcome_result(super::ReadOutcome::PeerClosed(frame));
                     }
                     Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
                 }
@@ -730,7 +804,7 @@ where
                 if let Some(size) = crate::core::terminal_size() {
                     if !InteractiveMode::is_screen_tall_enough(size.rows) {
                         teardown(&mut mode, &mut stdout)?;
-                        let _ = sink.send(Message::Close(None)).await;
+                        graceful_close(&mut sink).await?;
                         return Ok(());
                     }
                     if size.rows != mode.rows() || size.cols != mode.cols() {
@@ -743,18 +817,30 @@ where
     }
 }
 
-async fn send_text<S>(sink: &mut S, data: &[u8]) -> Result<(), FetchError>
+async fn send_message<S>(
+    sink: &mut S,
+    data: &[u8],
+    mode: WebSocketMessageMode,
+) -> Result<(), FetchError>
 where
     S: Sink<Message, Error = WsError> + Unpin,
 {
-    sink.send(Message::Text(
-        String::from_utf8_lossy(data).into_owned().into(),
-    ))
-    .await
-    .map_err(websocket_error)
+    sink.send(outgoing_message(data.to_vec(), mode)?)
+        .await
+        .map_err(websocket_error)
 }
 
-fn spawn_stdin_reader(tx: tokio_mpsc::Sender<Vec<u8>>) {
+async fn graceful_close<S>(sink: &mut S) -> Result<(), FetchError>
+where
+    S: Sink<Message, Error = WsError> + Unpin,
+{
+    sink.send(Message::Close(None))
+        .await
+        .map_err(websocket_error)?;
+    sink.flush().await.map_err(websocket_error)
+}
+
+fn spawn_stdin_reader(tx: tokio_mpsc::Sender<Result<Vec<u8>, io::Error>>) {
     thread::spawn(move || {
         let mut stdin = io::stdin();
         let mut buf = [0_u8; READ_BUF_SIZE];
@@ -762,18 +848,21 @@ fn spawn_stdin_reader(tx: tokio_mpsc::Sender<Vec<u8>>) {
             match stdin.read(&mut buf) {
                 Ok(0) => return,
                 Ok(n) => {
-                    if tx.blocking_send(buf[..n].to_vec()).is_err() {
+                    if tx.blocking_send(Ok(buf[..n].to_vec())).is_err() {
                         return;
                     }
                 }
-                Err(_) => return,
+                Err(err) => {
+                    let _ = tx.blocking_send(Err(err));
+                    return;
+                }
             }
         }
     });
 }
 
 async fn detect_cursor_row_async<W: Write>(
-    input_rx: &mut tokio_mpsc::Receiver<Vec<u8>>,
+    input_rx: &mut tokio_mpsc::Receiver<Result<Vec<u8>, io::Error>>,
     out: &mut W,
 ) -> io::Result<(usize, Vec<u8>)> {
     write!(out, "\x1b[6n")?;
@@ -794,7 +883,7 @@ async fn detect_cursor_row_async<W: Write>(
                 let Some(raw) = raw else {
                     return Ok((1, captured));
                 };
-                captured.extend_from_slice(&raw);
+                captured.extend_from_slice(&raw?);
             }
             _ = &mut deadline => {
                 return Ok((1, captured));
@@ -1044,7 +1133,7 @@ pub fn wrap_display_lines(text: &str, width: usize) -> Vec<String> {
                 .chars()
                 .next()
                 .expect("index is inside string bounds");
-            let char_width = char_display_width(ch).max(1);
+            let char_width = char_display_width(ch);
             if line_width > 0 && line_width + char_width > width {
                 lines.push(std::mem::take(&mut line));
                 line_width = 0;
@@ -1069,7 +1158,7 @@ pub fn fit_display_width(text: &str, width: usize) -> String {
     let mut out = String::new();
     let mut used = 0;
     for ch in text.chars() {
-        let char_width = char_display_width(ch).max(1);
+        let char_width = char_display_width(ch);
         if used + char_width > width {
             break;
         }
@@ -1091,7 +1180,7 @@ fn display_width(text: &str) -> usize {
             .chars()
             .next()
             .expect("index is inside string bounds");
-        width += char_display_width(ch).max(1);
+        width += char_display_width(ch);
         index += ch.len_utf8();
     }
     width
@@ -1112,27 +1201,7 @@ fn ansi_csi_sequence(text: &str, start: usize) -> Option<(&str, usize)> {
 }
 
 fn char_display_width(ch: char) -> usize {
-    if ch == '\n' || ch == '\r' {
-        return 0;
-    }
-    if is_wide(ch) { 2 } else { 1 }
-}
-
-fn is_wide(ch: char) -> bool {
-    matches!(
-        ch as u32,
-        0x1100..=0x115f
-            | 0x2329..=0x232a
-            | 0x2e80..=0xa4cf
-            | 0xac00..=0xd7a3
-            | 0xf900..=0xfaff
-            | 0xfe10..=0xfe19
-            | 0xfe30..=0xfe6f
-            | 0xff00..=0xff60
-            | 0xffe0..=0xffe6
-            | 0x1f300..=0x1f64f
-            | 0x1f900..=0x1f9ff
-    )
+    UnicodeWidthChar::width(ch).unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -1255,6 +1324,20 @@ mod tests {
     }
 
     #[test]
+    fn test_line_editor_delete_updates_byte_length_before_replacement() {
+        let mut editor = LineEditor::default();
+        editor.set_text("aé");
+        assert_eq!(editor.byte_len(), 3);
+
+        editor.move_left();
+        assert!(editor.delete());
+        assert_eq!(editor.byte_len(), 1);
+        editor.insert('é');
+        assert_eq!(editor.byte_len(), 3);
+        assert_eq!(editor.text(), "aé");
+    }
+
+    #[test]
     fn test_line_editor_insert_middle() {
         let mut editor = LineEditor::default();
         editor.insert('a');
@@ -1304,6 +1387,114 @@ mod tests {
         assert_eq!(mode.handle_escape(&[0x1b]), 0);
         assert_eq!(mode.handle_escape(&[0x1b, b'[']), 0);
         assert_eq!(mode.handle_escape(&[0x1b, b'[', b'3']), 0);
+    }
+
+    #[test]
+    fn interactive_input_limit_handles_multibyte_boundary() {
+        let mut accepted = InteractiveMode::new(20, false);
+        accepted.editor.byte_len = MAX_INPUT_BYTES - 2;
+        let mut out = Vec::new();
+        let (pending, actions) = accepted.handle_input(&mut out, "é".as_bytes()).unwrap();
+        assert!(pending.is_empty());
+        assert!(actions.is_empty());
+        assert_eq!(accepted.editor.byte_len(), MAX_INPUT_BYTES);
+        assert_eq!(accepted.editor.text(), "é");
+
+        let mut rejected = InteractiveMode::new(20, false);
+        rejected.editor.byte_len = MAX_INPUT_BYTES - 1;
+        let (pending, actions) = rejected.handle_input(&mut out, "é".as_bytes()).unwrap();
+        assert!(pending.is_empty());
+        assert!(actions.is_empty());
+        assert!(rejected.editor.text().is_empty());
+        assert!(rejected.status.contains("extra input rejected"));
+    }
+
+    #[test]
+    fn interactive_history_enforces_byte_budget_and_placeholder() {
+        let mut mode = InteractiveMode::new(20, false);
+        mode.push_message(MessageEntry {
+            arrow: Some("←"),
+            data: Some("x".repeat(MAX_HISTORY_BYTES + 1)),
+            binary_len: 0,
+        });
+        assert_eq!(mode.messages.len(), 1);
+        assert!(
+            mode.messages[0]
+                .data
+                .as_deref()
+                .unwrap()
+                .contains("message omitted")
+        );
+        assert!(mode.retained_message_bytes <= MAX_HISTORY_BYTES);
+
+        let mut mode = InteractiveMode::new(20, false);
+        mode.push_message(MessageEntry {
+            arrow: Some("←"),
+            data: Some("a".repeat(3 * 1024 * 1024)),
+            binary_len: 0,
+        });
+        mode.push_message(MessageEntry {
+            arrow: Some("←"),
+            data: Some("b".repeat(2 * 1024 * 1024)),
+            binary_len: 0,
+        });
+        assert_eq!(mode.messages.len(), 1);
+        assert_eq!(mode.retained_message_bytes, 2 * 1024 * 1024);
+
+        mode.push_message(MessageEntry::binary(usize::MAX));
+        assert_eq!(mode.messages.len(), 2);
+        assert_eq!(mode.retained_message_bytes, 2 * 1024 * 1024);
+        assert!(mode.retained_message_bytes <= MAX_HISTORY_BYTES);
+    }
+
+    #[test]
+    fn oversized_incomplete_escape_sequence_is_discarded() {
+        let mut mode = InteractiveMode::new(20, false);
+        let mut out = Vec::new();
+        mode.setup_screen(&mut out, 8, 20, 1).unwrap();
+        out.clear();
+        let mut input = vec![0x1b, b'['];
+        input.extend(std::iter::repeat_n(b'1', MAX_ESCAPE_SEQUENCE_BYTES));
+
+        let (pending, actions) = mode.handle_input(&mut out, &input).unwrap();
+
+        assert!(pending.is_empty());
+        assert!(actions.is_empty());
+        assert_eq!(mode.status, "oversized terminal escape sequence discarded");
+    }
+
+    #[test]
+    fn completing_long_escape_preserves_following_input() {
+        let mut mode = InteractiveMode::new(20, false);
+        let mut out = Vec::new();
+        let mut first = vec![0x1b, b'['];
+        first.extend(std::iter::repeat_n(
+            b'1',
+            MAX_ESCAPE_SEQUENCE_BYTES - first.len(),
+        ));
+        let (mut pending, actions) = mode.handle_input(&mut out, &first).unwrap();
+        assert_eq!(pending.len(), MAX_ESCAPE_SEQUENCE_BYTES);
+        assert!(actions.is_empty());
+
+        let next = b"mhello";
+        assert!(pending.len() + next.len() <= MAX_PENDING_INPUT_BYTES);
+        pending.extend_from_slice(next);
+        let (pending, actions) = mode.handle_input(&mut out, &pending).unwrap();
+        assert!(pending.is_empty());
+        assert!(actions.is_empty());
+        assert_eq!(mode.editor.text(), "hello");
+    }
+
+    #[test]
+    fn input_redraw_is_bounded_for_many_zero_width_characters() {
+        let mut mode = InteractiveMode::new(20, false);
+        mode.rows = 8;
+        mode.editor.set_text(&"\u{301}".repeat(10_000));
+        let mut out = Vec::new();
+
+        mode.draw_input_line(&mut out).unwrap();
+
+        assert!(out.len() < 1024, "redraw output was {} bytes", out.len());
     }
 
     #[test]

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -22,6 +22,8 @@ use tokio_tungstenite::tungstenite::http::{
     Version as WsVersion,
 };
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
+use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::{Error as WsError, Message};
 use tokio_tungstenite::{Connector, client_async_tls_with_config};
 use url::Url;
@@ -38,7 +40,7 @@ use crate::net::DialStream;
 
 pub mod interactive;
 
-const STDIN_MESSAGE_CHANNEL_CAPACITY: usize = 16;
+const STDIN_MESSAGE_CHANNEL_CAPACITY: usize = 1;
 const STDIN_BINARY_CHUNK_SIZE: usize = 16 * 1024;
 const STDIN_TEXT_MESSAGE_MAX_BYTES: usize = 16 * 1024 * 1024;
 const WEBSOCKET_MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
@@ -51,8 +53,15 @@ enum MessageOutput {
     Closed,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ReadOutcome {
+    Ended,
+    OutputClosed,
+    PeerClosed(Option<CloseFrame>),
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum WebSocketMessageMode {
+pub(super) enum WebSocketMessageMode {
     Auto,
     Text,
     Binary,
@@ -73,6 +82,9 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     if cli.timing {
         warnings.push("--timing is not supported for WebSocket connections".to_string());
     }
+    if cli.pager.is_some() {
+        warnings.push("--pager is not supported for WebSocket connections".to_string());
+    }
     write_warnings(cli, &warnings);
     let interactive = should_use_interactive(cli)?;
 
@@ -82,7 +94,9 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
         print_request_metadata(cli, method, &url, Some(request.headers()));
         return Ok(0);
     }
-    let initial_message = websocket_initial_message(cli)?;
+    // Keep the body descriptor until the handshake completes, so `-d @-`
+    // cannot consume stdin before the connection is established.
+    let initial_body = crate::http::request_body(cli)?;
     if cli.verbose >= 2 && !cli.silent {
         print_request_metadata(cli, method, &url, Some(request.headers()));
     }
@@ -112,39 +126,66 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
 
     print_response_metadata(cli, &response);
 
-    if interactive
-        && let Some(size) = core::terminal_size()
-        && interactive::InteractiveMode::is_screen_tall_enough(size.rows)
-    {
-        let stdio = core::stdio();
-        interactive::run_terminal(
-            stream,
-            initial_message.as_deref(),
-            should_format_for_interactive(cli),
-            stdio.stdout_color(cli.color.as_deref()),
-            size.rows,
-            size.cols,
-        )
+    // Use a detached OS thread rather than Tokio's blocking pool. A read from
+    // an open stdin pipe cannot be cancelled, and Tokio waits for its blocking
+    // pool during shutdown. Dropping this receiver on timeout lets the process
+    // exit without waiting for the reader thread.
+    let (initial_tx, initial_rx) = tokio::sync::oneshot::channel();
+    thread::spawn(move || {
+        let _ = initial_tx.send(websocket_initial_message(initial_body));
+    });
+    let initial_message = request_budget
+        .run(async move {
+            initial_rx.await.map_err(|_| {
+                FetchError::Runtime("WebSocket body reader stopped unexpectedly".to_string())
+            })?
+        })
         .await?;
-        return Ok(0);
+
+    if interactive {
+        match core::terminal_size() {
+            Some(size) if interactive::InteractiveMode::is_screen_tall_enough(size.rows) => {
+                let stdio = core::stdio();
+                interactive::run_terminal(
+                    stream,
+                    initial_message.as_deref(),
+                    message_mode(cli),
+                    should_format_for_interactive(cli),
+                    stdio.stdout_color(cli.color.as_deref()),
+                    size.rows,
+                    size.cols,
+                )
+                .await?;
+                return Ok(0);
+            }
+            _ if matches!(cli.ws_interactive.as_deref(), Some("on")) => {
+                return Err(
+                    "--ws-interactive on requires a terminal at least five rows tall".into(),
+                );
+            }
+            _ => {}
+        }
     }
 
     let (mut sender, mut receiver) = stream.split();
-    let send_messages =
-        send_noninteractive_messages(&mut sender, initial_message, message_mode(cli));
-    let receive_messages = read_messages(cli, &mut receiver);
-    tokio::pin!(send_messages);
-    tokio::pin!(receive_messages);
-    tokio::select! {
-        send_result = &mut send_messages => {
-            send_result?;
-            receive_messages.await?;
+    let outcome = {
+        let send_messages =
+            send_noninteractive_messages(&mut sender, initial_message, message_mode(cli));
+        let receive_messages = read_messages(cli, &mut receiver);
+        tokio::pin!(send_messages);
+        tokio::pin!(receive_messages);
+        tokio::select! {
+            send_result = &mut send_messages => {
+                send_result?;
+                receive_messages.await?
+            }
+            receive_result = &mut receive_messages => receive_result?,
         }
-        receive_result = &mut receive_messages => {
-            receive_result?;
-        }
+    };
+    if matches!(outcome, ReadOutcome::PeerClosed(_)) {
+        sender.flush().await.map_err(websocket_error)?;
     }
-    Ok(0)
+    close_outcome_result(outcome).map(|()| 0)
 }
 
 fn websocket_url(raw: &str) -> Result<Url, FetchError> {
@@ -215,6 +256,7 @@ fn websocket_config() -> WebSocketConfig {
     // Keep inbound message allocation policy owned by fetch instead of inheriting
     // dependency defaults. The limit matches non-interactive text stdin messages.
     WebSocketConfig::default()
+        .max_write_buffer_size(WEBSOCKET_MAX_MESSAGE_BYTES * 2)
         .max_frame_size(Some(WEBSOCKET_MAX_FRAME_BYTES))
         .max_message_size(Some(WEBSOCKET_MAX_MESSAGE_BYTES))
 }
@@ -224,9 +266,13 @@ async fn dial_websocket(
     url: &Url,
     timeout: TimeoutBudget,
 ) -> Result<DialStream, FetchError> {
+    let proxy = crate::http::client::effective_proxy_for_websocket(cli.proxy.as_deref(), url)?;
     Box::pin(crate::net::dial_url(
         url,
-        cli.proxy.as_deref(),
+        proxy.as_ref().map(|proxy| proxy.url.as_str()),
+        proxy
+            .as_ref()
+            .and_then(|proxy| proxy.authorization.as_deref()),
         cli.dns_server.as_deref(),
         websocket_doh_tls_config(cli)?,
         timeout,
@@ -312,11 +358,13 @@ fn interactive_for_mode(mode: Option<&str>, all_terms: bool) -> Result<bool, Fet
     }
 }
 
-fn websocket_initial_message(cli: &Cli) -> Result<Option<Vec<u8>>, FetchError> {
+fn websocket_initial_message(
+    body: crate::http::RequestBody,
+) -> Result<Option<Vec<u8>>, FetchError> {
     let limit_error =
         format!("WebSocket initial message exceeds maximum of {WEBSOCKET_MAX_MESSAGE_BYTES} bytes");
     Ok(crate::http::request_body_into_bytes_limited(
-        crate::http::request_body(cli)?,
+        body,
         WEBSOCKET_MAX_MESSAGE_BYTES,
         &limit_error,
     )?
@@ -350,7 +398,10 @@ where
     Ok(())
 }
 
-fn outgoing_message(bytes: Vec<u8>, mode: WebSocketMessageMode) -> Result<Message, FetchError> {
+pub(super) fn outgoing_message(
+    bytes: Vec<u8>,
+    mode: WebSocketMessageMode,
+) -> Result<Message, FetchError> {
     match mode {
         WebSocketMessageMode::Auto => match String::from_utf8(bytes) {
             Ok(text) => Ok(Message::Text(text.into())),
@@ -631,6 +682,7 @@ fn print_request_metadata(cli: &Cli, method: &str, url: &Url, headers: Option<&W
             sort_header_lines(&mut lines);
         }
         for (name, value) in lines {
+            let value = redact_header_value(&name, value);
             if debug {
                 printer.write_request_prefix();
             }
@@ -679,6 +731,7 @@ fn print_response_metadata(
         sort_header_lines(&mut lines);
     }
     for (name, value) in lines {
+        let value = redact_header_value(&name, value);
         if cli.verbose >= 2 {
             printer.write_response_prefix();
         }
@@ -704,6 +757,18 @@ fn header_lines(headers: &WsHeaderMap) -> Vec<(String, String)> {
     out
 }
 
+fn redact_header_value(name: &str, value: String) -> String {
+    match name {
+        "authorization"
+        | "cookie"
+        | "set-cookie"
+        | "proxy-authorization"
+        | "x-amz-security-token"
+        | "x-amz-credential" => "[REDACTED]".to_string(),
+        _ => value,
+    }
+}
+
 fn sort_header_lines(lines: &mut [(String, String)]) {
     lines.sort_by(
         |(left, _), (right, _)| match (left.starts_with(':'), right.starts_with(':')) {
@@ -725,7 +790,7 @@ fn ws_version_label(version: WsVersion) -> &'static str {
     }
 }
 
-async fn read_messages<S>(cli: &Cli, stream: &mut S) -> Result<(), FetchError>
+async fn read_messages<S>(cli: &Cli, stream: &mut S) -> Result<ReadOutcome, FetchError>
 where
     S: futures_util::Stream<Item = Result<Message, WsError>> + Unpin,
 {
@@ -736,19 +801,38 @@ where
                 if write_text_message(cli, text.as_str().as_bytes(), stdout_is_terminal)?
                     == MessageOutput::Closed
                 {
-                    return Ok(());
+                    return Ok(ReadOutcome::OutputClosed);
                 }
             }
             Message::Binary(bytes) => {
                 if write_binary_message(cli, &bytes, stdout_is_terminal)? == MessageOutput::Closed {
-                    return Ok(());
+                    return Ok(ReadOutcome::OutputClosed);
                 }
             }
-            Message::Close(_) => return Ok(()),
+            Message::Close(frame) => return Ok(ReadOutcome::PeerClosed(frame)),
             Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
         }
     }
-    Ok(())
+    Ok(ReadOutcome::Ended)
+}
+
+fn close_outcome_result(outcome: ReadOutcome) -> Result<(), FetchError> {
+    let ReadOutcome::PeerClosed(Some(frame)) = outcome else {
+        return Ok(());
+    };
+    if matches!(frame.code, CloseCode::Normal | CloseCode::Away) {
+        return Ok(());
+    }
+    let reason = interactive::sanitize_message_text(frame.reason.as_str());
+    let suffix = if reason.is_empty() {
+        String::new()
+    } else {
+        format!(": {reason}")
+    };
+    Err(FetchError::Runtime(format!(
+        "WebSocket closed with code {}{suffix}",
+        u16::from(frame.code)
+    )))
 }
 
 fn write_text_message(
@@ -764,6 +848,10 @@ fn write_text_message(
             return write_stdout_message(&mut stdout, &formatted.into_bytes(), false);
         }
     }
+    if stdout_is_terminal {
+        let sanitized = interactive::sanitize_message_text(&String::from_utf8_lossy(bytes));
+        return write_stdout_message(&mut stdout, sanitized.as_bytes(), true);
+    }
     write_stdout_message(&mut stdout, bytes, true)
 }
 
@@ -772,7 +860,7 @@ fn write_binary_message(
     bytes: &[u8],
     stdout_is_terminal: bool,
 ) -> Result<MessageOutput, FetchError> {
-    if should_warn_for_terminal_binary_message(bytes, stdout_is_terminal) {
+    if stdout_is_terminal {
         write_binary_terminal_warning(cli);
         return Ok(MessageOutput::Continue);
     }
@@ -782,8 +870,9 @@ fn write_binary_message(
     write_stdout_message(&mut stdout, bytes, false)
 }
 
-fn should_warn_for_terminal_binary_message(bytes: &[u8], stdout_is_terminal: bool) -> bool {
-    stdout_is_terminal && !core::bytes_appear_printable(bytes)
+#[cfg(test)]
+fn should_warn_for_terminal_binary_message(_bytes: &[u8], stdout_is_terminal: bool) -> bool {
+    stdout_is_terminal
 }
 
 fn write_stdout_message(
@@ -902,6 +991,10 @@ mod tests {
     fn websocket_config_sets_fetch_receive_limits() {
         let config = websocket_config();
 
+        assert_eq!(
+            config.max_write_buffer_size,
+            WEBSOCKET_MAX_MESSAGE_BYTES * 2
+        );
         assert_eq!(config.max_frame_size, Some(WEBSOCKET_MAX_FRAME_BYTES));
         assert_eq!(config.max_message_size, Some(WEBSOCKET_MAX_MESSAGE_BYTES));
     }
@@ -1145,6 +1238,39 @@ mod tests {
     }
 
     #[test]
+    fn websocket_close_outcome_rejects_abnormal_code_and_sanitizes_reason() {
+        let err = close_outcome_result(ReadOutcome::PeerClosed(Some(CloseFrame {
+            code: CloseCode::Policy,
+            reason: "bad\x1b]52;clipboard\x07".into(),
+        })))
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            r"WebSocket closed with code 1008: bad\x1b]52;clipboard\x07"
+        );
+        assert!(
+            close_outcome_result(ReadOutcome::PeerClosed(Some(CloseFrame {
+                code: CloseCode::Normal,
+                reason: "done".into(),
+            })))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn websocket_sensitive_headers_are_redacted() {
+        assert_eq!(
+            redact_header_value("authorization", "Bearer secret".to_string()),
+            "[REDACTED]"
+        );
+        assert_eq!(
+            redact_header_value("x-test", "visible".to_string()),
+            "visible"
+        );
+    }
+
+    #[test]
     fn websocket_message_mode_controls_outgoing_frame_type() {
         let auto_text = outgoing_message(b"hello".to_vec(), WebSocketMessageMode::Auto).unwrap();
         assert!(matches!(auto_text, Message::Text(_)));
@@ -1171,7 +1297,7 @@ mod tests {
         let body = format!("@{}", path.display());
         let cli = Cli::try_parse_from(["fetch", "-d", &body, "ws://example.com"]).unwrap();
 
-        let err = websocket_initial_message(&cli).unwrap_err();
+        let err = websocket_initial_message(crate::http::request_body(&cli).unwrap()).unwrap_err();
 
         assert_eq!(
             err.to_string(),
@@ -1231,10 +1357,7 @@ mod tests {
     fn websocket_binary_terminal_guard_matches_printable_policy() {
         assert!(should_warn_for_terminal_binary_message(b"abc\0def", true));
         assert!(!should_warn_for_terminal_binary_message(b"abc\0def", false));
-        assert!(!should_warn_for_terminal_binary_message(
-            b"plain text",
-            true
-        ));
+        assert!(should_warn_for_terminal_binary_message(b"plain text", true));
     }
 
     #[test]

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -136,6 +136,33 @@ pub(crate) fn start_http_connect_proxy(target_addr: String) -> (String, mpsc::Re
     (proxy_url, seen_rx)
 }
 
+pub(crate) fn start_authenticated_http_connect_proxy(
+    target_addr: String,
+    expected_authorization: &'static str,
+) -> (String, mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind authenticated HTTP proxy");
+    let proxy_url = format!("http://{}", listener.local_addr().unwrap());
+    let (seen_tx, seen_rx) = mpsc::channel();
+    thread::spawn(move || {
+        for conn in listener.incoming() {
+            let Ok(conn) = conn else {
+                break;
+            };
+            let target_addr = target_addr.clone();
+            let seen_tx = seen_tx.clone();
+            thread::spawn(move || {
+                handle_http_connect_proxy_conn_with_auth(
+                    conn,
+                    &target_addr,
+                    seen_tx,
+                    Some(expected_authorization),
+                )
+            });
+        }
+    });
+    (proxy_url, seen_rx)
+}
+
 pub(crate) fn start_https_proxy(require_client_auth: bool) -> HttpsProxyTestServer {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let dir = TempDir::new().unwrap().keep();
@@ -274,9 +301,18 @@ pub(crate) fn start_stalling_proxy(scheme: &str) -> String {
 }
 
 pub(crate) fn handle_http_connect_proxy_conn(
+    conn: TcpStream,
+    target_addr: &str,
+    seen: mpsc::Sender<String>,
+) {
+    handle_http_connect_proxy_conn_with_auth(conn, target_addr, seen, None);
+}
+
+fn handle_http_connect_proxy_conn_with_auth(
     mut conn: TcpStream,
     target_addr: &str,
     seen: mpsc::Sender<String>,
+    expected_authorization: Option<&str>,
 ) {
     let mut reader = BufReader::new(conn.try_clone().expect("clone proxy stream"));
     let Some(req) = read_request(&mut reader) else {
@@ -286,6 +322,15 @@ pub(crate) fn handle_http_connect_proxy_conn(
         write_response(
             &mut conn,
             TestResponse::status(405, "Method Not Allowed", ""),
+        );
+        return;
+    }
+    if expected_authorization.is_some_and(|expected| req.header("proxy-authorization") != expected)
+    {
+        let _ = seen.send("missing proxy authorization".to_string());
+        write_response(
+            &mut conn,
+            TestResponse::status(407, "Proxy Authentication Required", ""),
         );
         return;
     }

--- a/tests/support/websocket.rs
+++ b/tests/support/websocket.rs
@@ -328,8 +328,8 @@ pub(crate) fn read_ws_text(reader: &mut impl Read) -> String {
 }
 
 pub(crate) fn read_ws_text_frame(reader: &mut impl Read) -> Option<String> {
-    let (_opcode, payload) = read_ws_frame(reader)?;
-    Some(String::from_utf8_lossy(&payload).into_owned())
+    let (opcode, payload) = read_ws_frame(reader)?;
+    (opcode != 0x8).then(|| String::from_utf8_lossy(&payload).into_owned())
 }
 
 pub(crate) fn read_ws_frame(reader: &mut impl Read) -> Option<(u8, Vec<u8>)> {
@@ -366,15 +366,15 @@ pub(crate) fn read_ws_frame(reader: &mut impl Read) -> Option<(u8, Vec<u8>)> {
             *byte ^= mask[i % 4];
         }
     }
-    if opcode == 0x8 {
-        return None;
-    }
     Some((opcode, payload))
 }
 
 pub(crate) fn write_ws_close_and_drain<T: Read + Write>(stream: &mut T, reason: &[u8]) {
-    let _ = stream.write_all(&ws_close_frame(reason));
-    let _ = read_ws_text_frame(stream);
+    stream
+        .write_all(&ws_close_frame(reason))
+        .expect("write WebSocket close frame");
+    let (opcode, _payload) = read_ws_frame(stream).expect("client close response");
+    assert_eq!(opcode, 0x8, "client must respond with a close frame");
 }
 
 pub(crate) fn ws_text_frame(payload: &[u8]) -> Vec<u8> {
@@ -410,7 +410,11 @@ pub(crate) fn ws_binary_frame(payload: &[u8]) -> Vec<u8> {
 }
 
 pub(crate) fn ws_close_frame(reason: &[u8]) -> Vec<u8> {
-    let mut payload = 1000_u16.to_be_bytes().to_vec();
+    ws_close_frame_with_code(1000, reason)
+}
+
+pub(crate) fn ws_close_frame_with_code(code: u16, reason: &[u8]) -> Vec<u8> {
+    let mut payload = code.to_be_bytes().to_vec();
     payload.extend_from_slice(reason);
     let mut out = vec![0x88, payload.len() as u8];
     out.extend(payload);

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -16,15 +16,15 @@ use support::common::{
 use support::dns::{start_udp_dns_server, start_unresponsive_udp_dns_server};
 use support::http::{TestResponse, TestServer, read_request, write_response};
 use support::proxy::{
-    assert_proxy_seen, assert_socks_seen, start_http_connect_proxy, start_socks5_proxy,
-    start_stalling_proxy,
+    assert_proxy_seen, assert_socks_seen, start_authenticated_http_connect_proxy,
+    start_http_connect_proxy, start_socks5_proxy, start_stalling_proxy,
 };
 #[cfg(unix)]
 use support::pty::{configure_pty_child, open_pty, start_pty_capture};
 use support::websocket::{
     read_ws_frame, read_ws_text, start_ws_echo_server, start_ws_hold_open_push_server,
     start_ws_multi_echo_server, start_ws_push_server, start_wss_echo_server,
-    write_ws_close_and_drain, ws_binary_frame, ws_text_frame,
+    write_ws_close_and_drain, ws_binary_frame, ws_close_frame_with_code, ws_text_frame,
 };
 use tempfile::TempDir;
 use url::Url;
@@ -109,6 +109,37 @@ fn start_ws_text_push_server(payload: Vec<u8>) -> String {
         }
         let _ = stream.write_all(&ws_text_frame(&payload));
         write_ws_close_and_drain(&mut stream, b"done");
+    });
+    url
+}
+
+fn start_ws_abnormal_close_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind websocket close server");
+    let url = format!("ws://{}", listener.local_addr().unwrap());
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept websocket client");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let req = read_request(&mut reader).expect("read websocket handshake");
+        let mut sha = Sha1::new();
+        sha.update(req.header("sec-websocket-key").as_bytes());
+        sha.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+        let accept = base64::engine::general_purpose::STANDARD.encode(sha.finalize());
+        write!(
+            stream,
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+        )
+        .unwrap();
+        stream
+            .write_all(&ws_close_frame_with_code(
+                1008,
+                b"policy\x1b]52;clipboard\x07",
+            ))
+            .unwrap();
+        let (opcode, _) = read_ws_frame(&mut stream).expect("client close response");
+        assert_eq!(opcode, 0x8);
     });
     url
 }
@@ -717,6 +748,17 @@ fn websocket_receives_json_text_binary_and_query_handshake() {
 }
 
 #[test]
+fn websocket_abnormal_close_fails_and_sanitizes_reason() {
+    let ws_url = start_ws_abnormal_close_server();
+    let res = run_fetch(&[&ws_url, "--ws-interactive", "off"]);
+
+    assert!(!res.status.success());
+    assert!(res.stderr.contains("WebSocket closed with code 1008"));
+    assert!(res.stderr.contains(r"policy\x1b]52;clipboard\x07"));
+    assert!(!res.stderr.contains('\x1b'));
+}
+
+#[test]
 fn websocket_wss_trusts_custom_ca_go_case() {
     let (wss, seen) = start_wss_echo_server(|req| {
         if req.header("host").starts_with("localhost:") {
@@ -817,6 +859,38 @@ fn websocket_custom_dns_and_proxy_cases() {
         "proxied websocket"
     );
     assert!(res.stdout.contains("echo: proxied websocket"));
+
+    let (auth_target_url, auth_seen_ws) = start_ws_echo_server(|_| Ok(()));
+    let auth_target_addr = url_host_port(&auth_target_url);
+    let (auth_proxy_url, auth_proxy_seen) = start_authenticated_http_connect_proxy(
+        auth_target_addr.clone(),
+        "Basic cHJveHktdXNlcjpwcm94eS1wYXNz",
+    );
+    let auth_proxy_url = auth_proxy_url.replacen("http://", "http://proxy-user:proxy-pass@", 1);
+    let res = run_fetch_opts(
+        FetchOpts {
+            env: vec![
+                ("HTTP_PROXY".to_string(), auth_proxy_url),
+                ("NO_PROXY".to_string(), String::new()),
+            ],
+            ..FetchOpts::default()
+        },
+        &[
+            &auth_target_url,
+            "-d",
+            "authenticated proxy websocket",
+            "--format",
+            "off",
+            "--ws-interactive",
+            "off",
+        ],
+    );
+    assert_exit(&res, 0);
+    assert_proxy_seen(&auth_proxy_seen, &auth_target_addr);
+    assert_eq!(
+        auth_seen_ws.recv_timeout(Duration::from_secs(2)).unwrap(),
+        "authenticated proxy websocket"
+    );
 
     let (socks_target_url, socks_seen_ws) = start_ws_echo_server(|_| Ok(()));
     let socks_target_addr = url_host_port(&socks_target_url);
@@ -1036,7 +1110,8 @@ fn websocket_dry_run_prints_effective_handshake_headers() {
     assert!(res.stdout.is_empty());
     assert!(res.stderr.contains("> GET /socket HTTP/1.1"));
     assert!(res.stderr.contains("> x-test: yes"));
-    assert!(res.stderr.contains("> authorization: Bearer token"));
+    assert!(res.stderr.contains("> authorization: [REDACTED]"));
+    assert!(!res.stderr.contains("Bearer token"));
     assert!(res.stderr.contains("> accept: application/json, */*;q=0.5"));
     assert!(res.stderr.contains("> user-agent: fetch/"));
 }
@@ -1089,6 +1164,39 @@ fn websocket_dry_run_does_not_read_stdin_body() {
     assert_exit(&res, 0);
     assert!(res.stdout.is_empty());
     assert!(res.stderr.contains("> GET /socket HTTP/1.1"));
+}
+
+#[test]
+fn websocket_initial_stdin_read_exits_promptly_on_timeout() {
+    let (ws_url, shutdown, server) = start_ws_hold_open_push_server(b"connected");
+    let mut cmd = Command::new(fetch_bin());
+    cmd.args([
+        &ws_url,
+        "--ws-interactive",
+        "off",
+        "--timeout",
+        "0.1",
+        "-d",
+        "@-",
+    ]);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.env("HTTP_PROXY", "");
+    cmd.env("HTTPS_PROXY", "");
+    cmd.env("ALL_PROXY", "");
+    cmd.env("NO_PROXY", "*");
+
+    let mut child = cmd.spawn().expect("spawn websocket stdin timeout fetch");
+    let stdin = child.stdin.take().expect("child stdin");
+    let status = wait_child(&mut child, Duration::from_secs(2))
+        .expect("fetch remained alive after initial stdin timeout")
+        .expect("wait websocket stdin timeout fetch");
+    assert!(!status.success());
+
+    drop(stdin);
+    let _ = shutdown.send(());
+    server.join().expect("join hold-open websocket server");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- sanitize terminal-bound WebSocket and HTTP output and redact sensitive handshake headers
- bound interactive history, input, buffering, and redraw work while honoring message modes
- complete close handshakes, report abnormal closures, and preserve timeout/proxy semantics
- reject unsupported WebSocket flags and document the historical audit and resulting behavior

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins` (885 passed)
- full integration suite with `--test-threads=2` (153 passed)
