### PR TITLE
fix: apply CLI TLS settings to ECH DoH discovery

### DIFF
--- a/src/dns/svcb.rs
+++ b/src/dns/svcb.rs
@@ -241,6 +241,15 @@ pub(crate) async fn lookup_https_records(
     host: &str,
     timeout: Option<Duration>,
 ) -> Result<Vec<SvcbRecord>, FetchError> {
+    lookup_https_records_with_doh_tls_config(resolver, host, timeout, None).await
+}
+
+pub(crate) async fn lookup_https_records_with_doh_tls_config(
+    resolver: HttpsRecordResolver<'_>,
+    host: &str,
+    timeout: Option<Duration>,
+    doh_tls_config: Option<rustls::ClientConfig>,
+) -> Result<Vec<SvcbRecord>, FetchError> {
     if let Ok(_ip) = host.parse::<IpAddr>() {
         return Ok(Vec::new());
     }
@@ -251,7 +260,7 @@ pub(crate) async fn lookup_https_records(
             let server_url = Url::parse(server).map_err(|err| {
                 FetchError::Message(format!("invalid dns-server '{server}': {err}"))
             })?;
-            lookup_doh_https_records(&server_url, host, timeout).await
+            lookup_doh_https_records(&server_url, host, timeout, doh_tls_config).await
         }
         HttpsRecordResolver::Custom(server) => {
             let server_addr = crate::dns::resolver::normalize_udp_dns_server(server)
@@ -271,9 +280,13 @@ async fn lookup_doh_https_records(
     server_url: &Url,
     host: &str,
     timeout: Option<Duration>,
+    doh_tls_config: Option<rustls::ClientConfig>,
 ) -> Result<Vec<SvcbRecord>, FetchError> {
-    let client = crate::dns::doh::client_with_budget(TimeoutBudget::new(timeout))
-        .map_err(|err| FetchError::Message(err.to_string()))?;
+    let client = crate::dns::doh::client_with_budget_and_tls_config(
+        TimeoutBudget::new(timeout),
+        doh_tls_config,
+    )
+    .map_err(|err| FetchError::Message(err.to_string()))?;
     let answers =
         crate::dns::doh::lookup_doh_records_with_client(&client, server_url, host, "HTTPS")
             .await

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -537,10 +537,11 @@ async fn lookup_ech_https_records(
         .map(HttpsRecordResolver::Custom)
         .unwrap_or(HttpsRecordResolver::System);
     match TimeoutBudget::new(Some(timeout))
-        .run(crate::dns::svcb::lookup_https_records(
+        .run(crate::dns::svcb::lookup_https_records_with_doh_tls_config(
             resolver,
             host,
             Some(timeout),
+            doh_tls_config_for_cli(cli)?,
         ))
         .await
     {
@@ -833,7 +834,12 @@ pub(crate) async fn resolve_websocket_ech_mode(
         .unwrap_or(crate::dns::svcb::HttpsRecordResolver::System);
     let records = tokio::time::timeout(
         ech_timeout,
-        crate::dns::svcb::lookup_https_records(resolver, host, Some(ech_timeout)),
+        crate::dns::svcb::lookup_https_records_with_doh_tls_config(
+            resolver,
+            host,
+            Some(ech_timeout),
+            doh_tls_config_for_cli(cli)?,
+        ),
     )
     .await
     .ok()

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -238,11 +238,13 @@ async fn lookup_inspect_ech_candidates(
     let ech_timeout = timeout
         .remaining()?
         .unwrap_or(std::time::Duration::from_secs(5));
+    let doh_tls_config = crate::http::client::doh_tls_config_for_cli(cli)?;
     let records = match TimeoutBudget::new(Some(ech_timeout))
-        .run(crate::dns::svcb::lookup_https_records(
+        .run(crate::dns::svcb::lookup_https_records_with_doh_tls_config(
             resolver,
             host,
             Some(ech_timeout),
+            doh_tls_config,
         ))
         .await
     {

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -225,6 +225,44 @@ fn ech_dns_timeout_is_reported_instead_of_no_configuration() {
 }
 
 #[test]
+fn inspect_ech_discovery_uses_custom_doh_tls_config() {
+    let https_queries = Arc::new(AtomicUsize::new(0));
+    let seen_https_queries = Arc::clone(&https_queries);
+    let server = start_tls_server(move |req| {
+        if req.path == "/inspect-ech-doh" {
+            return TestResponse::ok("inspection target");
+        }
+        if req.path.contains("type=HTTPS") {
+            seen_https_queries.fetch_add(1, Ordering::SeqCst);
+        }
+        let body = if req.path.contains("type=A") {
+            r#"{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1"}]}"#
+        } else {
+            r#"{"Status":0}"#
+        };
+        TestResponse::ok(body)
+            .header("Content-Type", "application/dns-json")
+            .header("Connection", "close")
+    });
+    let doh_url = format!("{}/dns-query", server.url);
+    let target_url = format!("{}/inspect-ech-doh", server.url);
+
+    let result = run_fetch(&[
+        "--inspect-tls",
+        "--ech",
+        "auto",
+        "--ca-cert",
+        server.ca_cert_path.to_str().unwrap(),
+        "--dns-server",
+        &doh_url,
+        &target_url,
+    ]);
+
+    assert_exit(&result, 0);
+    assert_eq!(https_queries.load(Ordering::SeqCst), 1, "{}", result.stderr);
+}
+
+#[test]
 fn connect_timeout_is_shared_between_preresolved_dns_and_tls() {
     let tls = start_h2_tls_server_with_accept_delay(
         |_| TestResponse::ok("too late"),


### PR DESCRIPTION
## Summary
- pass CLI-derived DoH TLS configuration to HTTPS/SVCB ECH discovery
- cover custom-CA HTTPS DoH discovery during TLS inspection

## Tests
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --test network ech_ -- --test-threads=2
- cargo test --locked --all-features --lib --bins