### PR TITLE
fix(dns): support custom transports for HTTPS records

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -211,9 +211,9 @@ Force a specific HTTP version. `--http1`, `--http2`, and `--http3` are aliases
 for `--http 1`, `--http 2`, and `--http 3`.
 
 When `--http` is unset, direct HTTPS requests use DNS HTTPS/SVCB records to
-discover `h3`. With `--dns-server`, HTTPS-record discovery uses that custom UDP
-or DoH resolver. Without `--dns-server`, it uses the platform resolver,
-matching normal address lookup. HTTPS-record discovery and normal A/AAAA lookup
+discover `h3`. With `--dns-server`, HTTPS-record discovery uses that custom
+UDP, TCP, DoT, DoQ, or DoH resolver. Without `--dns-server`, it uses the
+platform resolver, matching normal address lookup. HTTPS-record discovery and normal A/AAAA lookup
 run in parallel. `fetch` starts the TCP/TLS path as soon as normal DNS produces
 a usable address, and a usable `h3` candidate that is discovered before TCP/TLS
 wins races QUIC setup against it. The request is sent once on the winning
@@ -358,7 +358,7 @@ effect with `--inspect-tls`. They cause a warning that `fetch` does not send an
 HTTP request. Configuration-file defaults do not cause this warning.
 
 `--dns-server` applies to TLS inspection too, so certificate diagnostics can use
-the same UDP or DNS-over-HTTPS resolver override as normal requests. When
+the same UDP, TCP, DoT, DoQ, or DoH resolver override as normal requests. When
 combined with `--http 3`, TLS inspection uses a QUIC handshake and offers `h3`
 ALPN instead of dialing TCP.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -609,9 +609,10 @@ Aliases: `--http1`, `--http2`, `--http3`.
 
 When `--http` is unset, direct HTTPS requests use DNS HTTPS/SVCB records to
 discover `h3` endpoints. With `--dns-server`, HTTPS-record discovery uses that
-custom UDP or DoH resolver. Without `--dns-server`, it uses the platform
-resolver, matching normal address lookup. This discovery is opportunistic and
-does not delay the normal address lookup or TCP/TLS setup: `fetch` starts
+custom UDP, TCP, DoT, DoQ, or DoH resolver. Without `--dns-server`, it uses the
+platform resolver, matching normal address lookup. This discovery is
+opportunistic and does not delay the normal address lookup or TCP/TLS setup:
+`fetch` starts
 TCP/TLS as soon as normal DNS produces a usable address, while a usable `h3`
 record discovered before TCP/TLS wins races QUIC setup against it. The request
 is sent once on the winning transport. If HTTPS-record discovery is too slow,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -395,10 +395,10 @@ retry-delay = 0.5
 Force a specific HTTP protocol version.
 
 When unset, direct HTTPS requests use DNS HTTPS/SVCB records to discover `h3`
-endpoints. With `dns-server`, HTTPS-record discovery uses that custom UDP or
-DoH resolver. Without `dns-server`, it uses the platform resolver, matching
-normal address lookup. Discovery runs in parallel with normal A/AAAA lookup and
-TCP/TLS setup. `fetch` starts TCP/TLS as soon as normal DNS produces a usable
+endpoints. With `dns-server`, HTTPS-record discovery uses that custom UDP, TCP,
+DoT, DoQ, or DoH resolver. Without `dns-server`, it uses the platform resolver,
+matching normal address lookup. Discovery runs in parallel with normal A/AAAA
+lookup and TCP/TLS setup. `fetch` starts TCP/TLS as soon as normal DNS produces a usable
 address, while a usable `h3` record discovered before TCP/TLS wins races QUIC
 setup against it. The request is sent once on the winning transport. If
 HTTPS-record discovery is too slow, fails, is unsupported by the OS resolver,

--- a/src/dns/custom.rs
+++ b/src/dns/custom.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use rustls::pki_types::ServerName;
 use url::Url;
 
+use crate::duration::TimeoutBudget;
 use crate::error::FetchError;
 
 const DEFAULT_DNS_PORT: u16 = 53;
@@ -25,6 +26,19 @@ pub(crate) enum ParsedDnsServer {
         port: u16,
     },
     Doh(Url),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DnsRecordData {
+    Wire(Vec<u8>),
+    Text(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DnsQueryRecord {
+    pub(crate) typ: u16,
+    pub(crate) ttl: Option<u32>,
+    pub(crate) data: DnsRecordData,
 }
 
 pub(crate) fn parse_dns_server(value: &str) -> Result<ParsedDnsServer, FetchError> {
@@ -160,6 +174,78 @@ pub(crate) async fn resolve_server_host(
         )));
     }
     Ok(addrs)
+}
+
+pub(crate) async fn query_type(
+    server: &ParsedDnsServer,
+    host: &str,
+    dns_type: u16,
+    dns_type_name: &str,
+    budget: TimeoutBudget,
+    doh_tls_config: Option<rustls::ClientConfig>,
+) -> Result<Vec<DnsQueryRecord>, FetchError> {
+    let wire_records = match server {
+        ParsedDnsServer::Udp(addr) => {
+            crate::dns::resolver::query_udp_type(addr, host, dns_type, budget).await
+        }
+        ParsedDnsServer::Tcp(addr) => {
+            crate::dns::resolver::query_tcp_type(addr, host, dns_type, budget).await
+        }
+        ParsedDnsServer::Tls {
+            server_name,
+            host: server_host,
+            port,
+        } => {
+            let addrs = resolve_server_host(server_host, *port, budget.remaining()?).await?;
+            crate::dns::resolver::query_tls_type(server_name, &addrs, host, dns_type, budget, false)
+                .await
+        }
+        ParsedDnsServer::Quic {
+            server_name,
+            host: server_host,
+            port,
+        } => {
+            let addrs = resolve_server_host(server_host, *port, budget.remaining()?).await?;
+            crate::dns::resolver::query_quic_type(
+                server_name,
+                &addrs,
+                host,
+                dns_type,
+                budget,
+                false,
+            )
+            .await
+        }
+        ParsedDnsServer::Doh(url) => {
+            let client = crate::dns::doh::client_with_budget_and_tls_config(budget, doh_tls_config)
+                .map_err(|err| FetchError::Message(err.to_string()))?;
+            let answers =
+                crate::dns::doh::lookup_doh_records_with_client(&client, url, host, dns_type_name)
+                    .await
+                    .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?;
+            return Ok(answers
+                .into_iter()
+                .map(|answer| DnsQueryRecord {
+                    typ: answer.answer_type,
+                    ttl: answer.ttl,
+                    data: DnsRecordData::Text(answer.data),
+                })
+                .collect());
+        }
+    };
+
+    wire_records
+        .map(|records| {
+            records
+                .into_iter()
+                .map(|record| DnsQueryRecord {
+                    typ: record.typ,
+                    ttl: Some(record.ttl),
+                    data: DnsRecordData::Wire(record.data),
+                })
+                .collect()
+        })
+        .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))
 }
 
 pub(crate) async fn lookup_ips(

--- a/src/dns/resolver.rs
+++ b/src/dns/resolver.rs
@@ -31,6 +31,13 @@ pub struct DnsRecord {
     pub ttl: Option<u32>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WireDnsRecord {
+    pub(crate) typ: u16,
+    pub(crate) ttl: u32,
+    pub(crate) data: Vec<u8>,
+}
+
 pub async fn lookup_udp(
     server_addr: &str,
     host: &str,
@@ -74,19 +81,29 @@ async fn lookup_udp_type_with_budget(
     dns_type: u16,
     budget: TimeoutBudget,
 ) -> Result<Vec<DnsRecord>, ResolverError> {
+    let records = query_udp_type(server_addr, host, dns_type, budget).await?;
+    Ok(ip_records(records, dns_type))
+}
+
+pub(crate) async fn query_udp_type(
+    server_addr: &SocketAddr,
+    host: &str,
+    dns_type: u16,
+    budget: TimeoutBudget,
+) -> Result<Vec<WireDnsRecord>, ResolverError> {
     let id = dns_query_id();
     let raw = wire::build_query(id, host, dns_type).map_err(resolver_error)?;
     let timeout = udp_dns_timeout(budget.remaining().map_err(resolver_error)?);
     let response = crate::dns::transport::query_udp(*server_addr, &raw, timeout)
         .await
         .map_err(resolver_error)?;
-    match dns_records_from_response(&response, id, host, dns_type) {
+    match wire_records_from_response(&response, id, host, dns_type) {
         Ok(records) => Ok(records),
         Err(err) if err.is_truncated() => {
             let response = crate::dns::transport::query_tcp(*server_addr, &raw, budget)
                 .await
                 .map_err(resolver_error)?;
-            dns_records_from_response(&response, id, host, dns_type).map_err(resolver_error)
+            wire_records_from_response(&response, id, host, dns_type).map_err(resolver_error)
         }
         Err(err) => Err(resolver_error(err)),
     }
@@ -159,12 +176,21 @@ pub(crate) async fn lookup_tcp_type(
     if let Ok(ip) = host.parse::<IpAddr>() {
         return Ok(vec![DnsRecord { ip, ttl: None }]);
     }
-    let budget = TimeoutBudget::new(Some(timeout));
+    let records = query_tcp_type(addr, host, dns_type, TimeoutBudget::new(Some(timeout))).await?;
+    Ok(ip_records(records, dns_type))
+}
+
+pub(crate) async fn query_tcp_type(
+    addr: &SocketAddr,
+    host: &str,
+    dns_type: u16,
+    budget: TimeoutBudget,
+) -> Result<Vec<WireDnsRecord>, ResolverError> {
     let connect_timeout = udp_dns_timeout(budget.remaining().map_err(resolver_error)?);
     let mut stream = crate::dns::transport::tcp_connection(addr, connect_timeout)
         .await
         .map_err(resolver_error)?;
-    lookup_stream_type(&mut stream, host, dns_type, budget).await
+    query_stream_type(&mut stream, host, dns_type, budget).await
 }
 
 pub(crate) async fn lookup_tls_type(
@@ -178,13 +204,32 @@ pub(crate) async fn lookup_tls_type(
     if let Ok(ip) = host.parse::<IpAddr>() {
         return Ok(vec![DnsRecord { ip, ttl: None }]);
     }
-    let budget = TimeoutBudget::new(Some(timeout));
+    let records = query_tls_type(
+        server_name,
+        server_addrs,
+        host,
+        dns_type,
+        TimeoutBudget::new(Some(timeout)),
+        insecure,
+    )
+    .await?;
+    Ok(ip_records(records, dns_type))
+}
+
+pub(crate) async fn query_tls_type(
+    server_name: &ServerName<'static>,
+    server_addrs: &[SocketAddr],
+    host: &str,
+    dns_type: u16,
+    budget: TimeoutBudget,
+    insecure: bool,
+) -> Result<Vec<WireDnsRecord>, ResolverError> {
     let connect_timeout = udp_dns_timeout(budget.remaining().map_err(resolver_error)?);
     let mut stream =
         crate::dns::transport::tls_connection(server_name, server_addrs, connect_timeout, insecure)
             .await
             .map_err(resolver_error)?;
-    lookup_stream_type(&mut stream, host, dns_type, budget).await
+    query_stream_type(&mut stream, host, dns_type, budget).await
 }
 
 pub(crate) async fn lookup_quic_type(
@@ -198,7 +243,26 @@ pub(crate) async fn lookup_quic_type(
     if let Ok(ip) = host.parse::<IpAddr>() {
         return Ok(vec![DnsRecord { ip, ttl: None }]);
     }
-    let budget = TimeoutBudget::new(Some(timeout));
+    let records = query_quic_type(
+        server_name,
+        server_addrs,
+        host,
+        dns_type,
+        TimeoutBudget::new(Some(timeout)),
+        insecure,
+    )
+    .await?;
+    Ok(ip_records(records, dns_type))
+}
+
+pub(crate) async fn query_quic_type(
+    server_name: &ServerName<'static>,
+    server_addrs: &[SocketAddr],
+    host: &str,
+    dns_type: u16,
+    budget: TimeoutBudget,
+    insecure: bool,
+) -> Result<Vec<WireDnsRecord>, ResolverError> {
     let connect_timeout = udp_dns_timeout(budget.remaining().map_err(resolver_error)?);
     let connection = crate::dns::transport::quic_connection(
         server_name,
@@ -216,15 +280,15 @@ pub(crate) async fn lookup_quic_type(
             .map_err(resolver_error)
     })
     .await?;
-    dns_records_from_response(&response, DOQ_MESSAGE_ID, host, dns_type).map_err(resolver_error)
+    wire_records_from_response(&response, DOQ_MESSAGE_ID, host, dns_type).map_err(resolver_error)
 }
 
-async fn lookup_stream_type<S: AsyncRead + AsyncWrite + Unpin>(
+async fn query_stream_type<S: AsyncRead + AsyncWrite + Unpin>(
     stream: &mut S,
     host: &str,
     dns_type: u16,
     budget: TimeoutBudget,
-) -> Result<Vec<DnsRecord>, ResolverError> {
+) -> Result<Vec<WireDnsRecord>, ResolverError> {
     let id = dns_query_id();
     let query = wire::build_query(id, host, dns_type).map_err(resolver_error)?;
     let timeout = budget.remaining().map_err(resolver_error)?;
@@ -240,7 +304,7 @@ async fn lookup_stream_type<S: AsyncRead + AsyncWrite + Unpin>(
     if response.len() < 2 {
         return Err(ResolverError("short DNS response".to_string()));
     }
-    dns_records_from_response(&response, id, host, dns_type).map_err(resolver_error)
+    wire_records_from_response(&response, id, host, dns_type).map_err(resolver_error)
 }
 
 async fn run_stream_lookup<S: AsyncRead + AsyncWrite + Unpin>(
@@ -412,20 +476,40 @@ fn dns_records_from_response(
     expected_name: &str,
     expected_type: u16,
 ) -> Result<Vec<DnsRecord>, wire::WireError> {
-    let records =
-        wire::parse_response(raw, expected_id, expected_name, expected_type, DNS_CLASS_IN)?;
+    Ok(ip_records(
+        wire_records_from_response(raw, expected_id, expected_name, expected_type)?,
+        expected_type,
+    ))
+}
 
-    Ok(records
+fn wire_records_from_response(
+    raw: &[u8],
+    expected_id: u16,
+    expected_name: &str,
+    expected_type: u16,
+) -> Result<Vec<WireDnsRecord>, wire::WireError> {
+    Ok(
+        wire::parse_response(raw, expected_id, expected_name, expected_type, DNS_CLASS_IN)?
+            .into_iter()
+            .filter(|record| record.typ == expected_type && record.class == DNS_CLASS_IN)
+            .map(|record| WireDnsRecord {
+                typ: record.typ,
+                ttl: record.ttl,
+                data: record.data.to_vec(),
+            })
+            .collect(),
+    )
+}
+
+fn ip_records(records: Vec<WireDnsRecord>, expected_type: u16) -> Vec<DnsRecord> {
+    records
         .into_iter()
         .filter(|record| record.typ == expected_type)
         .filter_map(ip_record)
-        .collect())
+        .collect()
 }
 
-fn ip_record(record: wire::ResourceRecord<'_>) -> Option<DnsRecord> {
-    if record.class != DNS_CLASS_IN {
-        return None;
-    }
+fn ip_record(record: WireDnsRecord) -> Option<DnsRecord> {
     let ip = match (record.typ, record.data.len()) {
         (DNS_TYPE_A, 4) => IpAddr::from([
             record.data[0],
@@ -435,7 +519,7 @@ fn ip_record(record: wire::ResourceRecord<'_>) -> Option<DnsRecord> {
         ]),
         (DNS_TYPE_AAAA, 16) => {
             let mut octets = [0u8; 16];
-            octets.copy_from_slice(record.data);
+            octets.copy_from_slice(&record.data);
             IpAddr::from(octets)
         }
         _ => return None,
@@ -1068,6 +1152,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn arbitrary_type_query_works_over_tcp_dot_and_doq() {
+        let budget = || TimeoutBudget::new(Some(Duration::from_secs(2)));
+
+        let (tcp_addr, stop_tcp) = start_tcp_server(DnsServerMode::Success);
+        let tcp = query_tcp_type(&tcp_addr, "example.com", wire::TYPE_HTTPS, budget())
+            .await
+            .unwrap();
+        assert_https_wire_record(&tcp);
+        stop_tcp();
+
+        let server_name = ServerName::IpAddress("127.0.0.1".parse::<IpAddr>().unwrap().into());
+        let (dot_addr, stop_dot) = start_tls_server().await;
+        let dot = query_tls_type(
+            &server_name,
+            &[dot_addr],
+            "example.com",
+            wire::TYPE_HTTPS,
+            budget(),
+            true,
+        )
+        .await
+        .unwrap();
+        assert_https_wire_record(&dot);
+        stop_dot();
+
+        let (doq_addr, stop_doq) = start_quic_server().await;
+        let doq = query_quic_type(
+            &server_name,
+            &[doq_addr],
+            "example.com",
+            wire::TYPE_HTTPS,
+            budget(),
+            true,
+        )
+        .await
+        .unwrap();
+        assert_https_wire_record(&doq);
+        stop_doq();
+    }
+
+    fn assert_https_wire_record(records: &[WireDnsRecord]) {
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].typ, wire::TYPE_HTTPS);
+        assert_eq!(records[0].ttl, 44);
+        assert_eq!(
+            crate::dns::svcb::parse_rdata(&records[0].data)
+                .unwrap()
+                .port,
+            Some(8443)
+        );
+    }
+
+    #[tokio::test]
     async fn lookup_tcp_rejects_short_framed_response() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -1219,8 +1356,10 @@ mod tests {
         response.extend_from_slice(&query[0..2]);
         match mode {
             DnsServerMode::Success => {
-                let answer_count =
-                    u16::from(query_type == DNS_TYPE_A || query_type == DNS_TYPE_AAAA);
+                let answer_count = u16::from(matches!(
+                    query_type,
+                    DNS_TYPE_A | DNS_TYPE_AAAA | wire::TYPE_HTTPS
+                ));
                 response.extend_from_slice(&0x8180u16.to_be_bytes());
                 response.extend_from_slice(&1u16.to_be_bytes());
                 response.extend_from_slice(&answer_count.to_be_bytes());
@@ -1243,6 +1382,9 @@ mod tests {
                     43,
                     &std::net::Ipv6Addr::LOCALHOST.octets(),
                 ),
+                wire::TYPE_HTTPS => {
+                    write_answer(&mut response, wire::TYPE_HTTPS, 44, &test_https_rdata())
+                }
                 _ => {}
             }
         }
@@ -1285,6 +1427,17 @@ mod tests {
             raw.extend_from_slice(label.as_bytes());
         }
         raw.push(0);
+    }
+
+    fn test_https_rdata() -> Vec<u8> {
+        let mut data = vec![0, 1, 0];
+        data.extend_from_slice(&1u16.to_be_bytes());
+        data.extend_from_slice(&3u16.to_be_bytes());
+        data.extend_from_slice(&[2, b'h', b'3']);
+        data.extend_from_slice(&3u16.to_be_bytes());
+        data.extend_from_slice(&2u16.to_be_bytes());
+        data.extend_from_slice(&8443u16.to_be_bytes());
+        data
     }
 
     fn write_answer(response: &mut Vec<u8>, dns_type: u16, ttl: u32, data: &[u8]) {

--- a/src/dns/svcb.rs
+++ b/src/dns/svcb.rs
@@ -1,19 +1,15 @@
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::Duration;
 
-use base64::Engine;
-use url::Url;
-
-use crate::dns::util::{dns_query_id, udp_dns_timeout};
+use crate::dns::custom::DnsRecordData;
 use crate::dns::wire;
 use crate::duration::TimeoutBudget;
 use crate::error::FetchError;
+use base64::Engine;
 
 mod system;
 
 const DNS_TYPE_HTTPS: u16 = wire::TYPE_HTTPS;
-const DNS_CLASS_IN: u16 = wire::CLASS_IN;
-
 const KEY_MANDATORY: u16 = 0;
 const KEY_ALPN: u16 = 1;
 const KEY_NO_DEFAULT_ALPN: u16 = 2;
@@ -254,21 +250,18 @@ pub(crate) async fn lookup_https_records_with_doh_tls_config(
         return Ok(Vec::new());
     }
     match resolver {
-        HttpsRecordResolver::Custom(server)
-            if server.starts_with("http://") || server.starts_with("https://") =>
-        {
-            let server_url = Url::parse(server).map_err(|err| {
-                FetchError::Message(format!("invalid dns-server '{server}': {err}"))
-            })?;
-            lookup_doh_https_records(&server_url, host, timeout, doh_tls_config).await
-        }
         HttpsRecordResolver::Custom(server) => {
-            let server_addr = crate::dns::resolver::normalize_udp_dns_server(server)
-                .map_err(|err| FetchError::Message(err.to_string()))?;
-            let server_addr = server_addr.parse::<SocketAddr>().map_err(|err| {
-                FetchError::Message(format!("invalid dns-server '{server}': {err}"))
-            })?;
-            lookup_udp_https_records(server_addr, host, TimeoutBudget::new(timeout)).await
+            let server = crate::dns::custom::parse_dns_server(server)?;
+            let records = crate::dns::custom::query_type(
+                &server,
+                host,
+                DNS_TYPE_HTTPS,
+                "HTTPS",
+                TimeoutBudget::new(timeout),
+                doh_tls_config,
+            )
+            .await?;
+            Ok(svcb_records_from_query(records))
         }
         HttpsRecordResolver::System => {
             system::lookup_https_records(host, TimeoutBudget::new(timeout)).await
@@ -276,69 +269,23 @@ pub(crate) async fn lookup_https_records_with_doh_tls_config(
     }
 }
 
-async fn lookup_doh_https_records(
-    server_url: &Url,
-    host: &str,
-    timeout: Option<Duration>,
-    doh_tls_config: Option<rustls::ClientConfig>,
-) -> Result<Vec<SvcbRecord>, FetchError> {
-    let client = crate::dns::doh::client_with_budget_and_tls_config(
-        TimeoutBudget::new(timeout),
-        doh_tls_config,
-    )
-    .map_err(|err| FetchError::Message(err.to_string()))?;
-    let answers =
-        crate::dns::doh::lookup_doh_records_with_client(&client, server_url, host, "HTTPS")
-            .await
-            .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?;
-    Ok(answers
+pub(super) fn svcb_records_from_query(
+    records: Vec<crate::dns::custom::DnsQueryRecord>,
+) -> Vec<SvcbRecord> {
+    records
         .into_iter()
-        .filter(|answer| answer.answer_type == DNS_TYPE_HTTPS)
-        .filter_map(|answer| {
-            parse_generic_rdata(&answer.data).and_then(|raw| {
-                parse_rdata(&raw).map(|mut record| {
-                    record.ttl = answer.ttl;
-                    record
-                })
-            })
-        })
-        .collect())
-}
-
-async fn lookup_udp_https_records(
-    server_addr: SocketAddr,
-    host: &str,
-    timeout: TimeoutBudget,
-) -> Result<Vec<SvcbRecord>, FetchError> {
-    let id = dns_query_id();
-    let raw = wire::build_query(id, host, DNS_TYPE_HTTPS)
-        .map_err(|err| FetchError::Runtime(err.to_string()))?;
-    let udp_timeout = udp_dns_timeout(timeout.remaining()?);
-    let mut response = crate::dns::transport::query_udp(server_addr, &raw, udp_timeout)
-        .await
-        .map_err(|err| FetchError::Runtime(err.to_string()))?;
-    let raw_records = match wire::parse_response(&response, id, host, DNS_TYPE_HTTPS, DNS_CLASS_IN)
-    {
-        Ok(records) => records,
-        Err(err) if err.is_truncated() => {
-            response = crate::dns::transport::query_tcp(server_addr, &raw, timeout)
-                .await
-                .map_err(|err| FetchError::Runtime(err.to_string()))?;
-            wire::parse_response(&response, id, host, DNS_TYPE_HTTPS, DNS_CLASS_IN)
-                .map_err(|err| FetchError::Runtime(err.to_string()))?
-        }
-        Err(err) => return Err(FetchError::Runtime(err.to_string())),
-    };
-    Ok(raw_records
-        .into_iter()
-        .filter(|record| record.class == DNS_CLASS_IN && record.typ == DNS_TYPE_HTTPS)
+        .filter(|record| record.typ == DNS_TYPE_HTTPS)
         .filter_map(|record| {
-            parse_rdata(record.data).map(|mut parsed| {
-                parsed.ttl = Some(record.ttl);
+            let raw = match record.data {
+                DnsRecordData::Wire(raw) => Some(raw),
+                DnsRecordData::Text(text) => parse_generic_rdata(&text),
+            }?;
+            parse_rdata(&raw).map(|mut parsed| {
+                parsed.ttl = record.ttl;
                 parsed
             })
         })
-        .collect())
+        .collect()
 }
 
 fn unpack_dns_name(raw: &[u8], mut offset: usize) -> Option<(String, usize)> {
@@ -448,6 +395,10 @@ fn hex_digit(byte: u8) -> Option<u8> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
     use super::*;
 
     fn name(labels: &[&str]) -> Vec<u8> {
@@ -541,6 +492,64 @@ mod tests {
 
         let bad_port = record(1, &[], vec![param(KEY_PORT, &[1])]);
         assert_eq!(parse_rdata(&bad_port), None);
+    }
+
+    #[tokio::test]
+    async fn custom_tcp_lookup_returns_https_records() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut len = [0u8; 2];
+            stream.read_exact(&mut len).unwrap();
+            let mut query = vec![0u8; usize::from(u16::from_be_bytes(len))];
+            stream.read_exact(&mut query).unwrap();
+            let question_end = query
+                .iter()
+                .enumerate()
+                .skip(12)
+                .find_map(|(index, byte)| (*byte == 0).then_some(index + 5))
+                .unwrap();
+            let rdata = record(
+                1,
+                &[],
+                vec![
+                    param(KEY_ALPN, &[2, b'h', b'3']),
+                    param(KEY_PORT, &8443u16.to_be_bytes()),
+                ],
+            );
+            let mut response = Vec::new();
+            response.extend_from_slice(&query[..2]);
+            response.extend_from_slice(&0x8180u16.to_be_bytes());
+            response.extend_from_slice(&1u16.to_be_bytes());
+            response.extend_from_slice(&1u16.to_be_bytes());
+            response.extend_from_slice(&0u32.to_be_bytes());
+            response.extend_from_slice(&query[12..question_end]);
+            response.extend_from_slice(&[0xc0, 0x0c]);
+            response.extend_from_slice(&DNS_TYPE_HTTPS.to_be_bytes());
+            response.extend_from_slice(&wire::CLASS_IN.to_be_bytes());
+            response.extend_from_slice(&30u32.to_be_bytes());
+            response.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
+            response.extend_from_slice(&rdata);
+            stream
+                .write_all(&(response.len() as u16).to_be_bytes())
+                .unwrap();
+            stream.write_all(&response).unwrap();
+        });
+
+        let server = format!("tcp://{addr}");
+        let records = lookup_https_records(
+            HttpsRecordResolver::Custom(&server),
+            "example.com",
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].port, Some(8443));
+        assert_eq!(records[0].ttl, Some(30));
+        handle.join().unwrap();
     }
 
     #[tokio::test]

--- a/src/dns/svcb/system.rs
+++ b/src/dns/svcb/system.rs
@@ -22,7 +22,16 @@ pub(super) async fn lookup_https_records(
     let Some(server_addr) = resolv_conf_nameserver() else {
         return Ok(Vec::new());
     };
-    super::lookup_udp_https_records(server_addr, host, timeout).await
+    let records = crate::dns::custom::query_type(
+        &crate::dns::custom::ParsedDnsServer::Udp(server_addr),
+        host,
+        crate::dns::wire::TYPE_HTTPS,
+        "HTTPS",
+        timeout,
+        None,
+    )
+    .await?;
+    Ok(super::svcb_records_from_query(records))
 }
 
 #[cfg(not(all(unix, not(target_os = "macos"))))]


### PR DESCRIPTION
## Summary

- add a generic single-record-type DNS query path for UDP, TCP, DoT, DoQ, and DoH
- use the shared path for HTTPS/SVCB discovery, including system UDP fallback
- preserve HTTPS record TTLs and add TCP, DoT, and DoQ coverage
- document HTTPS-record discovery across all custom DNS transports

## Validation

- `npx --yes prettier@3.6.2 -w docs/advanced-features.md docs/cli-reference.md docs/configuration.md`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- `cargo test --locked --all-features --test cli --test formatting --test grpc --test har --test http --test install --test network --test terminal --test update --test websocket -- --test-threads=2`