### PR TITLE
fix: escape untrusted DNS inspection output

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -178,6 +178,35 @@ pub fn bytes_appear_printable(bytes: &[u8]) -> bool {
     terminal_text_controls_safe(text)
 }
 
+/// Escape control characters before writing untrusted text to a terminal.
+///
+/// Safe text is returned unchanged. Newlines and other control characters are
+/// represented as printable escapes so that untrusted text cannot add output
+/// lines or start a terminal control sequence.
+pub fn escape_terminal_text(text: &str) -> String {
+    let mut escaped = None;
+    for (index, ch) in text.char_indices() {
+        if ch.is_control() {
+            let out = escaped.get_or_insert_with(|| {
+                let mut out = String::with_capacity(text.len());
+                out.push_str(&text[..index]);
+                out
+            });
+            match ch {
+                '\u{08}' => out.push_str(r"\b"),
+                '\u{0c}' => out.push_str(r"\f"),
+                '\n' => out.push_str(r"\n"),
+                '\r' => out.push_str(r"\r"),
+                '\t' => out.push_str(r"\t"),
+                ch => out.push_str(&format!(r"\u{:04x}", ch as u32)),
+            }
+        } else if let Some(out) = escaped.as_mut() {
+            out.push(ch);
+        }
+    }
+    escaped.unwrap_or_else(|| text.to_string())
+}
+
 fn terminal_text_controls_safe(text: &str) -> bool {
     let mut chars = text.chars().peekable();
     while let Some(ch) = chars.next() {
@@ -526,6 +555,21 @@ mod tests {
         assert!(!format_enabled(None, false));
         assert!(format_enabled(Some("auto"), true));
         assert!(!format_enabled(Some("auto"), false));
+    }
+
+    #[test]
+    fn escape_terminal_text_preserves_safe_text_and_escapes_controls() {
+        let cases = [
+            ("plain text", "plain text"),
+            ("line\nfeed", r"line\nfeed"),
+            ("carriage\rreturn", r"carriage\rreturn"),
+            ("escape\x1b[2J", r"escape\u001b[2J"),
+            ("multiple\x01\x7f", r"multiple\u0001\u007f"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(escape_terminal_text(input), expected);
+        }
     }
 
     #[test]

--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -433,8 +433,13 @@ async fn lookup(
     if record_count(&out) > 0 {
         return Ok(out);
     }
+    let host = core::escape_terminal_text(host);
     if let Some(err) = first_err {
-        return Err(format!("lookup {host}: {}", err.message).into());
+        return Err(format!(
+            "lookup {host}: {}",
+            core::escape_terminal_text(&err.message)
+        )
+        .into());
     }
     Err(format!("lookup {host}: no DNS records found").into())
 }
@@ -892,6 +897,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_inspect_doh_escapes_txt_control_sequences() {
+        let (server_url, task) = start_test_server(|request| {
+            if request
+                .uri()
+                .query()
+                .unwrap_or_default()
+                .contains("type=TXT")
+            {
+                return http::Response::new(
+                    r#"{"Status":0,"Answer":[{"type":16,"data":"txt \u001b[2J\r\nforged","TTL":60}]}"#
+                        .to_string(),
+                );
+            }
+            http::Response::new(r#"{"Status":0}"#.to_string())
+        })
+        .await;
+
+        let out = inspect(
+            &Url::parse("https://example.com").unwrap(),
+            Some(server_url.as_str()),
+        )
+        .await
+        .unwrap();
+
+        assert!(out.contains(r"txt \u001b[2J\r\nforged (TTL 1m)"));
+        assert!(!out.contains("txt \x1b[2J"));
+        assert!(!out.contains("forged\r\n"));
+        task.abort();
+    }
+
+    #[tokio::test]
     async fn test_inspect_ip_literal_skips_lookup() {
         let out = inspect(&Url::parse("http://127.0.0.1").unwrap(), None)
             .await
@@ -1103,6 +1139,33 @@ mod tests {
     }
 
     #[test]
+    fn test_render_escapes_untrusted_dns_text() {
+        let out = render(&Inspection {
+            host: "example.com\r\nforged\x1b[2J".to_string(),
+            resolver: "system\r\nforged\x1b]52;c;clipboard\x07".to_string(),
+            records: HashMap::from([(
+                "TXT".to_string(),
+                vec![Record {
+                    typ: "TXT".to_string(),
+                    value: "txt\x1b[2J\r\nforged".to_string(),
+                    ttl: 60,
+                    has_ttl: true,
+                }],
+            )]),
+            warnings: Vec::new(),
+            duration: Duration::ZERO,
+            exit_code: 0,
+        });
+
+        assert!(out.contains(r"example.com\r\nforged\u001b[2J"));
+        assert!(out.contains(r"system\r\nforged\u001b]52;c;clipboard\u0007"));
+        assert!(out.contains(r"txt\u001b[2J\r\nforged (TTL 1m)"));
+        assert!(!out.contains("\x1b[2J"));
+        assert!(!out.contains("\x1b]52;c;clipboard"));
+        assert!(!out.contains("txt\x1b"));
+    }
+
+    #[test]
     fn test_render_colors_dns_output_like_go() {
         let out = render_with_color(
             &Inspection {
@@ -1211,6 +1274,29 @@ mod tests {
         );
 
         assert_eq!(got, r#"0 issue "letsencrypt.org""#);
+    }
+
+    #[tokio::test]
+    async fn test_inspect_doh_error_escapes_response_excerpt() {
+        let (server_url, task) = start_test_server(|_| {
+            http::Response::builder()
+                .status(400)
+                .body(r#"{"error":"bad \u001b[2J\r\nforged"}"#.to_string())
+                .unwrap()
+        })
+        .await;
+
+        let err = inspect(
+            &Url::parse("https://missing.example").unwrap(),
+            Some(server_url.as_str()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains(r"400: bad \u001b[2J\r\nforged"));
+        assert!(!err.to_string().contains("\x1b[2J"));
+        assert!(!err.to_string().contains("bad \r\nforged"));
+        task.abort();
     }
 
     #[tokio::test]

--- a/src/dns/inspect/render.rs
+++ b/src/dns/inspect/render.rs
@@ -86,11 +86,13 @@ fn write_dns_title(out: &mut Printer, host: &str, resolver: &str) {
     out.write_info_prefix();
     out.write_styled("DNS lookup", &[Sequence::Bold, Sequence::Cyan]);
     out.push_str(": ");
-    out.write_styled(host, &[Sequence::Bold]);
+    let host = core::escape_terminal_text(host);
+    out.write_styled(&host, &[Sequence::Bold]);
     out.push_str("\n");
     out.write_info_prefix();
     out.push_str("Resolver: ");
-    out.write_styled(resolver, &[Sequence::Italic]);
+    let resolver = core::escape_terminal_text(resolver);
+    out.write_styled(&resolver, &[Sequence::Italic]);
     out.push_str("\n");
     out.write_info_prefix();
     out.push_str("\n");
@@ -133,7 +135,8 @@ fn render_section(out: &mut Printer, name: &str, records: Option<&Vec<Record>>) 
         };
         out.write_info_prefix();
         out.push_str(&format!("{marker} "));
-        out.write_styled(&record.value, &[Sequence::Green]);
+        let value = core::escape_terminal_text(&record.value);
+        out.write_styled(&value, &[Sequence::Green]);
         if record.has_ttl {
             out.push_str(" ");
             out.write_styled(


### PR DESCRIPTION
Prevent terminal control-sequence injection in DNS inspection output.

- Add shared terminal-safe control escaping.
- Escape DNS record values, host names, resolver labels, and lookup error excerpts.
- Add TXT, forged line, label, and error regression tests.

Finding 1 only.