### PR TITLE
fix: report TLS cipher suite in inspection

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -337,7 +337,9 @@ fetch --inspect-tls example.com
 
 Output includes:
 
-- **TLS version and cipher suite** (e.g., TLS 1.3: TLS_AES_256_GCM_SHA384)
+- **TLS version and negotiated cipher suite** (for example, `TLS 1.3:
+TLS13_AES_256_GCM_SHA384`). HTTP/3 reports the cipher suite as unavailable
+  because the current QUIC integration does not expose it.
 - **ALPN negotiated protocol** (e.g., h2)
 - **Certificate chain** with tree visualization and expiry status
 - **Subject Alternative Names** (DNS names and IP addresses)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -557,10 +557,12 @@ See [Encrypted Client Hello](ech.md) for details.
 ### `--inspect-tls`
 
 Inspect the TLS certificate chain with a TLS handshake. This operation does not
-make an HTTP request. The output shows the TLS version, cipher suite, ALPN
-protocol, certificate chain and expiry status, Subject Alternative Names
-(SANs), and OCSP staple status. Use an HTTPS URL. With `--http 3`, inspection
-uses a QUIC handshake and offers `h3` ALPN.
+make an HTTP request. The output shows the TLS version, negotiated cipher
+suite, ALPN protocol, certificate chain and expiry status, Subject Alternative
+Names (SANs), and OCSP staple status. Use an HTTPS URL. With `--http 3`,
+inspection uses a QUIC handshake and offers `h3` ALPN. The current QUIC
+integration does not expose the negotiated TLS cipher suite, so HTTP/3 output
+reports it as unavailable.
 
 Request-only CLI flags have no effect with `--inspect-tls`. They cause a warning
 that `fetch` does not send an HTTP request. Configuration-file defaults do not

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -191,7 +191,10 @@ async fn inspect_tcp(
 
     Ok(Inspection {
         version: conn.protocol_version(),
-        cipher_suite: conn.negotiated_cipher_suite(),
+        cipher_suite: conn
+            .negotiated_cipher_suite()
+            .map(CipherSuiteStatus::Negotiated)
+            .unwrap_or(CipherSuiteStatus::Unavailable),
         alpn: conn
             .alpn_protocol()
             .map(|protocol| String::from_utf8_lossy(protocol).into_owned()),
@@ -399,7 +402,9 @@ async fn inspect_quic_addr(
 
     Ok(Inspection {
         version: Some(ProtocolVersion::TLSv1_3),
-        cipher_suite: None,
+        // Quinn 0.11 exposes QUIC handshake ALPN and peer identity, but not
+        // the rustls cipher suite selected by the TLS handshake.
+        cipher_suite: CipherSuiteStatus::UnavailableForHttp3,
         alpn,
         ech_status: EchStatus::NotOffered,
         chain,
@@ -580,10 +585,17 @@ pub(crate) fn ignored_inspection_flags(cli: &Cli) -> Vec<&'static str> {
     ignored
 }
 
+#[derive(Clone, Copy)]
+enum CipherSuiteStatus {
+    Negotiated(SupportedCipherSuite),
+    Unavailable,
+    UnavailableForHttp3,
+}
+
 #[derive(Clone)]
 struct Inspection {
     version: Option<ProtocolVersion>,
-    cipher_suite: Option<SupportedCipherSuite>,
+    cipher_suite: CipherSuiteStatus,
     alpn: Option<String>,
     ech_status: EchStatus,
     chain: Vec<ParsedCert>,
@@ -1114,10 +1126,12 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
     }
 
     #[test]
-    fn render_contains_tls_alpn_chain_and_sans() {
+    fn render_tcp_contains_tls_alpn_chain_sans_and_cipher_suite() {
         let inspection = Inspection {
             version: Some(ProtocolVersion::TLSv1_3),
-            cipher_suite: None,
+            cipher_suite: CipherSuiteStatus::Negotiated(
+                rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
+            ),
             alpn: Some("h2".to_string()),
             ech_status: EchStatus::NotOffered,
             chain: vec![ParsedCert {
@@ -1139,17 +1153,36 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
 
         let out = render(&inspection);
 
-        assert!(out.contains("TLS 1.3"));
+        assert!(out.contains("TLS 1.3: TLS13_AES_256_GCM_SHA384"));
         assert!(out.contains("ALPN: h2"));
         assert!(out.contains("Certificate chain"));
         assert!(out.contains("SANs: example.com, 127.0.0.1"));
     }
 
     #[test]
+    fn render_quic_reports_unavailable_cipher_suite() {
+        let inspection = Inspection {
+            version: Some(ProtocolVersion::TLSv1_3),
+            cipher_suite: CipherSuiteStatus::UnavailableForHttp3,
+            alpn: Some("h3".to_string()),
+            ech_status: EchStatus::NotOffered,
+            chain: Vec::new(),
+            ocsp_response: Vec::new(),
+        };
+
+        assert_eq!(
+            render(&inspection),
+            "* TLS 1.3: cipher suite unavailable for HTTP/3\n* ALPN: h3\n"
+        );
+    }
+
+    #[test]
     fn render_with_color_colors_tls_metadata_like_go() {
         let inspection = Inspection {
             version: Some(ProtocolVersion::TLSv1_3),
-            cipher_suite: None,
+            cipher_suite: CipherSuiteStatus::Negotiated(
+                rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
+            ),
             alpn: Some("h2".to_string()),
             ech_status: EchStatus::NotOffered,
             chain: vec![ParsedCert {
@@ -1249,6 +1282,10 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
         .unwrap();
 
         assert!(inspection.version.is_some());
+        assert!(matches!(
+            inspection.cipher_suite,
+            CipherSuiteStatus::Negotiated(_)
+        ));
         assert_eq!(inspection.alpn.as_deref(), Some("h2"));
         assert!(
             inspection
@@ -1379,6 +1416,10 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
 
         assert_eq!(inspection.alpn.as_deref(), Some("h3"));
         assert_eq!(inspection.version, Some(ProtocolVersion::TLSv1_3));
+        assert!(matches!(
+            inspection.cipher_suite,
+            CipherSuiteStatus::UnavailableForHttp3
+        ));
         assert!(
             inspection
                 .chain

--- a/src/tls/inspect/render.rs
+++ b/src/tls/inspect/render.rs
@@ -23,9 +23,17 @@ pub(super) fn render_to(inspection: &Inspection, out: &mut Printer) {
         version_label(inspection.version),
         &[Sequence::Bold, Sequence::Yellow],
     );
-    if let Some(cipher) = inspection.cipher_suite {
-        out.push_str(": ");
-        out.push_str(&cipher_suite_label(cipher));
+    out.push_str(": ");
+    match inspection.cipher_suite {
+        super::CipherSuiteStatus::Negotiated(cipher) => {
+            out.push_str(&cipher_suite_label(cipher));
+        }
+        super::CipherSuiteStatus::Unavailable => {
+            out.push_str("cipher suite unavailable");
+        }
+        super::CipherSuiteStatus::UnavailableForHttp3 => {
+            out.push_str("cipher suite unavailable for HTTP/3");
+        }
     }
     out.push('\n');
 


### PR DESCRIPTION
## Summary
- Report the negotiated TLS cipher suite for TCP TLS inspection.
- Report when the cipher suite is unavailable for HTTP/3 and update documentation.

## Validation
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- `cargo test --locked --all-features --lib tls::inspect`