### PR TITLE
fix: use platform verifier for TLS inspection

### DIFF
--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -6,12 +6,9 @@ use std::time::{Duration, Instant};
 use quinn::crypto::rustls::{HandshakeData, QuicClientConfig};
 use rustls::client::EchMode;
 use rustls::client::EchStatus;
-use rustls::client::WebPkiServerVerifier;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-use rustls::{
-    DigitallySignedStruct, ProtocolVersion, RootCertStore, SignatureScheme, SupportedCipherSuite,
-};
+use rustls::{DigitallySignedStruct, ProtocolVersion, SignatureScheme, SupportedCipherSuite};
 use tokio_rustls::TlsConnector;
 use url::Url;
 
@@ -139,13 +136,7 @@ async fn inspect_tcp(
     let native_roots = load_native_root_certs();
     let trusted_roots = trusted_root_certs(&ca_certs, &native_roots);
     let ocsp_capture = OcspCapture::default();
-    let mut config = build_client_config(
-        cli,
-        &ca_certs,
-        &native_roots,
-        ocsp_capture.clone(),
-        ech_mode,
-    )?;
+    let mut config = build_client_config(cli, ocsp_capture.clone(), ech_mode)?;
     config.alpn_protocols = alpn_protocols(http_version)
         .iter()
         .map(|protocol| protocol.as_bytes().to_vec())
@@ -305,8 +296,7 @@ async fn inspect_quic(
         .into_iter()
         .map(|addr| {
             let ocsp_capture = OcspCapture::default();
-            let mut config =
-                build_client_config(cli, &ca_certs, &native_roots, ocsp_capture.clone(), None)?;
+            let mut config = build_client_config(cli, ocsp_capture.clone(), None)?;
             config.alpn_protocols = alpn_protocols(Some(HttpVersion::Http3))
                 .iter()
                 .map(|protocol| protocol.as_bytes().to_vec())
@@ -452,8 +442,6 @@ fn go_style_tls_inspect_error(err: impl fmt::Display) -> FetchError {
 
 fn build_client_config(
     cli: &Cli,
-    ca_certs: &[ParsedCert],
-    native_roots: &[ParsedCert],
     ocsp_capture: OcspCapture,
     ech_mode: Option<EchMode>,
 ) -> Result<rustls::ClientConfig, FetchError> {
@@ -502,13 +490,11 @@ fn build_client_config(
                     .supported_schemes(),
             }))
     } else {
-        let verifier = WebPkiServerVerifier::builder(Arc::new(root_store(ca_certs, native_roots)?))
-            .build()
-            .map_err(|err| FetchError::Message(err.to_string()))?;
+        let verifier = super::rustls_platform_verifier(&cli.ca_cert, provider)?;
         builder
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(CapturingServerVerifier {
-                inner: verifier,
+                inner: Arc::new(verifier),
                 ocsp_capture,
             }))
     };
@@ -549,24 +535,6 @@ fn ensure_quic_protocol_versions(cli: &Cli) -> Result<(), FetchError> {
     } else {
         Err("HTTP/3 TLS inspection requires TLS 1.3".into())
     }
-}
-
-fn root_store(
-    ca_certs: &[ParsedCert],
-    native_roots: &[ParsedCert],
-) -> Result<RootCertStore, FetchError> {
-    let mut roots = RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    let _ = roots.add_parsable_certificates(
-        native_roots
-            .iter()
-            .map(|cert| CertificateDer::from(cert.raw.clone())),
-    );
-    for cert in ca_certs {
-        roots
-            .add(CertificateDer::from(cert.raw.clone()))
-            .map_err(|err| FetchError::Message(format!("invalid CA certificate: {err}")))?;
-    }
-    Ok(roots)
 }
 
 fn alpn_protocols(http_version: Option<HttpVersion>) -> &'static [&'static str] {
@@ -1347,7 +1315,7 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
             .into_iter()
             .map(|addr| {
                 let capture = OcspCapture::default();
-                let mut config = build_client_config(&cli, &[], &[], capture.clone(), None)?;
+                let mut config = build_client_config(&cli, capture.clone(), None)?;
                 config.alpn_protocols = vec![b"h3".to_vec()];
                 Ok((addr, quic_client_config(config)?, capture))
             })

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -117,6 +117,20 @@ pub fn rustls_platform_client_config() -> Result<rustls::ClientConfig, FetchErro
     rustls_platform_client_config_with_options(&[], None, None, false, None, None, None)
 }
 
+pub(crate) fn rustls_platform_verifier(
+    ca_cert_paths: &[String],
+    provider: Arc<rustls::crypto::CryptoProvider>,
+) -> Result<rustls_platform_verifier::Verifier, FetchError> {
+    let extra_roots = custom_ca_certificates(ca_cert_paths)?;
+    let verifier = if extra_roots.is_empty() {
+        rustls_platform_verifier::Verifier::new(provider)
+    } else {
+        rustls_platform_verifier::Verifier::new_with_extra_roots(extra_roots, provider)
+    }
+    .map_err(|err| FetchError::Message(err.to_string()))?;
+    Ok(verifier)
+}
+
 pub fn rustls_platform_client_config_with_options(
     ca_cert_paths: &[String],
     cert_path: Option<&str>,
@@ -157,13 +171,7 @@ pub fn rustls_platform_client_config_with_options(
                     .supported_schemes(),
             }))
     } else {
-        let extra_roots = custom_ca_certificates(ca_cert_paths)?;
-        let verifier = if extra_roots.is_empty() {
-            rustls_platform_verifier::Verifier::new(provider)
-        } else {
-            rustls_platform_verifier::Verifier::new_with_extra_roots(extra_roots, provider)
-        }
-        .map_err(|err| FetchError::Message(err.to_string()))?;
+        let verifier = rustls_platform_verifier(ca_cert_paths, provider)?;
         builder
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(verifier))

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -1925,6 +1925,21 @@ fn tls_certificate_validation_inspection_and_bounds_cases() {
     ]);
     assert_exit(&res, 0);
 
+    let res = run_fetch(&["--inspect-tls", &tls.url]);
+    assert_exit(&res, 1);
+    assert!(res.stderr.contains("certificate"));
+
+    let res = run_fetch(&[
+        "--inspect-tls",
+        "--ca-cert",
+        tls.ca_cert_path.to_str().unwrap(),
+        &tls.url,
+    ]);
+    assert_exit(&res, 0);
+    assert!(res.stdout.is_empty());
+    assert!(res.stderr.contains("TLS"));
+    assert!(res.stderr.contains("Certificate") || res.stderr.contains("certificate"));
+
     let res = run_fetch(&["--inspect-tls", "--insecure", &tls.url]);
     assert_exit(&res, 0);
     assert!(res.stdout.is_empty());


### PR DESCRIPTION
## Summary
- use the shared platform certificate verifier for TLS inspection
- preserve OCSP capture and inspection certificate display metadata
- verify custom CA inspection behavior

## Tests
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --lib --bins
- integration suite (one unrelated terminal pager test was flaky and passed on rerun)

Implements task 8 only.