### PR TITLE
fix: derive insecure TLS schemes from crypto provider

### DIFF
--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -450,7 +450,7 @@ fn build_client_config(
     let provider = rustls::crypto::CryptoProvider::get_default()
         .cloned()
         .unwrap_or_else(|| std::sync::Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
-    let versions_builder = rustls::ClientConfig::builder_with_provider(provider);
+    let versions_builder = rustls::ClientConfig::builder_with_provider(provider.clone());
     let versions = inspection_protocol_versions(cli)?;
     let builder = if let Some(ech_mode) = ech_mode {
         if !versions
@@ -483,7 +483,12 @@ fn build_client_config(
     let builder = if cli.insecure {
         builder
             .dangerous()
-            .with_custom_certificate_verifier(Arc::new(NoCertificateVerification { ocsp_capture }))
+            .with_custom_certificate_verifier(Arc::new(NoCertificateVerification {
+                ocsp_capture,
+                supported_schemes: provider
+                    .signature_verification_algorithms
+                    .supported_schemes(),
+            }))
     } else {
         let verifier = WebPkiServerVerifier::builder(Arc::new(root_store(ca_certs, native_roots)?))
             .build()
@@ -624,6 +629,7 @@ impl ServerCertVerifier for CapturingServerVerifier {
 #[derive(Debug)]
 struct NoCertificateVerification {
     ocsp_capture: OcspCapture,
+    supported_schemes: Vec<SignatureScheme>,
 }
 
 impl ServerCertVerifier for NoCertificateVerification {
@@ -658,17 +664,7 @@ impl ServerCertVerifier for NoCertificateVerification {
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        vec![
-            SignatureScheme::ECDSA_NISTP256_SHA256,
-            SignatureScheme::ECDSA_NISTP384_SHA384,
-            SignatureScheme::ED25519,
-            SignatureScheme::RSA_PSS_SHA256,
-            SignatureScheme::RSA_PSS_SHA384,
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA384,
-            SignatureScheme::RSA_PKCS1_SHA512,
-        ]
+        self.supported_schemes.clone()
     }
 }
 

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -151,7 +151,11 @@ pub fn rustls_platform_client_config_with_options(
     let builder = if insecure {
         builder
             .dangerous()
-            .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
+            .with_custom_certificate_verifier(Arc::new(NoCertificateVerification {
+                supported_schemes: provider
+                    .signature_verification_algorithms
+                    .supported_schemes(),
+            }))
     } else {
         let extra_roots = custom_ca_certificates(ca_cert_paths)?;
         let verifier = if extra_roots.is_empty() {
@@ -413,7 +417,9 @@ fn first_private_key(data: &[u8]) -> Result<Option<PrivateKeyDer<'static>>, Fetc
 }
 
 #[derive(Debug)]
-struct NoCertificateVerification;
+struct NoCertificateVerification {
+    supported_schemes: Vec<SignatureScheme>,
+}
 
 impl ServerCertVerifier for NoCertificateVerification {
     fn verify_server_cert(
@@ -446,17 +452,7 @@ impl ServerCertVerifier for NoCertificateVerification {
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        vec![
-            SignatureScheme::ECDSA_NISTP256_SHA256,
-            SignatureScheme::ECDSA_NISTP384_SHA384,
-            SignatureScheme::ED25519,
-            SignatureScheme::RSA_PSS_SHA256,
-            SignatureScheme::RSA_PSS_SHA384,
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA384,
-            SignatureScheme::RSA_PKCS1_SHA512,
-        ]
+        self.supported_schemes.clone()
     }
 }
 
@@ -526,6 +522,20 @@ mod tests {
         file.write_all(contents).unwrap();
         let path = file.path().to_string_lossy().into_owned();
         (file, path)
+    }
+
+    #[test]
+    fn insecure_verifier_uses_all_provider_signature_schemes() {
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+        let supported_schemes = provider
+            .signature_verification_algorithms
+            .supported_schemes();
+        let verifier = NoCertificateVerification {
+            supported_schemes: supported_schemes.clone(),
+        };
+
+        assert!(supported_schemes.contains(&SignatureScheme::ECDSA_NISTP521_SHA512));
+        assert_eq!(verifier.supported_verify_schemes(), supported_schemes);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- derive insecure TLS verification schemes from the configured crypto provider
- support provider additions such as ECDSA P-521
- add a regression test for provider-supported schemes

## Validation
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --lib
- git diff --check