### PR TITLE
fix(dns): prevent authenticated SVCB downgrade

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -217,10 +217,12 @@ platform resolver, matching normal address lookup. HTTPS-record discovery and no
 run in parallel. `fetch` starts the TCP/TLS path as soon as normal DNS produces
 a usable address, and a usable `h3` candidate that is discovered before TCP/TLS
 wins races QUIC setup against it. The request is sent once on the winning
-transport. If HTTPS-record discovery is too slow, fails, is unsupported by the
-OS resolver, or returns no usable `h3` record, HTTPS uses the normal ALPN path
-and offers `h2` then `http/1.1`. Proxy and Unix socket requests also use the
-normal ALPN path.
+transport. With system, UDP, TCP, or plaintext HTTP DNS, a slow or failed
+HTTPS-record lookup uses the normal ALPN path. With certificate-verified DoH,
+DoT, or DoQ, a transport, server, or malformed-response failure stops the
+connection to prevent protocol downgrade. An authenticated NODATA or NXDOMAIN
+result can use the normal ALPN path. Proxy and Unix socket requests also use
+the normal ALPN path.
 
 `fetch` also remembers recent HTTP/3 alternatives learned from HTTPS/SVCB
 records and `Alt-Svc: h3=...` response headers in a bounded per-origin cache

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -543,8 +543,10 @@ fetch --min-tls 1.2 --max-tls 1.2 example.com
 Encrypted Client Hello mode. Values: `auto`, `on`, `off`. Default: `off`.
 
 - **`auto`** — Use ECH if the server advertises it in DNS HTTPS/SVCB records.
-  Falls back to GREASE ECH when no real config is found. If the server
-  rejects the offer, the connection proceeds gracefully.
+  Falls back to GREASE ECH when an authenticated lookup completes without a
+  real config. An authenticated DNS lookup failure stops the connection to
+  prevent downgrade. If the server rejects the offer, the connection proceeds
+  gracefully.
 - **`on`** — Require ECH. `fetch` reports an error if the server does not
   advertise ECH in DNS or rejects the offer. This mode cannot be combined with
   explicit HTTP/3. Automatic protocol selection uses TCP.
@@ -617,9 +619,11 @@ opportunistic and does not delay the normal address lookup or TCP/TLS setup:
 `fetch` starts
 TCP/TLS as soon as normal DNS produces a usable address, while a usable `h3`
 record discovered before TCP/TLS wins races QUIC setup against it. The request
-is sent once on the winning transport. If HTTPS-record discovery is too slow,
-fails, is unsupported by the OS resolver, or returns no usable `h3` record,
-HTTPS offers `h2` then `http/1.1` through ALPN. Proxy and Unix socket requests
+is sent once on the winning transport. System, UDP, TCP, and plaintext HTTP
+DNS can fall back after an HTTPS-record lookup failure. A transport, server,
+or malformed-response failure from certificate-verified DoH, DoT, or DoQ
+stops the connection to prevent protocol downgrade. Authenticated NODATA and
+NXDOMAIN results can use the normal ALPN path. Proxy and Unix socket requests
 also use the normal ALPN path.
 
 `--http 1`, `--http 2`, and `--http 3` force that protocol instead of setting

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -400,10 +400,12 @@ DoT, DoQ, or DoH resolver. Without `dns-server`, it uses the platform resolver,
 matching normal address lookup. Discovery runs in parallel with normal A/AAAA
 lookup and TCP/TLS setup. `fetch` starts TCP/TLS as soon as normal DNS produces a usable
 address, while a usable `h3` record discovered before TCP/TLS wins races QUIC
-setup against it. The request is sent once on the winning transport. If
-HTTPS-record discovery is too slow, fails, is unsupported by the OS resolver,
-or returns no usable `h3` record, HTTPS offers `h2` then `http/1.1` through
-ALPN. Proxy and Unix socket requests also use the normal ALPN path.
+setup against it. The request is sent once on the winning transport. System,
+UDP, TCP, and plaintext HTTP DNS can fall back after an HTTPS-record lookup
+failure. A transport, server, or malformed-response failure from
+certificate-verified DoH, DoT, or DoQ stops the connection to prevent protocol
+downgrade. Authenticated NODATA and NXDOMAIN results can use the normal ALPN
+path. Proxy and Unix socket requests also use the normal ALPN path.
 
 Setting this option to `1`, `2`, or `3` forces that protocol. It does not set a
 version cap. Set `http = 1` or `http = 2` to opt out of automatic HTTP/3.

--- a/docs/ech.md
+++ b/docs/ech.md
@@ -20,9 +20,11 @@ fetch --ech off https://example.com
 ## Modes
 
 - **`auto`** — Use ECH if the server advertises it in DNS. Falls back to
-  GREASE ECH when no real config is found. If the server rejects the offer,
-  the connection proceeds (outer ClientHello fallback). This is the
-  recommended mode for general use.
+  GREASE ECH when an authenticated lookup completes without a real config.
+  An authenticated DNS transport, server, or response failure stops the
+  connection to prevent downgrade. If the server rejects the ECH offer, the
+  connection proceeds (outer ClientHello fallback). This is the recommended
+  mode for general use.
 
 - **`on`** — Require ECH. Errors if the server does not advertise ECH in DNS,
   and fails if the server rejects the offer. This mode cannot be used with

--- a/src/dns/custom.rs
+++ b/src/dns/custom.rs
@@ -28,6 +28,28 @@ pub(crate) enum ParsedDnsServer {
     Doh(Url),
 }
 
+impl ParsedDnsServer {
+    /// Returns whether DNS responses have transport authentication.
+    ///
+    /// DoT and DoQ always verify the configured resolver identity. HTTPS DoH
+    /// is authenticated unless certificate verification was disabled by the
+    /// caller. Plain HTTP, UDP, and TCP do not authenticate responses.
+    pub(crate) fn is_authenticated(&self, verify_doh_certificate: bool) -> bool {
+        match self {
+            Self::Tls { .. } | Self::Quic { .. } => true,
+            Self::Doh(url) => url.scheme() == "https" && verify_doh_certificate,
+            Self::Udp(_) | Self::Tcp(_) => false,
+        }
+    }
+}
+
+pub(crate) fn dns_server_is_authenticated(
+    value: &str,
+    verify_doh_certificate: bool,
+) -> Result<bool, FetchError> {
+    Ok(parse_dns_server(value)?.is_authenticated(verify_doh_certificate))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DnsRecordData {
     Wire(Vec<u8>),
@@ -219,10 +241,20 @@ pub(crate) async fn query_type(
         ParsedDnsServer::Doh(url) => {
             let client = crate::dns::doh::client_with_budget_and_tls_config(budget, doh_tls_config)
                 .map_err(|err| FetchError::Message(err.to_string()))?;
-            let answers =
-                crate::dns::doh::lookup_doh_records_with_client(&client, url, host, dns_type_name)
-                    .await
-                    .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?;
+            let answers = match crate::dns::doh::lookup_doh_records_with_client(
+                &client,
+                url,
+                host,
+                dns_type_name,
+            )
+            .await
+            {
+                Ok(answers) => answers,
+                Err(err) if err.is_nxdomain() => return Ok(Vec::new()),
+                Err(err) => {
+                    return Err(FetchError::Runtime(format!("lookup {host}: {err}")));
+                }
+            };
             return Ok(answers
                 .into_iter()
                 .map(|answer| DnsQueryRecord {
@@ -234,18 +266,18 @@ pub(crate) async fn query_type(
         }
     };
 
-    wire_records
-        .map(|records| {
-            records
-                .into_iter()
-                .map(|record| DnsQueryRecord {
-                    typ: record.typ,
-                    ttl: Some(record.ttl),
-                    data: DnsRecordData::Wire(record.data),
-                })
-                .collect()
-        })
-        .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))
+    match wire_records {
+        Ok(records) => Ok(records
+            .into_iter()
+            .map(|record| DnsQueryRecord {
+                typ: record.typ,
+                ttl: Some(record.ttl),
+                data: DnsRecordData::Wire(record.data),
+            })
+            .collect()),
+        Err(err) if err.is_nxdomain() => Ok(Vec::new()),
+        Err(err) => Err(FetchError::Runtime(format!("lookup {host}: {err}"))),
+    }
 }
 
 pub(crate) async fn lookup_ips(
@@ -303,6 +335,45 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use super::*;
+
+    #[test]
+    fn classifies_authenticated_dns_transports() {
+        assert!(
+            !parse_dns_server("udp://127.0.0.1")
+                .unwrap()
+                .is_authenticated(true)
+        );
+        assert!(
+            !parse_dns_server("tcp://127.0.0.1")
+                .unwrap()
+                .is_authenticated(true)
+        );
+        assert!(
+            !parse_dns_server("http://resolver.example/dns-query")
+                .unwrap()
+                .is_authenticated(true)
+        );
+        assert!(
+            !parse_dns_server("https://resolver.example/dns-query")
+                .unwrap()
+                .is_authenticated(false)
+        );
+        assert!(
+            parse_dns_server("https://resolver.example/dns-query")
+                .unwrap()
+                .is_authenticated(true)
+        );
+        assert!(
+            parse_dns_server("tls://resolver.example")
+                .unwrap()
+                .is_authenticated(true)
+        );
+        assert!(
+            parse_dns_server("doq://resolver.example")
+                .unwrap()
+                .is_authenticated(true)
+        );
+    }
 
     #[test]
     fn socket_addrs_use_zero_port_for_transport_override() {

--- a/src/dns/doh.rs
+++ b/src/dns/doh.rs
@@ -36,6 +36,12 @@ impl fmt::Display for DnsError {
 
 impl std::error::Error for DnsError {}
 
+impl DnsError {
+    pub(crate) fn is_nxdomain(&self) -> bool {
+        self.0 == "no such host: NXDomain"
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DnsRecord {
     pub ip: IpAddr,

--- a/src/dns/resolver.rs
+++ b/src/dns/resolver.rs
@@ -25,6 +25,12 @@ impl fmt::Display for ResolverError {
 
 impl std::error::Error for ResolverError {}
 
+impl ResolverError {
+    pub(crate) fn is_nxdomain(&self) -> bool {
+        self.0 == "no such host: NXDomain"
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DnsRecord {
     pub ip: IpAddr,

--- a/src/dns/svcb.rs
+++ b/src/dns/svcb.rs
@@ -261,7 +261,7 @@ pub(crate) async fn lookup_https_records_with_doh_tls_config(
                 doh_tls_config,
             )
             .await?;
-            Ok(svcb_records_from_query(records))
+            svcb_records_from_query(records)
         }
         HttpsRecordResolver::System => {
             system::lookup_https_records(host, TimeoutBudget::new(timeout)).await
@@ -271,19 +271,22 @@ pub(crate) async fn lookup_https_records_with_doh_tls_config(
 
 pub(super) fn svcb_records_from_query(
     records: Vec<crate::dns::custom::DnsQueryRecord>,
-) -> Vec<SvcbRecord> {
+) -> Result<Vec<SvcbRecord>, FetchError> {
     records
         .into_iter()
         .filter(|record| record.typ == DNS_TYPE_HTTPS)
-        .filter_map(|record| {
+        .map(|record| {
             let raw = match record.data {
-                DnsRecordData::Wire(raw) => Some(raw),
-                DnsRecordData::Text(text) => parse_generic_rdata(&text),
-            }?;
-            parse_rdata(&raw).map(|mut parsed| {
-                parsed.ttl = record.ttl;
-                parsed
-            })
+                DnsRecordData::Wire(raw) => raw,
+                DnsRecordData::Text(text) => parse_generic_rdata(&text).ok_or_else(|| {
+                    FetchError::Runtime("malformed HTTPS DNS record data".to_string())
+                })?,
+            };
+            let mut parsed = parse_rdata(&raw).ok_or_else(|| {
+                FetchError::Runtime("malformed HTTPS DNS record data".to_string())
+            })?;
+            parsed.ttl = record.ttl;
+            Ok(parsed)
         })
         .collect()
 }
@@ -494,6 +497,17 @@ mod tests {
         assert_eq!(parse_rdata(&bad_port), None);
     }
 
+    #[test]
+    fn malformed_https_record_rejects_the_lookup() {
+        let result = svcb_records_from_query(vec![crate::dns::custom::DnsQueryRecord {
+            typ: DNS_TYPE_HTTPS,
+            ttl: Some(60),
+            data: DnsRecordData::Wire(vec![0, 1]),
+        }]);
+
+        assert!(result.unwrap_err().to_string().contains("malformed HTTPS"));
+    }
+
     #[tokio::test]
     async fn custom_tcp_lookup_returns_https_records() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -549,6 +563,46 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].port, Some(8443));
         assert_eq!(records[0].ttl, Some(30));
+        handle.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn custom_tcp_nxdomain_is_a_completed_empty_lookup() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut len = [0u8; 2];
+            stream.read_exact(&mut len).unwrap();
+            let mut query = vec![0u8; usize::from(u16::from_be_bytes(len))];
+            stream.read_exact(&mut query).unwrap();
+            let question_end = query
+                .iter()
+                .enumerate()
+                .skip(12)
+                .find_map(|(index, byte)| (*byte == 0).then_some(index + 5))
+                .unwrap();
+            let mut response = Vec::new();
+            response.extend_from_slice(&query[..2]);
+            response.extend_from_slice(&0x8183u16.to_be_bytes());
+            response.extend_from_slice(&1u16.to_be_bytes());
+            response.extend_from_slice(&0u32.to_be_bytes());
+            response.extend_from_slice(&query[12..question_end]);
+            stream
+                .write_all(&(response.len() as u16).to_be_bytes())
+                .unwrap();
+            stream.write_all(&response).unwrap();
+        });
+
+        let records = lookup_https_records(
+            HttpsRecordResolver::Custom(&format!("tcp://{addr}")),
+            "missing.example",
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+
+        assert!(records.is_empty());
         handle.join().unwrap();
     }
 

--- a/src/dns/svcb/system.rs
+++ b/src/dns/svcb/system.rs
@@ -31,7 +31,7 @@ pub(super) async fn lookup_https_records(
         None,
     )
     .await?;
-    Ok(super::svcb_records_from_query(records))
+    super::svcb_records_from_query(records)
 }
 
 #[cfg(not(all(unix, not(target_os = "macos"))))]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -116,7 +116,7 @@ pub(crate) async fn build_client_for_url(
     let dns_timeout = connect_budget.remaining()?;
     let effective_proxy = effective_proxy_for_url(cli.proxy.as_deref(), http_version, url)?;
     let auto_http3 = auto_http3_allowed(context.mode, url, cli.unix.as_deref(), effective_proxy);
-    let discovery = if dynamic_dns_for_client(cli, url, effective_proxy) {
+    let discovery = if dynamic_dns_for_client(cli, url, effective_proxy, auto_http3)? {
         let debug_dns = cli.timing || cli.har.is_some() || (cli.verbose >= 3 && !cli.silent);
         ClientDnsDiscovery {
             dns_resolution: None,
@@ -321,6 +321,15 @@ async fn resolve_dns_for_client_inner(
                 lookup_ech_https_records(cli, Some(dns_server), host, timeout),
             );
             (addrs?, https_records?)
+        } else if auto_http3 && custom::dns_server_is_authenticated(dns_server, !cli.insecure)? {
+            // Authenticated HTTPS lookup failures must gate service access.
+            // Run address and service discovery together, but do not abort or
+            // suppress the service lookup when address resolution completes.
+            let (addrs, https_records) = tokio::join!(
+                lookup_custom_ips_with_doh_tls(cli, dns_server, host, timeout),
+                lookup_authenticated_auto_http3_https_records(cli, dns_server, host, timeout),
+            );
+            (addrs?, https_records?)
         } else if let Some(auto_http3_budget) = auto_http3_discovery {
             let https = spawn_auto_http3_https_records(
                 Some(dns_server.to_string()),
@@ -453,12 +462,25 @@ async fn resolve_dns_for_client_inner(
     })
 }
 
-fn dynamic_dns_for_client(cli: &Cli, url: &Url, effective_proxy: Option<EffectiveProxy>) -> bool {
-    url.host_str()
+fn dynamic_dns_for_client(
+    cli: &Cli,
+    url: &Url,
+    effective_proxy: Option<EffectiveProxy>,
+    auto_http3: bool,
+) -> Result<bool, FetchError> {
+    let authenticated_dns = cli
+        .dns_server
+        .as_deref()
+        .map(|server| custom::dns_server_is_authenticated(server, !cli.insecure))
+        .transpose()?
+        .unwrap_or(false);
+    Ok(url
+        .host_str()
         .is_some_and(|host| host.parse::<IpAddr>().is_err())
         && cli.unix.is_none()
         && effective_proxy.is_none()
         && !is_ech_active(cli)
+        && !(auto_http3 && authenticated_dns))
 }
 
 fn is_ech_active(cli: &Cli) -> bool {
@@ -531,10 +553,31 @@ async fn lookup_ech_https_records(
     {
         Ok(records) => Ok(records),
         Err(err) => {
-            crate::tls::ech::handle_ech_discovery_error(cli, err)?;
+            let authenticated = dns_server
+                .map(|server| custom::dns_server_is_authenticated(server, !cli.insecure))
+                .transpose()?
+                .unwrap_or(false);
+            crate::tls::ech::handle_ech_discovery_error(cli, err, authenticated)?;
             Ok(Vec::new())
         }
     }
+}
+
+async fn lookup_authenticated_auto_http3_https_records(
+    cli: &Cli,
+    dns_server: &str,
+    host: &str,
+    timeout: TimeoutBudget,
+) -> Result<Vec<SvcbRecord>, FetchError> {
+    let lookup_timeout = timeout.remaining()?.unwrap_or(Duration::from_secs(5));
+    TimeoutBudget::new(Some(lookup_timeout))
+        .run(crate::dns::svcb::lookup_https_records_with_doh_tls_config(
+            HttpsRecordResolver::Custom(dns_server),
+            host,
+            Some(lookup_timeout),
+            doh_tls_config_for_cli(cli)?,
+        ))
+        .await
 }
 
 fn spawn_auto_http3_https_records(

--- a/src/tls/ech.rs
+++ b/src/tls/ech.rs
@@ -85,11 +85,17 @@ pub(crate) fn generate_ech_grease_config() -> EchGreaseConfig {
 
 /// Handle a failure to discover ECH configuration in DNS.
 ///
-/// Required ECH reports the original discovery error. Automatic ECH keeps
-/// working with GREASE, but reports the discovery error at verbose level.
-pub(crate) fn handle_ech_discovery_error(cli: &Cli, err: FetchError) -> Result<(), FetchError> {
+/// Required ECH reports the original discovery error. Automatic ECH can use
+/// GREASE after a failure from unauthenticated DNS. A failure from authenticated
+/// DNS is fatal because fallback would permit an active downgrade.
+pub(crate) fn handle_ech_discovery_error(
+    cli: &Cli,
+    err: FetchError,
+    dns_authenticated: bool,
+) -> Result<(), FetchError> {
     match cli.ech.as_deref() {
         Some("on") => Err(err),
+        Some("auto") if dns_authenticated => Err(err),
         Some("auto") => {
             if cli.verbose >= 3 && !cli.silent {
                 let mut printer = core::stdio().stderr_printer(cli.color.as_deref());
@@ -324,6 +330,30 @@ mod tests {
     }
 
     // --- Auto mode with verbose warning for unusable config ---
+
+    #[test]
+    fn authenticated_discovery_error_is_fatal_in_auto_mode() {
+        let cli = cli_with_ech("auto");
+        let err = handle_ech_discovery_error(
+            &cli,
+            FetchError::Runtime("HTTPS lookup timed out".to_string()),
+            true,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "HTTPS lookup timed out");
+    }
+
+    #[test]
+    fn unauthenticated_discovery_error_allows_auto_fallback() {
+        let cli = cli_with_ech("auto");
+        handle_ech_discovery_error(
+            &cli,
+            FetchError::Runtime("HTTPS lookup timed out".to_string()),
+            false,
+        )
+        .unwrap();
+    }
 
     #[test]
     fn auto_mode_with_malformed_and_verbose_produces_warning() {

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -235,7 +235,15 @@ async fn lookup_inspect_ech_candidates(
     {
         Ok(records) => records,
         Err(err) => {
-            super::ech::handle_ech_discovery_error(cli, err)?;
+            let authenticated = cli
+                .dns_server
+                .as_deref()
+                .map(|server| {
+                    crate::dns::custom::dns_server_is_authenticated(server, !cli.insecure)
+                })
+                .transpose()?
+                .unwrap_or(false);
+            super::ech::handle_ech_discovery_error(cli, err, authenticated)?;
             Vec::new()
         }
     };

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -264,6 +264,76 @@ fn inspect_ech_discovery_uses_custom_doh_tls_config() {
 }
 
 #[test]
+fn authenticated_doh_failure_is_fatal_for_ech_auto() {
+    let server = start_tls_server(|req| {
+        if req.path == "/authenticated-ech-target" {
+            return TestResponse::ok("must not downgrade");
+        }
+        if req.path.contains("type=HTTPS") {
+            return TestResponse::status(503, "Service Unavailable", "HTTPS lookup failed");
+        }
+        let body = if req.path.contains("type=A") {
+            r#"{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1"}]}"#
+        } else {
+            r#"{"Status":0}"#
+        };
+        TestResponse::ok(body)
+            .header("Content-Type", "application/dns-json")
+            .header("Connection", "close")
+    });
+    let doh_url = format!("{}/dns-query", server.url);
+    let target_url = format!("{}/authenticated-ech-target", server.url);
+
+    let result = run_fetch(&[
+        "--ech",
+        "auto",
+        "--ca-cert",
+        server.ca_cert_path.to_str().unwrap(),
+        "--dns-server",
+        &doh_url,
+        &target_url,
+    ]);
+
+    assert_exit(&result, 1);
+    assert!(result.stderr.contains("503"), "{}", result.stderr);
+    assert!(!result.stderr.contains("falling back to GREASE"));
+}
+
+#[test]
+fn authenticated_doh_failure_is_fatal_for_auto_http3() {
+    let server = start_tls_server(|req| {
+        if req.path == "/authenticated-http3-target" {
+            return TestResponse::ok("must not downgrade");
+        }
+        if req.path.contains("type=HTTPS") {
+            return TestResponse::status(503, "Service Unavailable", "HTTPS lookup failed");
+        }
+        let body = if req.path.contains("type=A") {
+            r#"{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1"}]}"#
+        } else {
+            r#"{"Status":0}"#
+        };
+        TestResponse::ok(body)
+            .header("Content-Type", "application/dns-json")
+            .header("Connection", "close")
+    });
+    let doh_url = format!("{}/dns-query", server.url);
+    let target_url = format!("{}/authenticated-http3-target", server.url);
+
+    let result = run_fetch(&[
+        "--ca-cert",
+        server.ca_cert_path.to_str().unwrap(),
+        "--dns-server",
+        &doh_url,
+        &target_url,
+    ]);
+
+    assert_exit(&result, 1);
+    assert!(result.stderr.contains("503"), "{}", result.stderr);
+    assert!(!result.stdout.contains("must not downgrade"));
+}
+
+#[test]
 fn connect_timeout_is_shared_between_preresolved_dns_and_tls() {
     let tls = start_h2_tls_server_with_accept_delay(
         |_| TestResponse::ok("too late"),


### PR DESCRIPTION
## Summary

- classify verified DoH, DoT, and DoQ resolvers as authenticated
- make authenticated HTTPS/SVCB transport, server, timeout, and malformed-response failures fatal for ECH auto and automatic HTTP/3
- preserve fallback for unauthenticated DNS and authenticated NODATA/NXDOMAIN outcomes
- document the downgrade policy and add authenticated DoH regression tests

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- full integration suite from `AGENTS.md` with `--test-threads=2`
