### PR TITLE
fix: enforce ECH requirements for HTTP/3

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -546,7 +546,8 @@ Encrypted Client Hello mode. Values: `auto`, `on`, `off`. Default: `off`.
   Falls back to GREASE ECH when no real config is found. If the server
   rejects the offer, the connection proceeds gracefully.
 - **`on`** — Require ECH. `fetch` reports an error if the server does not
-  advertise ECH in DNS or rejects the offer.
+  advertise ECH in DNS or rejects the offer. This mode cannot be combined with
+  explicit HTTP/3. Automatic protocol selection uses TCP.
 - **`off`** — Never use ECH.
 
 ECH requires TLS 1.3 and is incompatible with `--min-tls 1.2`.

--- a/docs/ech.md
+++ b/docs/ech.md
@@ -25,7 +25,9 @@ fetch --ech off https://example.com
   recommended mode for general use.
 
 - **`on`** — Require ECH. Errors if the server does not advertise ECH in DNS,
-  and fails if the server rejects the offer.
+  and fails if the server rejects the offer. This mode cannot be used with
+  explicit HTTP/3 because fetch cannot verify ECH acceptance on QUIC
+  connections. Automatic protocol selection uses TCP when this mode is active.
 
 - **`off`** — Never use ECH (the default).
 

--- a/src/http/metadata.rs
+++ b/src/http/metadata.rs
@@ -227,9 +227,18 @@ pub(super) fn validate_http_version_options(
     }
 }
 
-pub(crate) fn validate_ech_for_url(cli: &Cli, url: &Url) -> Result<(), FetchError> {
+pub(crate) fn validate_ech_for_url(
+    cli: &Cli,
+    url: &Url,
+    version: Option<HttpVersion>,
+) -> Result<(), FetchError> {
     if url.scheme() != "https" && matches!(cli.ech.as_deref(), Some("auto" | "on")) {
         return Err("--ech requires an https:// URL".into());
+    }
+    if matches!(cli.ech.as_deref(), Some("on")) && matches!(version, Some(HttpVersion::Http3)) {
+        return Err(
+            "--ech on cannot be used with HTTP/3 because ECH acceptance cannot be verified".into(),
+        );
     }
     Ok(())
 }
@@ -799,6 +808,21 @@ mod tests {
         let err =
             validate_http_version_options(Some(HttpVersion::Http3), &url, false, None).unwrap_err();
         assert_eq!(err.to_string(), "http3: unsupported protocol scheme: http");
+    }
+
+    #[test]
+    fn ech_on_rejects_explicit_http3() {
+        let cli =
+            Cli::try_parse_from(["fetch", "--ech", "on", "--http", "3", "https://example.com"])
+                .unwrap();
+        let url = Url::parse("https://example.com/").unwrap();
+
+        let err = validate_ech_for_url(&cli, &url, Some(HttpVersion::Http3)).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "--ech on cannot be used with HTTP/3 because ECH acceptance cannot be verified"
+        );
     }
 
     #[test]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -106,7 +106,7 @@ async fn execute_inner(cli: &Cli) -> Result<i32, FetchError> {
     apply_query(&mut url, &cli.query);
     client::validate_proxy_for_http_version(cli.proxy.as_deref(), http_version)?;
     validate_http_version_options(http_version, &url, cli.grpc, cli.unix.as_deref())?;
-    validate_ech_for_url(cli, &url)?;
+    validate_ech_for_url(cli, &url, http_version)?;
     let grpc_schema = if cli.grpc {
         proto::load_local_schema(cli)?
     } else {

--- a/src/http/transport/client.rs
+++ b/src/http/transport/client.rs
@@ -193,11 +193,7 @@ impl Client {
         // one on the heap so nested clients such as DoH do not exhaust Windows'
         // default thread stack while polling a request.
         let response = match version {
-            None if (self.config.auto_http3.is_some()
-                || self.config.auto_http3_discovery
-                || self.config.http3_cache.is_some())
-                && url.scheme() == "https" =>
-            {
+            None if should_send_auto_http3(&self.config, &url) => {
                 Box::pin(self.send_auto_http3(method, url.clone(), headers, body, body_deadline))
                     .await
             }
@@ -405,6 +401,14 @@ impl Client {
             },
         })
     }
+}
+
+pub(super) fn should_send_auto_http3(config: &ClientConfig, url: &Url) -> bool {
+    !config.ech_hard_fail
+        && (config.auto_http3.is_some()
+            || config.auto_http3_discovery
+            || config.http3_cache.is_some())
+        && url.scheme() == "https"
 }
 
 impl ClientBuilder {

--- a/src/http/transport/tests.rs
+++ b/src/http/transport/tests.rs
@@ -1,5 +1,5 @@
 use super::body::H3UploadTask;
-use super::client::replace_headers;
+use super::client::{replace_headers, should_send_auto_http3};
 use super::h3::{
     auto_http3_hint_addrs, http3_endpoint_local_addr, race_primary_fallback,
     spawn_auto_http3_origin_addrs, take_finished_auto_http3_origin_addrs,
@@ -74,6 +74,16 @@ fn http3_client_endpoint_defaults_to_dual_stack_bind() {
 
     let explicit = http3_endpoint_local_addr(Some(IpAddr::V4(Ipv4Addr::LOCALHOST)));
     assert_eq!(explicit.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+}
+
+#[test]
+fn ech_hard_fail_forces_tcp_despite_auto_http3_discovery() {
+    let url = Url::parse("https://example.com/").unwrap();
+    let mut builder = Client::builder().auto_http3_discovery();
+    assert!(should_send_auto_http3(&builder.config, &url));
+
+    builder = builder.ech_hard_fail(true);
+    assert!(!should_send_auto_http3(&builder.config, &url));
 }
 
 fn https_record(priority: u16, target: &str, alpn: &[&str], port: Option<u16>) -> SvcbRecord {

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -2258,6 +2258,26 @@ fn ech_rejected_for_plain_http() {
 }
 
 #[test]
+fn ech_on_rejects_explicit_http3() {
+    let res = run_fetch(&[
+        "--ech",
+        "on",
+        "--http",
+        "3",
+        "https://ech-http3-reject.invalid",
+    ]);
+
+    assert_exit(&res, 1);
+    assert!(
+        res.stderr.contains(
+            "--ech on cannot be used with HTTP/3 because ECH acceptance cannot be verified"
+        ),
+        "expected ECH HTTP/3 error, got:\n{}",
+        res.stderr
+    );
+}
+
+#[test]
 fn ech_allowed_for_https() {
     // --ech auto on https:// with a self-signed server should proceed past
     // scheme validation (the actual error should be about the certificate,


### PR DESCRIPTION
## Summary
- reject explicit `--ech on` requests that select HTTP/3 because QUIC cannot expose ECH acceptance
- force automatic HTTP/3 discovery and cache candidates onto the TCP TLS path when ECH hard-fail is enabled
- add unit and integration coverage and document the protocol restriction

## Checks
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- `cargo test --locked --all-features --test cli --test formatting --test grpc --test har --test http --test install --test network --test terminal --test update --test websocket -- --test-threads=2`
