### PR TITLE
fix: mark OCSP inspection status unverified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ quinn = { version = "=0.11.11", default-features = false, features = ["runtime-t
 rustls = { version = "=0.23.43", default-features = false, features = ["std", "aws-lc-rs", "prefer-post-quantum", "tls12"] }
 rustls-native-certs = "=0.8.4"
 rustls-platform-verifier = "=0.7.0"
+sha1 = "=0.11.0"
 serde = { version = "=1.0.229", features = ["derive"] }
 serde_json = { version = "=1.0.151", features = ["arbitrary_precision", "preserve_order"] }
 sha2 = "=0.11.0"
@@ -85,6 +86,5 @@ windows-sys = { version = "=0.61.2", features = ["Win32_Foundation", "Win32_Netw
 assert_cmd = "=2.2.2"
 predicates = "=3.1.4"
 rcgen = { version = "=0.14.8", features = ["aws_lc_rs"] }
-sha1 = "=0.11.0"
 tempfile = "=3.27.0"
 wait-timeout = "=0.2.1"

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -343,7 +343,9 @@ TLS13_AES_256_GCM_SHA384`). HTTP/3 reports the cipher suite as unavailable
 - **ALPN negotiated protocol** (e.g., h2)
 - **Certificate chain** with tree visualization and expiry status
 - **Subject Alternative Names** (DNS names and IP addresses)
-- **OCSP staple status** (good, revoked, or unknown)
+- **OCSP staple status** (good, revoked, or unknown). The embedded status is
+  labeled unverified; TLS inspection does not validate its signature or
+  freshness.
 
 Expiry is color-coded: red if expired or less than 7 days remaining, yellow if less than 30 days, green otherwise.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -559,7 +559,8 @@ See [Encrypted Client Hello](ech.md) for details.
 Inspect the TLS certificate chain with a TLS handshake. This operation does not
 make an HTTP request. The output shows the TLS version, negotiated cipher
 suite, ALPN protocol, certificate chain and expiry status, Subject Alternative
-Names (SANs), and OCSP staple status. Use an HTTPS URL. With `--http 3`,
+Names (SANs), and the unverified embedded status from an OCSP staple. Use
+an HTTPS URL. With `--http 3`,
 inspection uses a QUIC handshake and offers `h3` ALPN. The current QUIC
 integration does not expose the negotiated TLS cipher suite, so HTTP/3 output
 reports it as unavailable.

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -670,6 +670,7 @@ mod tests {
     use super::*;
     use clap::Parser;
     use quinn::crypto::rustls::QuicServerConfig;
+    use sha1::{Digest as _, Sha1};
 
     const TEST_QUIC_CERT_PEM: &[u8] = br#"-----BEGIN CERTIFICATE-----
 MIICzTCCAbWgAwIBAgIJALgQEfpjYIDxMA0GCSqGSIb3DQEBCwUAMBYxFDASBgNV
@@ -944,7 +945,10 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
             not_after: None,
             issuer_der: Vec::new(),
             subject_der: Vec::new(),
+            subject_name_der: Vec::new(),
             spki_der: Vec::new(),
+            subject_public_key: Vec::new(),
+            serial_number: Vec::new(),
             subject_key_id: None,
             authority_key_id: None,
             subject: "CN=example.com, O=Example Inc".to_string(),
@@ -1111,7 +1115,10 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
                 not_after: Some(time::OffsetDateTime::now_utc() + time::Duration::hours(1)),
                 issuer_der: Vec::new(),
                 subject_der: Vec::new(),
+                subject_name_der: Vec::new(),
                 spki_der: Vec::new(),
+                subject_public_key: Vec::new(),
+                serial_number: Vec::new(),
                 subject_key_id: None,
                 authority_key_id: None,
                 subject: "CN=example.com".to_string(),
@@ -1162,7 +1169,10 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
                 not_after: Some(time::OffsetDateTime::now_utc() + time::Duration::hours(1)),
                 issuer_der: Vec::new(),
                 subject_der: Vec::new(),
+                subject_name_der: Vec::new(),
                 spki_der: Vec::new(),
+                subject_public_key: Vec::new(),
+                serial_number: Vec::new(),
                 subject_key_id: None,
                 authority_key_id: None,
                 subject: "CN=example.com".to_string(),
@@ -1189,26 +1199,67 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
             (0x82, OcspStatus::Unknown),
         ] {
             let response = test_ocsp_response(tag);
-            assert_eq!(parse_ocsp_status(&response), Some(want), "tag {tag:#x}");
+            assert_eq!(
+                parse_ocsp_status(&response, None, None),
+                Some(want),
+                "tag {tag:#x}"
+            );
         }
 
-        assert_eq!(parse_ocsp_status(&der_seq(&[der(0x0a, &[1])])), None);
-        assert_eq!(parse_ocsp_status(b"not der"), None);
+        assert_eq!(
+            parse_ocsp_status(&der_seq(&[der(0x0a, &[1])]), None, None),
+            None
+        );
+        assert_eq!(parse_ocsp_status(b"not der", None, None), None);
+    }
+
+    #[test]
+    fn parse_ocsp_status_matches_leaf_cert_id_across_all_entries() {
+        let cert = ParsedCert::parse(
+            &super::super::pem_certificates(TEST_QUIC_CERT_PEM)
+                .unwrap()
+                .remove(0),
+        )
+        .unwrap();
+        let matching_cert_id = test_ocsp_cert_id(&cert, &cert);
+        let unrelated_cert_id = der_seq(&[
+            der_seq(&[der(0x06, &[0x2b, 0x0e, 0x03, 0x02, 0x1a]), der(0x05, &[])]),
+            der(0x04, &[9; 20]),
+            der(0x04, &[8; 20]),
+            der(0x02, &[7]),
+        ]);
+        let response = test_ocsp_response_entries(vec![
+            (unrelated_cert_id.clone(), 0xa1),
+            (matching_cert_id, 0x80),
+        ]);
+        let no_match_response = test_ocsp_response_entries(vec![(unrelated_cert_id, 0x80)]);
+
+        assert_eq!(
+            parse_ocsp_status(&response, Some(&cert), Some(&cert)),
+            Some(OcspStatus::Good)
+        );
+        assert_eq!(
+            parse_ocsp_status(&no_match_response, Some(&cert), Some(&cert)),
+            None
+        );
     }
 
     #[test]
     fn render_ocsp_status_matches_go_stapled_status_line() {
         let mut out = Printer::new(false);
-        render_ocsp_status(&mut out, &test_ocsp_response(0x80));
+        render_ocsp_status(&mut out, &test_ocsp_response(0x80), None, None);
 
-        assert_eq!(out.into_string().unwrap(), "* OCSP: good (stapled)\n");
+        assert_eq!(
+            out.into_string().unwrap(),
+            "* OCSP: good (stapled, unverified)\n"
+        );
 
         let mut out = Printer::new(false);
-        render_ocsp_status(&mut out, b"malformed");
+        render_ocsp_status(&mut out, b"malformed", None, None);
         assert!(out.bytes().is_empty());
 
         let mut out = Printer::new(true);
-        render_ocsp_status(&mut out, &test_ocsp_response(0x80));
+        render_ocsp_status(&mut out, &test_ocsp_response(0x80), None, None);
         assert!(out.into_string().unwrap().contains("\x1b[32mgood\x1b[0m"));
     }
 
@@ -1447,9 +1498,17 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
             der(0x04, &[2]),
             der(0x02, &[1]),
         ]);
-        let single_response =
-            der_seq(&[cert_id, der(status_tag, &[]), der(0x18, b"20250101000000Z")]);
-        let responses = der_seq(&[single_response]);
+        test_ocsp_response_entries(vec![(cert_id, status_tag)])
+    }
+
+    fn test_ocsp_response_entries(entries: Vec<(Vec<u8>, u8)>) -> Vec<u8> {
+        let singles = entries
+            .into_iter()
+            .map(|(cert_id, status_tag)| {
+                der_seq(&[cert_id, der(status_tag, &[]), der(0x18, b"20250101000000Z")])
+            })
+            .collect::<Vec<_>>();
+        let responses = der_seq(&singles);
         let tbs_response_data =
             der_seq(&[der(0xa1, &[]), der(0x18, b"20250101000000Z"), responses]);
         let basic_response = der_seq(&[tbs_response_data, der_seq(&[]), der(0x03, &[0])]);
@@ -1461,6 +1520,15 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
             der(0x04, &basic_response),
         ]);
         der_seq(&[der(0x0a, &[0]), der(0xa0, &response_bytes)])
+    }
+
+    fn test_ocsp_cert_id(leaf: &ParsedCert, issuer: &ParsedCert) -> Vec<u8> {
+        der_seq(&[
+            der_seq(&[der(0x06, &[0x2b, 0x0e, 0x03, 0x02, 0x1a]), der(0x05, &[])]),
+            der(0x04, &Sha1::digest(&issuer.subject_name_der)),
+            der(0x04, &Sha1::digest(&issuer.subject_public_key)),
+            der(0x02, &leaf.serial_number),
+        ])
     }
 
     fn der_seq(parts: &[Vec<u8>]) -> Vec<u8> {
@@ -1508,7 +1576,10 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
             not_after: Some(not_after),
             issuer_der: issuer_der.to_vec(),
             subject_der: subject_der.to_vec(),
+            subject_name_der: Vec::new(),
             spki_der: spki_der.to_vec(),
+            subject_public_key: Vec::new(),
+            serial_number: vec![raw],
             subject_key_id: None,
             authority_key_id: None,
             subject: format!("CN={common_name}"),

--- a/src/tls/inspect/cert.rs
+++ b/src/tls/inspect/cert.rs
@@ -1,6 +1,9 @@
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 
+use sha1::Sha1;
+use sha2::{Digest as _, Sha256};
+
 use crate::error::FetchError;
 
 use super::der::DerReader;
@@ -12,7 +15,11 @@ pub(super) enum OcspStatus {
     Unknown,
 }
 
-pub(super) fn parse_ocsp_status(raw: &[u8]) -> Option<OcspStatus> {
+pub(super) fn parse_ocsp_status(
+    raw: &[u8],
+    leaf: Option<&ParsedCert>,
+    issuer: Option<&ParsedCert>,
+) -> Option<OcspStatus> {
     if raw.is_empty() {
         return None;
     }
@@ -49,10 +56,14 @@ pub(super) fn parse_ocsp_status(raw: &[u8]) -> Option<OcspStatus> {
     if basic_response.tag != 0x04 {
         return None;
     }
-    parse_basic_ocsp_response_status(basic_response.value)
+    parse_basic_ocsp_response_status(basic_response.value, leaf, issuer)
 }
 
-fn parse_basic_ocsp_response_status(raw: &[u8]) -> Option<OcspStatus> {
+fn parse_basic_ocsp_response_status(
+    raw: &[u8],
+    leaf: Option<&ParsedCert>,
+    issuer: Option<&ParsedCert>,
+) -> Option<OcspStatus> {
     let mut top = DerReader::new(raw);
     let basic = top.read_tlv()?;
     if basic.tag != 0x30 {
@@ -81,21 +92,98 @@ fn parse_basic_ocsp_response_status(raw: &[u8]) -> Option<OcspStatus> {
     if responses.tag != 0x30 {
         return None;
     }
+
+    let matching = leaf.zip(issuer);
+    let mut fallback = None;
     let mut responses = DerReader::new(responses.value);
-    let single = responses.read_tlv()?;
-    if single.tag != 0x30 {
-        return None;
+    while let Some(single) = responses.read_tlv() {
+        if single.tag != 0x30 {
+            continue;
+        }
+        let mut single = DerReader::new(single.value);
+        let Some(cert_id) = single.read_tlv() else {
+            continue;
+        };
+        let Some(status) = single.read_tlv().and_then(parse_ocsp_cert_status) else {
+            continue;
+        };
+
+        if let Some((leaf, issuer)) = matching {
+            if ocsp_cert_id_matches(cert_id.raw, leaf, issuer) {
+                return Some(status);
+            }
+        } else if fallback.is_none() {
+            fallback = Some(status);
+        }
     }
 
-    let mut single = DerReader::new(single.value);
-    single.read_tlv()?; // certID
-    let status = single.read_tlv()?;
+    // Without both certificates there is no possible certificate match. The
+    // embedded status is still useful for diagnostics, but it is unverified.
+    fallback
+}
+
+fn parse_ocsp_cert_status(status: super::der::Tlv<'_>) -> Option<OcspStatus> {
     match status.tag {
         0x80 | 0xa0 => Some(OcspStatus::Good),
         0x81 | 0xa1 => Some(OcspStatus::Revoked),
         0x82 | 0xa2 => Some(OcspStatus::Unknown),
         _ => None,
     }
+}
+
+fn ocsp_cert_id_matches(raw: &[u8], leaf: &ParsedCert, issuer: &ParsedCert) -> bool {
+    let mut reader = DerReader::new(raw);
+    let Some(cert_id) = reader.read_tlv() else {
+        return false;
+    };
+    if cert_id.tag != 0x30 {
+        return false;
+    }
+    let mut cert_id = DerReader::new(cert_id.value);
+    let Some(hash_algorithm) = cert_id.read_tlv() else {
+        return false;
+    };
+    let Some(name_hash) = cert_id.read_tlv() else {
+        return false;
+    };
+    let Some(key_hash) = cert_id.read_tlv() else {
+        return false;
+    };
+    let Some(serial) = cert_id.read_tlv() else {
+        return false;
+    };
+    if hash_algorithm.tag != 0x30
+        || name_hash.tag != 0x04
+        || key_hash.tag != 0x04
+        || serial.tag != 0x02
+    {
+        return false;
+    }
+
+    let mut algorithm = DerReader::new(hash_algorithm.value);
+    let Some(algorithm_oid) = algorithm.read_tlv() else {
+        return false;
+    };
+    if algorithm_oid.tag != 0x06 {
+        return false;
+    }
+    let (expected_name_hash, expected_key_hash): (Vec<u8>, Vec<u8>) = match algorithm_oid.value {
+        // id-sha1
+        [0x2b, 0x0e, 0x03, 0x02, 0x1a] => (
+            Sha1::digest(&issuer.subject_name_der).to_vec(),
+            Sha1::digest(&issuer.subject_public_key).to_vec(),
+        ),
+        // id-sha256
+        [0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01] => (
+            Sha256::digest(&issuer.subject_name_der).to_vec(),
+            Sha256::digest(&issuer.subject_public_key).to_vec(),
+        ),
+        _ => return false,
+    };
+
+    name_hash.value == expected_name_hash
+        && key_hash.value == expected_key_hash
+        && serial.value == leaf.serial_number.as_slice()
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -108,7 +196,10 @@ pub(super) struct ParsedCert {
     pub(super) not_after: Option<time::OffsetDateTime>,
     pub(super) issuer_der: Vec<u8>,
     pub(super) subject_der: Vec<u8>,
+    pub(super) subject_name_der: Vec<u8>,
     pub(super) spki_der: Vec<u8>,
+    pub(super) subject_public_key: Vec<u8>,
+    pub(super) serial_number: Vec<u8>,
     pub(super) subject_key_id: Option<Vec<u8>>,
     pub(super) authority_key_id: Option<Vec<u8>>,
     pub(super) subject: String,
@@ -129,7 +220,10 @@ impl ParsedCert {
             not_after: fields.not_after,
             issuer_der: fields.issuer_der,
             subject_der: fields.subject_der,
+            subject_name_der: fields.subject_name_der,
             spki_der: fields.spki_der,
+            subject_public_key: fields.subject_public_key,
+            serial_number: fields.serial_number,
             subject_key_id: fields.subject_key_id,
             authority_key_id: fields.authority_key_id,
             subject: fields.subject.display,
@@ -259,7 +353,10 @@ struct TbsFields<'a> {
     ip_addresses: Vec<IpAddr>,
     issuer_der: Vec<u8>,
     subject_der: Vec<u8>,
+    subject_name_der: Vec<u8>,
     spki_der: Vec<u8>,
+    subject_public_key: Vec<u8>,
+    serial_number: Vec<u8>,
     subject_key_id: Option<Vec<u8>>,
     authority_key_id: Option<Vec<u8>>,
     extensions: Option<&'a [u8]>,
@@ -271,7 +368,7 @@ impl<'a> TbsFields<'a> {
         if reader.peek_tag()? == 0xa0 {
             reader.read_tlv()?;
         }
-        reader.read_tlv()?; // serial
+        let serial = reader.read_tlv()?;
         reader.read_tlv()?; // signature
         let issuer = reader.read_tlv()?;
         let validity = reader.read_tlv()?;
@@ -279,6 +376,7 @@ impl<'a> TbsFields<'a> {
         let subject_tlv = reader.read_tlv()?;
         let subject = parse_name(subject_tlv.value);
         let spki = reader.read_tlv()?;
+        let subject_public_key = parse_subject_public_key(spki.value).unwrap_or_default();
 
         let mut extensions = None;
         while !reader.is_empty() {
@@ -295,7 +393,10 @@ impl<'a> TbsFields<'a> {
             ip_addresses: Vec::new(),
             issuer_der: issuer.value.to_vec(),
             subject_der: subject_tlv.value.to_vec(),
+            subject_name_der: subject_tlv.raw.to_vec(),
             spki_der: spki.raw.to_vec(),
+            subject_public_key,
+            serial_number: serial.value.to_vec(),
             subject_key_id: None,
             authority_key_id: None,
             extensions,
@@ -424,6 +525,16 @@ fn parse_extensions(extensions: Option<&[u8]>, fields: &mut TbsFields<'_>) {
             _ => {}
         }
     }
+}
+
+fn parse_subject_public_key(spki: &[u8]) -> Option<Vec<u8>> {
+    let mut reader = DerReader::new(spki);
+    reader.read_tlv()?; // algorithm
+    let key = reader.read_tlv()?;
+    if key.tag != 0x03 || key.value.first()? != &0 {
+        return None;
+    }
+    Some(key.value[1..].to_vec())
 }
 
 fn parse_subject_key_identifier(octets: &[u8]) -> Option<Vec<u8>> {

--- a/src/tls/inspect/render.rs
+++ b/src/tls/inspect/render.rs
@@ -52,7 +52,12 @@ pub(super) fn render_to(inspection: &Inspection, out: &mut Printer) {
         render_cert_chain(out, &inspection.chain);
         render_sans(out, &inspection.chain[0]);
     }
-    render_ocsp_status(out, &inspection.ocsp_response);
+    render_ocsp_status(
+        out,
+        &inspection.ocsp_response,
+        inspection.chain.first(),
+        inspection.chain.get(1),
+    );
 }
 
 fn render_ech_status(out: &mut Printer, status: rustls::client::EchStatus) {
@@ -98,14 +103,19 @@ fn render_sans(out: &mut Printer, cert: &ParsedCert) {
     out.push('\n');
 }
 
-pub(super) fn render_ocsp_status(out: &mut Printer, raw_ocsp: &[u8]) {
-    let Some(status) = parse_ocsp_status(raw_ocsp) else {
+pub(super) fn render_ocsp_status(
+    out: &mut Printer,
+    raw_ocsp: &[u8],
+    leaf: Option<&ParsedCert>,
+    issuer: Option<&ParsedCert>,
+) {
+    let Some(status) = parse_ocsp_status(raw_ocsp, leaf, issuer) else {
         return;
     };
     out.write_info_prefix();
     out.push_str("OCSP: ");
     out.write_styled(ocsp_status_label(status), &[ocsp_status_color(status)]);
-    out.push_str(" (stapled)\n");
+    out.push_str(" (stapled, unverified)\n");
 }
 
 fn ocsp_status_label(status: OcspStatus) -> &'static str {


### PR DESCRIPTION
## Summary
- label parsed OCSP staple statuses as unverified
- parse all SingleResponse entries and match CertID to the inspected leaf and issuer when available
- document the trust limitation and add coverage

## Validation
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --lib --bins
- focused TLS inspection tests
- integration suite

Task 9 only; tasks 10-11 are not included.