### PR TITLE
fix: report ECH DNS discovery failures

### DIFF
--- a/src/dns/svcb/system.rs
+++ b/src/dns/svcb/system.rs
@@ -22,10 +22,7 @@ pub(super) async fn lookup_https_records(
     let Some(server_addr) = resolv_conf_nameserver() else {
         return Ok(Vec::new());
     };
-    match super::lookup_udp_https_records(server_addr, host, timeout).await {
-        Ok(records) => Ok(records),
-        Err(_) => Ok(Vec::new()),
-    }
+    super::lookup_udp_https_records(server_addr, host, timeout).await
 }
 
 #[cfg(not(all(unix, not(target_os = "macos"))))]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -288,9 +288,9 @@ async fn resolve_dns_for_client_inner(
                 .flatten()
                 .unwrap_or(Duration::from_secs(5));
             let https_records = if let Some(dns_server) = cli.dns_server.as_deref() {
-                lookup_ech_https_records(Some(dns_server), host, ech_timeout).await
+                lookup_ech_https_records(cli, Some(dns_server), host, ech_timeout).await?
             } else {
-                lookup_ech_https_records(None, host, ech_timeout).await
+                lookup_ech_https_records(cli, None, host, ech_timeout).await?
             };
             return Ok(ClientDnsDiscovery {
                 dns_resolution: None,
@@ -328,9 +328,9 @@ async fn resolve_dns_for_client_inner(
                 .unwrap_or(Duration::from_secs(5));
             let (addrs, https_records) = tokio::join!(
                 lookup_custom_ips_with_doh_tls(cli, dns_server, host, timeout),
-                lookup_ech_https_records(Some(dns_server), host, ech_timeout),
+                lookup_ech_https_records(cli, Some(dns_server), host, ech_timeout),
             );
-            (addrs?, https_records)
+            (addrs?, https_records?)
         } else if let Some(auto_http3_budget) = auto_http3_discovery {
             let https = spawn_auto_http3_https_records(
                 Some(dns_server.to_string()),
@@ -408,13 +408,15 @@ async fn resolve_dns_for_client_inner(
             .ok()
             .flatten()
             .unwrap_or(Duration::from_secs(5));
-        let (socket_addrs, https_records) =
-            tokio::join!(lookup, lookup_ech_https_records(None, host, ech_timeout),);
+        let (socket_addrs, https_records) = tokio::join!(
+            lookup,
+            lookup_ech_https_records(cli, None, host, ech_timeout),
+        );
         (
             socket_addrs
                 .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?
                 .collect::<Vec<_>>(),
-            https_records,
+            https_records?,
         )
     } else if let Some(auto_http3_budget) = auto_http3_discovery {
         let https = spawn_auto_http3_https_records(None, host.to_string(), Some(auto_http3_budget));
@@ -526,21 +528,28 @@ async fn lookup_auto_http3_https_records(
 }
 
 async fn lookup_ech_https_records(
+    cli: &Cli,
     dns_server: Option<&str>,
     host: &str,
     timeout: Duration,
-) -> Vec<SvcbRecord> {
+) -> Result<Vec<SvcbRecord>, FetchError> {
     let resolver = dns_server
         .map(HttpsRecordResolver::Custom)
         .unwrap_or(HttpsRecordResolver::System);
-    tokio::time::timeout(
-        timeout,
-        crate::dns::svcb::lookup_https_records(resolver, host, Some(timeout)),
-    )
-    .await
-    .ok()
-    .and_then(Result::ok)
-    .unwrap_or_default()
+    match TimeoutBudget::new(Some(timeout))
+        .run(crate::dns::svcb::lookup_https_records(
+            resolver,
+            host,
+            Some(timeout),
+        ))
+        .await
+    {
+        Ok(records) => Ok(records),
+        Err(err) => {
+            crate::tls::ech::handle_ech_discovery_error(cli, err)?;
+            Ok(Vec::new())
+        }
+    }
 }
 
 fn spawn_auto_http3_https_records(

--- a/src/tls/ech.rs
+++ b/src/tls/ech.rs
@@ -83,6 +83,28 @@ pub(crate) fn generate_ech_grease_config() -> EchGreaseConfig {
     EchGreaseConfig::new(suite, public_key)
 }
 
+/// Handle a failure to discover ECH configuration in DNS.
+///
+/// Required ECH reports the original discovery error. Automatic ECH keeps
+/// working with GREASE, but reports the discovery error at verbose level.
+pub(crate) fn handle_ech_discovery_error(cli: &Cli, err: FetchError) -> Result<(), FetchError> {
+    match cli.ech.as_deref() {
+        Some("on") => Err(err),
+        Some("auto") => {
+            if cli.verbose >= 3 && !cli.silent {
+                let mut printer = core::stdio().stderr_printer(cli.color.as_deref());
+                core::write_warning_msg_no_flush(
+                    &mut printer,
+                    format!("ECH discovery failed: {err}; falling back to GREASE"),
+                );
+                core::flush_stderr(printer);
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 /// Returns `true` if ECH is active (mode is `auto` or `on`).
 pub(crate) fn is_ech_active(cli: &Cli) -> bool {
     matches!(cli.ech.as_deref(), Some("auto" | "on"))

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -217,7 +217,7 @@ async fn resolve_inspect_ech_mode(
         return super::ech::resolve_ech_mode(cli, &[]);
     }
 
-    let candidates = lookup_inspect_ech_candidates(cli, host, timeout).await;
+    let candidates = lookup_inspect_ech_candidates(cli, host, timeout).await?;
     let candidate_refs: Vec<&[u8]> = candidates.iter().map(|b| b.as_slice()).collect();
     super::ech::resolve_ech_mode(cli, &candidate_refs)
 }
@@ -228,7 +228,7 @@ async fn lookup_inspect_ech_candidates(
     cli: &Cli,
     host: &str,
     timeout: TimeoutBudget,
-) -> Vec<Vec<u8>> {
+) -> Result<Vec<Vec<u8>>, FetchError> {
     let resolver = cli
         .dns_server
         .as_deref()
@@ -236,28 +236,32 @@ async fn lookup_inspect_ech_candidates(
         .unwrap_or(HttpsRecordResolver::System);
 
     let ech_timeout = timeout
-        .remaining()
-        .ok()
-        .flatten()
+        .remaining()?
         .unwrap_or(std::time::Duration::from_secs(5));
-    let records = tokio::time::timeout(
-        ech_timeout,
-        crate::dns::svcb::lookup_https_records(resolver, host, Some(ech_timeout)),
-    )
-    .await
-    .ok()
-    .and_then(Result::ok)
-    .unwrap_or_default();
+    let records = match TimeoutBudget::new(Some(ech_timeout))
+        .run(crate::dns::svcb::lookup_https_records(
+            resolver,
+            host,
+            Some(ech_timeout),
+        ))
+        .await
+    {
+        Ok(records) => records,
+        Err(err) => {
+            super::ech::handle_ech_discovery_error(cli, err)?;
+            Vec::new()
+        }
+    };
 
     let mut usable: Vec<&crate::dns::svcb::SvcbRecord> = records
         .iter()
         .filter(|r| !r.is_alias_mode() && r.is_usable())
         .collect();
     usable.sort_by_key(|r| r.priority);
-    usable
+    Ok(usable
         .iter()
         .filter_map(|r| r.ech.as_ref().filter(|b| !b.is_empty()).cloned())
-        .collect()
+        .collect())
 }
 
 async fn inspect_quic(

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -13,8 +13,9 @@ use support::common::{
 use support::dns::{
     parse_dns_question, start_udp_dns_server, start_udp_dns_server_dropping_https,
     start_udp_dns_server_with_delayed_aaaa, start_udp_dns_server_with_delayed_https_and_resolution,
-    start_udp_dns_server_with_delayed_resolution, start_udp_dns_server_with_hosts,
-    start_udp_dns_server_with_https, start_udp_dns_server_with_https_target_dropping_target,
+    start_udp_dns_server_with_delayed_resolution, start_udp_dns_server_with_failing_https,
+    start_udp_dns_server_with_hosts, start_udp_dns_server_with_https,
+    start_udp_dns_server_with_https_target_dropping_target,
     start_udp_dns_server_with_https_targets_dropping_targets,
     start_udp_dns_server_with_toggleable_https, start_unresponsive_udp_dns_server,
 };
@@ -144,6 +145,83 @@ fn ech_on_still_overlaps_address_resolution_before_required_failure() {
         overlapped.load(Ordering::SeqCst),
         "A/AAAA resolution did not overlap the delayed required HTTPS lookup"
     );
+}
+
+#[test]
+fn ech_dns_discovery_failure_is_reported_and_auto_falls_back() {
+    let tls = start_tls_server(|_| TestResponse::ok("ECH discovery fallback"));
+    let port = Url::parse(&tls.url).unwrap().port().unwrap();
+    let host = "fetch-ech-discovery-failure.test.";
+    let dns_addr = start_udp_dns_server_with_failing_https(host, Ipv4Addr::new(127, 0, 0, 1));
+    let url = format!("https://fetch-ech-discovery-failure.test:{port}/ech-discovery-failure");
+
+    let required = run_fetch(&[
+        "--inspect-tls",
+        "--insecure",
+        "--dns-server",
+        &dns_addr,
+        "--ech",
+        "on",
+        &url,
+    ]);
+    assert_exit(&required, 1);
+    assert!(
+        required.stderr.contains("mismatched DNS response ID"),
+        "{}",
+        required.stderr
+    );
+    assert!(!required.stderr.contains("does not advertise ECH"));
+
+    let inspected = run_fetch(&[
+        "--inspect-tls",
+        "--insecure",
+        "-vvv",
+        "--dns-server",
+        &dns_addr,
+        "--ech",
+        "auto",
+        &url,
+    ]);
+    assert_exit(&inspected, 0);
+    assert!(inspected.stderr.contains("ECH discovery failed"));
+    assert!(inspected.stderr.contains("GREASE"));
+
+    let requested = run_fetch(&[
+        "-vvv",
+        "--insecure",
+        "--dns-server",
+        &dns_addr,
+        "--ech",
+        "auto",
+        &url,
+    ]);
+    assert_exit(&requested, 0);
+    assert_eq!(requested.stdout, "ECH discovery fallback");
+    assert!(requested.stderr.contains("ECH discovery failed"));
+}
+
+#[test]
+fn ech_dns_timeout_is_reported_instead_of_no_configuration() {
+    let tls = start_tls_server(|_| TestResponse::ok("ECH timeout"));
+    let port = Url::parse(&tls.url).unwrap().port().unwrap();
+    let host = "fetch-ech-discovery-timeout.test.";
+    let dns_addr = start_udp_dns_server_dropping_https(host, Ipv4Addr::new(127, 0, 0, 1));
+    let url = format!("https://fetch-ech-discovery-timeout.test:{port}/ech-timeout");
+
+    let result = run_fetch(&[
+        "--inspect-tls",
+        "--insecure",
+        "--dns-server",
+        &dns_addr,
+        "--ech",
+        "on",
+        "--connect-timeout",
+        "0.05",
+        &url,
+    ]);
+    assert_exit(&result, 1);
+    assert!(result.stderr.contains("timed out"), "{}", result.stderr);
+    assert!(!result.stderr.contains("does not advertise ECH"));
 }
 
 #[test]

--- a/tests/support/dns.rs
+++ b/tests/support/dns.rs
@@ -212,6 +212,35 @@ pub(crate) fn start_udp_dns_server_dropping_https(host: &'static str, ip: Ipv4Ad
     addr
 }
 
+pub(crate) fn start_udp_dns_server_with_failing_https(host: &'static str, ip: Ipv4Addr) -> String {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("bind udp dns server");
+    let addr = socket.local_addr().unwrap().to_string();
+    thread::spawn(move || {
+        let mut buf = [0u8; 512];
+        while let Ok((n, peer)) = socket.recv_from(&mut buf) {
+            let Some((name, qtype, question_end)) = parse_dns_question(&buf[..n]) else {
+                continue;
+            };
+            let mut response = if name == host && qtype == TYPE_A {
+                dns_response(
+                    &buf[..n],
+                    question_end,
+                    Some((TYPE_A, ip.octets().to_vec())),
+                )
+            } else {
+                dns_response(&buf[..n], question_end, None)
+            };
+            if name == host && qtype == TYPE_HTTPS {
+                // Return a response with a mismatched transaction ID so the
+                // resolver reports a protocol failure instead of no records.
+                response[0] ^= 1;
+            }
+            let _ = socket.send_to(&response, peer);
+        }
+    });
+    addr
+}
+
 pub(crate) fn start_udp_dns_server_with_delayed_resolution(
     host: &'static str,
     ip: Ipv4Addr,


### PR DESCRIPTION
## Summary
- preserve ECH DNS and timeout errors for required ECH discovery
- fall back to GREASE with verbose diagnostics in auto mode
- apply the same behavior to normal HTTP ECH discovery
- add resolver failure and timeout integration coverage

## Tests
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --lib --bins
- relevant network and HTTP tests
- CI-equivalent integration suite (one unrelated terminal test was transiently flaky and passed on isolated rerun)