### PR TITLE
fix: avoid guessing omitted TLS trust roots

### DIFF
--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -1078,6 +1078,81 @@ TQt+xSSOMTZFrHhhVqsL9JQlHg==
     }
 
     #[test]
+    fn verified_display_chain_does_not_guess_between_same_subject_roots() {
+        let not_after = time::OffsetDateTime::UNIX_EPOCH + time::Duration::days(24_000);
+        let peer_not_after = time::OffsetDateTime::UNIX_EPOCH + time::Duration::days(21_000);
+        let first_root = chain_test_cert(
+            9,
+            "First CA",
+            b"root-subject",
+            b"root-subject",
+            b"first-root-spki",
+            not_after,
+        );
+        let second_root = chain_test_cert(
+            10,
+            "Second CA",
+            b"root-subject",
+            b"root-subject",
+            b"second-root-spki",
+            not_after,
+        );
+        let peer = chain_test_cert(
+            1,
+            "test-server",
+            b"leaf-subject",
+            b"root-subject",
+            b"leaf-spki",
+            peer_not_after,
+        );
+
+        let chain = certificate_chain_for_display(vec![peer], &[first_root, second_root], true);
+
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].display_name(), "test-server");
+    }
+
+    #[test]
+    fn verified_display_chain_appends_matching_root_when_identity_is_unambiguous() {
+        let not_after = time::OffsetDateTime::UNIX_EPOCH + time::Duration::days(24_000);
+        let peer_not_after = time::OffsetDateTime::UNIX_EPOCH + time::Duration::days(21_000);
+        let mut other_root = chain_test_cert(
+            9,
+            "Other CA",
+            b"root-subject",
+            b"root-subject",
+            b"other-root-spki",
+            not_after,
+        );
+        other_root.subject_key_id = Some(b"other-key".to_vec());
+        let mut selected_root = chain_test_cert(
+            10,
+            "Selected CA",
+            b"root-subject",
+            b"root-subject",
+            b"selected-root-spki",
+            not_after,
+        );
+        selected_root.subject_key_id = Some(b"selected-key".to_vec());
+        let mut peer = chain_test_cert(
+            1,
+            "test-server",
+            b"leaf-subject",
+            b"root-subject",
+            b"leaf-spki",
+            peer_not_after,
+        );
+        peer.authority_key_id = Some(b"selected-key".to_vec());
+
+        let chain =
+            certificate_chain_for_display(vec![peer], &[other_root, selected_root.clone()], true);
+
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[1].raw, selected_root.raw);
+        assert_eq!(chain[1].display_name(), "Selected CA");
+    }
+
+    #[test]
     fn insecure_display_chain_keeps_peer_chain_without_trusted_root() {
         let root_not_after = time::OffsetDateTime::UNIX_EPOCH + time::Duration::days(24_000);
         let peer_not_after = time::OffsetDateTime::UNIX_EPOCH + time::Duration::days(21_000);

--- a/src/tls/inspect/cert.rs
+++ b/src/tls/inspect/cert.rs
@@ -295,9 +295,10 @@ pub(super) fn certificate_chain_for_display(
         return peer_chain;
     }
 
-    if let Some(root) = trusted_roots
-        .iter()
-        .find(|root| issued_by_trusted_root(&last, root))
+    // The platform verifier reports whether validation succeeded, but does not
+    // expose the trust anchor that it selected. Do not guess when the local
+    // root metadata leaves more than one possible anchor.
+    if let Some(root) = unique_issued_by_trusted_root(&last, trusted_roots)
         && !peer_chain.iter().any(|cert| cert.raw == root.raw)
     {
         peer_chain.push(root.clone());
@@ -313,6 +314,21 @@ fn same_trust_anchor_identity(cert: &ParsedCert, root: &ParsedCert) -> bool {
         && cert.spki_der == root.spki_der
 }
 
+fn unique_issued_by_trusted_root<'a>(
+    cert: &ParsedCert,
+    trusted_roots: &'a [ParsedCert],
+) -> Option<&'a ParsedCert> {
+    let mut matches = trusted_roots
+        .iter()
+        .filter(|root| issued_by_trusted_root(cert, root));
+    let root = matches.next()?;
+    if matches.next().is_some() {
+        None
+    } else {
+        Some(root)
+    }
+}
+
 fn issued_by_trusted_root(cert: &ParsedCert, root: &ParsedCert) -> bool {
     if cert.issuer_der.is_empty()
         || root.subject_der.is_empty()
@@ -323,6 +339,8 @@ fn issued_by_trusted_root(cert: &ParsedCert, root: &ParsedCert) -> bool {
 
     match (&cert.authority_key_id, &root.subject_key_id) {
         (Some(authority), Some(subject)) => authority == subject,
+        // Missing key identifiers cannot rule out a candidate. The caller
+        // requires a unique candidate before displaying a trust root.
         _ => true,
     }
 }


### PR DESCRIPTION
## Summary
- avoid appending an arbitrary trust root when multiple roots match
- retain root display when issuer and key identity data identify one candidate
- add ambiguous and unambiguous chain-display regression tests

## Validation
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --lib --bins