### PR TITLE
fix: do not record update timestamp during dry-run

### DIFF
--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -35,7 +35,9 @@ pub async fn execute(cli: &Cli) -> Result<i32, FetchError> {
     )?
     .ok_or_else(|| FetchError::Message("unable to acquire update lock".to_string()))?;
     let result = update_inner(&client, cli.silent, cli.color.as_deref(), cli.dry_run).await;
-    record_last_attempt_time(&cache_dir);
+    if !cli.dry_run {
+        record_last_attempt_time(&cache_dir);
+    }
     result?;
     Ok(0)
 }


### PR DESCRIPTION
## Summary

`--dry-run` was writing to `metadata.json`, which reset the auto-update interval timer and suppressed the next real update check for the full interval.

## Changes

- `src/update/mod.rs`: Gate `record_last_attempt_time` behind `!cli.dry_run` in `execute()`.

## Validation

- `cargo fmt` — clean
- `cargo clippy --locked --all-targets --all-features -- -D warnings` — clean
- `cargo test --locked --all-features --lib --bins` — 885 passed, 0 failed