### PR TITLE
fix(dns): follow HTTPS AliasMode records

### DIFF
--- a/src/dns/svcb.rs
+++ b/src/dns/svcb.rs
@@ -10,6 +10,7 @@ use base64::Engine;
 mod system;
 
 const DNS_TYPE_HTTPS: u16 = wire::TYPE_HTTPS;
+const MAX_ALIAS_CHAIN_DEPTH: usize = 8;
 const KEY_MANDATORY: u16 = 0;
 const KEY_ALPN: u16 = 1;
 const KEY_NO_DEFAULT_ALPN: u16 = 2;
@@ -67,6 +68,16 @@ struct SvcParam {
 pub(crate) enum HttpsRecordResolver<'a> {
     Custom(&'a str),
     System,
+}
+
+/// The result of RFC 9460 service binding resolution.
+///
+/// `fallback_target` is the effective name to resolve with A/AAAA when the
+/// final name has no usable ServiceMode records.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct HttpsLookup {
+    pub(crate) records: Vec<SvcbRecord>,
+    pub(crate) fallback_target: String,
 }
 
 pub(crate) fn parse_rdata(raw: &[u8]) -> Option<SvcbRecord> {
@@ -236,7 +247,7 @@ pub(crate) async fn lookup_https_records(
     resolver: HttpsRecordResolver<'_>,
     host: &str,
     timeout: Option<Duration>,
-) -> Result<Vec<SvcbRecord>, FetchError> {
+) -> Result<HttpsLookup, FetchError> {
     lookup_https_records_with_doh_tls_config(resolver, host, timeout, None).await
 }
 
@@ -245,28 +256,98 @@ pub(crate) async fn lookup_https_records_with_doh_tls_config(
     host: &str,
     timeout: Option<Duration>,
     doh_tls_config: Option<rustls::ClientConfig>,
-) -> Result<Vec<SvcbRecord>, FetchError> {
-    if let Ok(_ip) = host.parse::<IpAddr>() {
-        return Ok(Vec::new());
+) -> Result<HttpsLookup, FetchError> {
+    if host.parse::<IpAddr>().is_ok() {
+        return Ok(HttpsLookup {
+            records: Vec::new(),
+            fallback_target: host.to_string(),
+        });
     }
-    match resolver {
-        HttpsRecordResolver::Custom(server) => {
-            let server = crate::dns::custom::parse_dns_server(server)?;
-            let records = crate::dns::custom::query_type(
-                &server,
-                host,
-                DNS_TYPE_HTTPS,
-                "HTTPS",
-                TimeoutBudget::new(timeout),
-                doh_tls_config,
-            )
-            .await?;
-            svcb_records_from_query(records)
+
+    let budget = TimeoutBudget::new(timeout);
+    let custom_server = match resolver {
+        HttpsRecordResolver::Custom(server) => Some(crate::dns::custom::parse_dns_server(server)?),
+        HttpsRecordResolver::System => None,
+    };
+    let original = canonical_host(host);
+    let mut current = original.clone();
+    let mut visited = std::collections::HashSet::new();
+    let mut alias_ttl = None;
+
+    for depth in 0..=MAX_ALIAS_CHAIN_DEPTH {
+        if !visited.insert(current.clone()) {
+            return Ok(HttpsLookup {
+                records: Vec::new(),
+                fallback_target: original,
+            });
         }
-        HttpsRecordResolver::System => {
-            system::lookup_https_records(host, TimeoutBudget::new(timeout)).await
+
+        let mut records = match &custom_server {
+            Some(server) => {
+                let records = crate::dns::custom::query_type(
+                    server,
+                    &current,
+                    DNS_TYPE_HTTPS,
+                    "HTTPS",
+                    budget,
+                    doh_tls_config.clone(),
+                )
+                .await?;
+                svcb_records_from_query(records)?
+            }
+            None => system::lookup_https_records(&current, budget).await?,
+        };
+
+        let aliases = records
+            .iter()
+            .filter(|record| record.is_alias_mode())
+            .collect::<Vec<_>>();
+        if aliases.is_empty() {
+            for record in &mut records {
+                if let Some(limit) = alias_ttl {
+                    record.ttl = record.ttl.map(|ttl| ttl.min(limit));
+                }
+                if record.target == "." {
+                    record.target = dns_name(&current);
+                }
+            }
+            return Ok(HttpsLookup {
+                records,
+                fallback_target: current,
+            });
         }
+        if depth == MAX_ALIAS_CHAIN_DEPTH {
+            return Ok(HttpsLookup {
+                records: Vec::new(),
+                fallback_target: original,
+            });
+        }
+
+        // RFC 9460 section 2.4.2 requires ServiceMode records to be ignored
+        // when AliasMode records are present. Multiple AliasMode records are
+        // discouraged, but clients select one rather than rejecting the set.
+        let alias = aliases[rand::random_range(0..aliases.len())];
+        let target = canonical_host(&alias.target);
+        if target.is_empty() || target == "." {
+            return Err(FetchError::Runtime(
+                "invalid HTTPS DNS AliasMode target".to_string(),
+            ));
+        }
+        if let Some(ttl) = alias.ttl {
+            alias_ttl = Some(alias_ttl.map_or(ttl, |limit: u32| limit.min(ttl)));
+        }
+        current = target;
     }
+
+    unreachable!("alias depth is bounded by the loop")
+}
+
+fn canonical_host(host: &str) -> String {
+    host.trim_end_matches('.').to_ascii_lowercase()
+}
+
+fn dns_name(host: &str) -> String {
+    format!("{}.", host.trim_end_matches('.'))
 }
 
 pub(super) fn svcb_records_from_query(
@@ -399,7 +480,7 @@ fn hex_digit(byte: u8) -> Option<u8> {
 #[cfg(test)]
 mod tests {
     use std::io::{Read, Write};
-    use std::net::TcpListener;
+    use std::net::{TcpListener, UdpSocket};
     use std::thread;
 
     use super::*;
@@ -430,6 +511,58 @@ mod tests {
             out.extend_from_slice(&param);
         }
         out
+    }
+
+    type AliasAnswers = Vec<(String, Vec<(u32, Vec<u8>)>)>;
+
+    fn start_udp_alias_server(
+        answers: AliasAnswers,
+    ) -> (std::net::SocketAddr, thread::JoinHandle<()>) {
+        let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+        socket
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let addr = socket.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            let mut raw = [0u8; 2048];
+            for (expected_name, records) in answers {
+                let (len, peer) = socket.recv_from(&mut raw).unwrap();
+                let query = &raw[..len];
+                let mut offset = 12;
+                let mut labels = Vec::new();
+                while query[offset] != 0 {
+                    let label_len = usize::from(query[offset]);
+                    offset += 1;
+                    labels.push(std::str::from_utf8(&query[offset..offset + label_len]).unwrap());
+                    offset += label_len;
+                }
+                offset += 1;
+                assert_eq!(labels.join("."), expected_name);
+                assert_eq!(
+                    u16::from_be_bytes([query[offset], query[offset + 1]]),
+                    DNS_TYPE_HTTPS
+                );
+                let question_end = offset + 4;
+
+                let mut response = Vec::new();
+                response.extend_from_slice(&query[..2]);
+                response.extend_from_slice(&0x8180u16.to_be_bytes());
+                response.extend_from_slice(&1u16.to_be_bytes());
+                response.extend_from_slice(&(records.len() as u16).to_be_bytes());
+                response.extend_from_slice(&0u32.to_be_bytes());
+                response.extend_from_slice(&query[12..question_end]);
+                for (ttl, rdata) in records {
+                    response.extend_from_slice(&[0xc0, 0x0c]);
+                    response.extend_from_slice(&DNS_TYPE_HTTPS.to_be_bytes());
+                    response.extend_from_slice(&wire::CLASS_IN.to_be_bytes());
+                    response.extend_from_slice(&ttl.to_be_bytes());
+                    response.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
+                    response.extend_from_slice(&rdata);
+                }
+                socket.send_to(&response, peer).unwrap();
+            }
+        });
+        (addr, handle)
     }
 
     #[test]
@@ -560,10 +693,218 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(records.len(), 1);
-        assert_eq!(records[0].port, Some(8443));
-        assert_eq!(records[0].ttl, Some(30));
+        assert_eq!(records.records.len(), 1);
+        assert_eq!(records.records[0].port, Some(8443));
+        assert_eq!(records.records[0].ttl, Some(30));
         handle.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn follows_alias_mode_and_returns_final_service_records() {
+        let (addr, server) = start_udp_alias_server(vec![
+            (
+                "example.com".to_string(),
+                vec![(20, record(0, &["svc", "example"], Vec::new()))],
+            ),
+            (
+                "svc.example".to_string(),
+                vec![(60, record(1, &[], vec![param(KEY_ALPN, &[2, b'h', b'3'])]))],
+            ),
+        ]);
+
+        let lookup = lookup_https_records(
+            HttpsRecordResolver::Custom(&addr.to_string()),
+            "EXAMPLE.com.",
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(lookup.fallback_target, "svc.example");
+        assert_eq!(lookup.records.len(), 1);
+        assert_eq!(lookup.records[0].target, "svc.example.");
+        assert_eq!(lookup.records[0].ttl, Some(20));
+        assert!(!lookup.records[0].is_alias_mode());
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn alias_target_nodata_returns_the_effective_fallback_target() {
+        let (addr, server) = start_udp_alias_server(vec![
+            (
+                "example.com".to_string(),
+                vec![(60, record(0, &["fallback", "example"], Vec::new()))],
+            ),
+            ("fallback.example".to_string(), Vec::new()),
+        ]);
+
+        let lookup = lookup_https_records(
+            HttpsRecordResolver::Custom(&addr.to_string()),
+            "example.com",
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+
+        assert!(lookup.records.is_empty());
+        assert_eq!(lookup.fallback_target, "fallback.example");
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn alias_queries_share_the_remaining_timeout() {
+        let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let addr = socket.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let mut raw = [0u8; 2048];
+            let (len, peer) = socket.recv_from(&mut raw).unwrap();
+            let query = &raw[..len];
+            let question_end = query[12..]
+                .iter()
+                .position(|byte| *byte == 0)
+                .map(|offset| offset + 17)
+                .unwrap();
+            let alias = record(0, &["slow", "example"], Vec::new());
+            let mut response = Vec::new();
+            response.extend_from_slice(&query[..2]);
+            response.extend_from_slice(&0x8180u16.to_be_bytes());
+            response.extend_from_slice(&1u16.to_be_bytes());
+            response.extend_from_slice(&1u16.to_be_bytes());
+            response.extend_from_slice(&0u32.to_be_bytes());
+            response.extend_from_slice(&query[12..question_end]);
+            response.extend_from_slice(&[0xc0, 0x0c]);
+            response.extend_from_slice(&DNS_TYPE_HTTPS.to_be_bytes());
+            response.extend_from_slice(&wire::CLASS_IN.to_be_bytes());
+            response.extend_from_slice(&60u32.to_be_bytes());
+            response.extend_from_slice(&(alias.len() as u16).to_be_bytes());
+            response.extend_from_slice(&alias);
+            socket.send_to(&response, peer).unwrap();
+
+            let _ = socket.recv_from(&mut raw).unwrap();
+            thread::sleep(Duration::from_millis(100));
+        });
+        let started = std::time::Instant::now();
+
+        let err = lookup_https_records(
+            HttpsRecordResolver::Custom(&addr.to_string()),
+            "example.com",
+            Some(Duration::from_millis(30)),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_millis(90));
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn alias_mode_loops_fall_back_to_the_original_name() {
+        let (addr, server) = start_udp_alias_server(vec![
+            (
+                "a.example".to_string(),
+                vec![(60, record(0, &["b", "example"], Vec::new()))],
+            ),
+            (
+                "b.example".to_string(),
+                vec![(60, record(0, &["A", "example"], Vec::new()))],
+            ),
+        ]);
+
+        let lookup = lookup_https_records(
+            HttpsRecordResolver::Custom(&addr.to_string()),
+            "a.example",
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+
+        assert!(lookup.records.is_empty());
+        assert_eq!(lookup.fallback_target, "a.example");
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn mixed_mode_rrset_ignores_service_records_and_follows_alias() {
+        let (addr, server) = start_udp_alias_server(vec![
+            (
+                "example.com".to_string(),
+                vec![
+                    (60, record(1, &[], vec![param(KEY_ALPN, &[2, b'h', b'3'])])),
+                    (60, record(0, &["alias", "example"], Vec::new())),
+                ],
+            ),
+            (
+                "alias.example".to_string(),
+                vec![(30, record(1, &[], vec![param(KEY_ALPN, &[2, b'h', b'2'])]))],
+            ),
+        ]);
+
+        let lookup = lookup_https_records(
+            HttpsRecordResolver::Custom(&addr.to_string()),
+            "example.com",
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(lookup.fallback_target, "alias.example");
+        assert_eq!(lookup.records[0].alpn, ["h2"]);
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn multiple_alias_records_are_accepted() {
+        let (addr, server) = start_udp_alias_server(vec![
+            (
+                "example.com".to_string(),
+                vec![
+                    (60, record(0, &["alias", "example"], Vec::new())),
+                    (60, record(0, &["alias", "example"], Vec::new())),
+                ],
+            ),
+            ("alias.example".to_string(), Vec::new()),
+        ]);
+
+        let lookup = lookup_https_records(
+            HttpsRecordResolver::Custom(&addr.to_string()),
+            "example.com",
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+
+        assert!(lookup.records.is_empty());
+        assert_eq!(lookup.fallback_target, "alias.example");
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn alias_mode_depth_limit_falls_back_to_the_original_name() {
+        let answers = (0..=MAX_ALIAS_CHAIN_DEPTH)
+            .map(|index| {
+                (
+                    format!("n{index}.example"),
+                    vec![(
+                        60,
+                        record(0, &[&format!("n{}", index + 1), "example"], Vec::new()),
+                    )],
+                )
+            })
+            .collect();
+        let (addr, server) = start_udp_alias_server(answers);
+
+        let lookup = lookup_https_records(
+            HttpsRecordResolver::Custom(&addr.to_string()),
+            "n0.example",
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+
+        assert!(lookup.records.is_empty());
+        assert_eq!(lookup.fallback_target, "n0.example");
+        server.join().unwrap();
     }
 
     #[tokio::test]
@@ -602,7 +943,8 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(records.is_empty());
+        assert!(records.records.is_empty());
+        assert_eq!(records.fallback_target, "missing.example");
         handle.join().unwrap();
     }
 
@@ -616,7 +958,8 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(records.is_empty());
+        assert!(records.records.is_empty());
+        assert_eq!(records.fallback_target, "127.0.0.1");
     }
 
     #[test]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -11,7 +11,7 @@ use super::http3_cache::Http3Cache;
 use super::transport::{AutoHttp3Config, Client, ClientBuilder, NoProxy, Proxy, redirect};
 use crate::cli::{Cli, HttpVersion};
 use crate::dns::custom;
-use crate::dns::svcb::{HttpsRecordResolver, SvcbRecord};
+use crate::dns::svcb::{HttpsLookup, HttpsRecordResolver, SvcbRecord};
 use crate::duration::{TimeoutBudget, request_timeout_message};
 use crate::error::FetchError;
 use crate::timing::{DnsTiming, TransportTiming};
@@ -293,7 +293,7 @@ async fn resolve_dns_for_client_inner(
                 dns_server: None,
                 auto_http3: None,
                 auto_http3_discovery: false,
-                ech_https_records: https_records,
+                ech_https_records: https_records.records,
             });
         }
         return Ok(ClientDnsDiscovery {
@@ -313,14 +313,14 @@ async fn resolve_dns_for_client_inner(
 
     if let Some(dns_server) = cli.dns_server.as_deref() {
         let start = Instant::now();
-        let (addrs, https_records) = if need_ech_svcb {
+        let (addrs, https_lookup) = if need_ech_svcb {
             // ECH requires HTTPS records; don't use the abort-early auto-H3
             // pattern which may discard them before the SVCB query finishes.
             let (addrs, https_records) = tokio::join!(
                 lookup_custom_ips_with_doh_tls(cli, dns_server, host, timeout),
                 lookup_ech_https_records(cli, Some(dns_server), host, timeout),
             );
-            (addrs?, https_records?)
+            (addrs, https_records?)
         } else if auto_http3 && custom::dns_server_is_authenticated(dns_server, !cli.insecure)? {
             // Authenticated HTTPS lookup failures must gate service access.
             // Run address and service discovery together, but do not abort or
@@ -329,7 +329,7 @@ async fn resolve_dns_for_client_inner(
                 lookup_custom_ips_with_doh_tls(cli, dns_server, host, timeout),
                 lookup_authenticated_auto_http3_https_records(cli, dns_server, host, timeout),
             );
-            (addrs?, https_records?)
+            (addrs, https_records?)
         } else if let Some(auto_http3_budget) = auto_http3_discovery {
             let https = spawn_auto_http3_https_records(
                 Some(dns_server.to_string()),
@@ -337,14 +337,29 @@ async fn resolve_dns_for_client_inner(
                 Some(auto_http3_budget),
             );
             let addrs = lookup_custom_ips_with_doh_tls(cli, dns_server, host, timeout).await;
-            let https_records = take_finished_auto_http3_https_records(https).await;
-            (addrs?, https_records)
+            let https_records = if addrs.is_err() {
+                https.await.unwrap_or_else(|_| empty_https_lookup(host))
+            } else {
+                take_finished_auto_http3_https_records(https, host).await
+            };
+            (addrs, https_records)
         } else {
             (
-                lookup_custom_ips_with_doh_tls(cli, dns_server, host, timeout).await?,
-                Vec::new(),
+                lookup_custom_ips_with_doh_tls(cli, dns_server, host, timeout).await,
+                empty_https_lookup(host),
             )
         };
+        let alias_followed = !https_lookup.fallback_target.eq_ignore_ascii_case(host);
+        let addrs = resolve_custom_alias_fallback(
+            cli,
+            dns_server,
+            host,
+            &https_lookup.fallback_target,
+            timeout,
+            addrs,
+        )
+        .await?;
+        let https_records = https_lookup.records;
         let timing_addrs = dns_timing_addrs(addrs.iter().copied());
         let socket_addrs = custom::socket_addrs_for_override(&addrs);
         let auto_http3_config = auto_http3_config_for_records(
@@ -354,7 +369,7 @@ async fn resolve_dns_for_client_inner(
             &https_records,
             &socket_addrs,
             auto_http3_discovery,
-            false,
+            alias_followed,
         )
         .await;
         if auto_http3 {
@@ -406,29 +421,43 @@ async fn resolve_dns_for_client_inner(
             tokio::join!(lookup, lookup_ech_https_records(cli, None, host, timeout),);
         (
             socket_addrs
-                .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?
-                .collect::<Vec<_>>(),
+                .map(|addrs| addrs.collect::<Vec<_>>())
+                .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}"))),
             https_records?,
         )
     } else if let Some(auto_http3_budget) = auto_http3_discovery {
         let https = spawn_auto_http3_https_records(None, host.to_string(), Some(auto_http3_budget));
         let socket_addrs = lookup.await;
-        let https_records = take_finished_auto_http3_https_records(https).await;
+        let https_records = if socket_addrs.is_err() {
+            https.await.unwrap_or_else(|_| empty_https_lookup(host))
+        } else {
+            take_finished_auto_http3_https_records(https, host).await
+        };
         (
             socket_addrs
-                .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?
-                .collect::<Vec<_>>(),
+                .map(|addrs| addrs.collect::<Vec<_>>())
+                .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}"))),
             https_records,
         )
     } else {
         (
             lookup
                 .await
-                .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?
-                .collect::<Vec<_>>(),
-            Vec::new(),
+                .map(|addrs| addrs.collect::<Vec<_>>())
+                .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}"))),
+            empty_https_lookup(host),
         )
     };
+    let alias_followed = !https_records.fallback_target.eq_ignore_ascii_case(host);
+    let socket_addrs = resolve_system_alias_fallback(
+        host,
+        port,
+        &https_records.fallback_target,
+        timeout,
+        socket_addrs,
+    )
+    .await?;
+    let https_records = https_records.records;
     let addrs = dns_timing_addrs(socket_addrs.iter().map(|addr| addr.ip()));
     let auto_http3_config = auto_http3_config_for_records(
         None,
@@ -437,7 +466,7 @@ async fn resolve_dns_for_client_inner(
         &https_records,
         &socket_addrs,
         auto_http3_discovery,
-        false,
+        alias_followed,
     )
     .await;
     if auto_http3 {
@@ -460,6 +489,39 @@ async fn resolve_dns_for_client_inner(
         auto_http3_discovery: false,
         ech_https_records: https_records,
     })
+}
+
+async fn resolve_custom_alias_fallback(
+    cli: &Cli,
+    dns_server: &str,
+    original: &str,
+    target: &str,
+    timeout: TimeoutBudget,
+    original_addrs: Result<Vec<IpAddr>, FetchError>,
+) -> Result<Vec<IpAddr>, FetchError> {
+    if target.eq_ignore_ascii_case(original) {
+        return original_addrs;
+    }
+    lookup_custom_ips_with_doh_tls(cli, dns_server, target, timeout).await
+}
+
+async fn resolve_system_alias_fallback(
+    original: &str,
+    port: u16,
+    target: &str,
+    timeout: TimeoutBudget,
+    original_addrs: Result<Vec<SocketAddr>, FetchError>,
+) -> Result<Vec<SocketAddr>, FetchError> {
+    if target.eq_ignore_ascii_case(original) {
+        return original_addrs;
+    }
+    let lookup = async {
+        tokio::net::lookup_host((target, port))
+            .await
+            .map(|addrs| addrs.collect::<Vec<_>>())
+            .map_err(|err| FetchError::Runtime(format!("lookup {target}: {err}")))
+    };
+    timeout.run(lookup).await
 }
 
 fn dynamic_dns_for_client(
@@ -515,9 +577,9 @@ async fn lookup_auto_http3_https_records(
     dns_server: Option<&str>,
     host: &str,
     discovery_budget: Option<AutoHttp3DiscoveryBudget>,
-) -> Vec<SvcbRecord> {
+) -> HttpsLookup {
     let Some(timeout) = discovery_budget.and_then(AutoHttp3DiscoveryBudget::remaining) else {
-        return Vec::new();
+        return empty_https_lookup(host);
     };
     let resolver = dns_server
         .map(HttpsRecordResolver::Custom)
@@ -529,7 +591,7 @@ async fn lookup_auto_http3_https_records(
     .await
     .ok()
     .and_then(Result::ok)
-    .unwrap_or_default()
+    .unwrap_or_else(|| empty_https_lookup(host))
 }
 
 async fn lookup_ech_https_records(
@@ -537,7 +599,7 @@ async fn lookup_ech_https_records(
     dns_server: Option<&str>,
     host: &str,
     timeout: TimeoutBudget,
-) -> Result<Vec<SvcbRecord>, FetchError> {
+) -> Result<HttpsLookup, FetchError> {
     let ech_timeout = timeout.remaining()?.unwrap_or(Duration::from_secs(5));
     let resolver = dns_server
         .map(HttpsRecordResolver::Custom)
@@ -551,14 +613,14 @@ async fn lookup_ech_https_records(
         ))
         .await
     {
-        Ok(records) => Ok(records),
+        Ok(lookup) => Ok(lookup),
         Err(err) => {
             let authenticated = dns_server
                 .map(|server| custom::dns_server_is_authenticated(server, !cli.insecure))
                 .transpose()?
                 .unwrap_or(false);
             crate::tls::ech::handle_ech_discovery_error(cli, err, authenticated)?;
-            Ok(Vec::new())
+            Ok(empty_https_lookup(host))
         }
     }
 }
@@ -568,7 +630,7 @@ async fn lookup_authenticated_auto_http3_https_records(
     dns_server: &str,
     host: &str,
     timeout: TimeoutBudget,
-) -> Result<Vec<SvcbRecord>, FetchError> {
+) -> Result<HttpsLookup, FetchError> {
     let lookup_timeout = timeout.remaining()?.unwrap_or(Duration::from_secs(5));
     TimeoutBudget::new(Some(lookup_timeout))
         .run(crate::dns::svcb::lookup_https_records_with_doh_tls_config(
@@ -584,23 +646,31 @@ fn spawn_auto_http3_https_records(
     dns_server: Option<String>,
     host: String,
     discovery_budget: Option<AutoHttp3DiscoveryBudget>,
-) -> JoinHandle<Vec<SvcbRecord>> {
+) -> JoinHandle<HttpsLookup> {
     tokio::spawn(async move {
         lookup_auto_http3_https_records(dns_server.as_deref(), &host, discovery_budget).await
     })
 }
 
 async fn take_finished_auto_http3_https_records(
-    handle: JoinHandle<Vec<SvcbRecord>>,
-) -> Vec<SvcbRecord> {
+    handle: JoinHandle<HttpsLookup>,
+    host: &str,
+) -> HttpsLookup {
     if !handle.is_finished() {
         tokio::task::yield_now().await;
     }
     if handle.is_finished() {
-        handle.await.unwrap_or_default()
+        handle.await.unwrap_or_else(|_| empty_https_lookup(host))
     } else {
         handle.abort();
-        Vec::new()
+        empty_https_lookup(host)
+    }
+}
+
+fn empty_https_lookup(host: &str) -> HttpsLookup {
+    HttpsLookup {
+        records: Vec::new(),
+        fallback_target: host.trim_end_matches('.').to_ascii_lowercase(),
     }
 }
 
@@ -850,7 +920,7 @@ pub(crate) async fn resolve_websocket_ech_mode(
         return Ok(None);
     }
     let records = lookup_ech_https_records(cli, cli.dns_server.as_deref(), host, timeout).await?;
-    let candidates = ech_candidates_from_records(&records);
+    let candidates = ech_candidates_from_records(&records.records);
     crate::tls::ech::resolve_ech_mode(cli, &candidates)
 }
 

--- a/src/http/transport/client.rs
+++ b/src/http/transport/client.rs
@@ -664,6 +664,66 @@ pub(super) async fn connect_direct_tcp_config(
             tcp_duration: tcp_start.elapsed(),
         });
     }
+    if config.auto_http3_discovery && url.scheme() == "https" {
+        let max_discovery = crate::net::HAPPY_EYEBALLS_FALLBACK_DELAY;
+        let discovery_timeout = match timeout.remaining()? {
+            None => Some(max_discovery),
+            Some(remaining) if remaining <= max_discovery => None,
+            Some(remaining) => Some((remaining - max_discovery).min(max_discovery)),
+        };
+        if let Some(discovery_timeout) = discovery_timeout {
+            let resolver = config
+                .dns_server
+                .as_deref()
+                .map(crate::dns::svcb::HttpsRecordResolver::Custom)
+                .unwrap_or(crate::dns::svcb::HttpsRecordResolver::System);
+            let original = crate::net::connect_tcp_traced_with_doh_tls(
+                url,
+                config.dns_server.as_deref(),
+                config.doh_tls_config.clone(),
+                timeout,
+            );
+            let service = crate::dns::svcb::lookup_https_records_with_doh_tls_config(
+                resolver,
+                host,
+                Some(discovery_timeout),
+                config.doh_tls_config.clone(),
+            );
+            tokio::pin!(original);
+            tokio::pin!(service);
+            let (original_result, service_result) = tokio::select! {
+                service_result = &mut service => (None, Some(service_result)),
+                original_result = &mut original => {
+                    if original_result.is_ok() {
+                        return original_result;
+                    }
+                    (Some(original_result), Some(service.await))
+                }
+            };
+            if let Some(Ok(service)) = service_result
+                && !service.fallback_target.eq_ignore_ascii_case(host)
+            {
+                let mut target_url = url.clone();
+                target_url
+                    .set_host(Some(&service.fallback_target))
+                    .map_err(|_| {
+                        FetchError::Runtime("invalid HTTPS AliasMode target".to_string())
+                    })?;
+                return crate::net::connect_tcp_traced_with_doh_tls(
+                    &target_url,
+                    config.dns_server.as_deref(),
+                    config.doh_tls_config.clone(),
+                    timeout,
+                )
+                .await;
+            }
+            return match original_result {
+                Some(result) => result,
+                None => original.await,
+            };
+        }
+    }
+
     crate::net::connect_tcp_traced_with_doh_tls(
         url,
         config.dns_server.as_deref(),

--- a/src/http/transport/h3.rs
+++ b/src/http/transport/h3.rs
@@ -17,7 +17,7 @@ use super::client::{
     record_dns_addrs_trace,
 };
 use super::{Error, ErrorKind};
-use crate::dns::svcb::{HttpsRecordResolver, SvcbRecord};
+use crate::dns::svcb::{HttpsLookup, HttpsRecordResolver, SvcbRecord};
 use crate::duration::TimeoutBudget;
 use crate::error::FetchError;
 use crate::http::http3_cache::Http3CacheCandidate;
@@ -187,24 +187,38 @@ impl Client {
             self.config.doh_tls_config.clone(),
             timeout,
         );
-        let records =
+        let lookup =
             lookup_auto_http3_https_records(self.config.dns_server.as_deref(), &host, timeout)
                 .await;
         if let Some(cache) = &self.config.http3_cache {
             cache
-                .store_https_records(url, self.config.dns_server.as_deref(), &records)
+                .store_https_records(url, self.config.dns_server.as_deref(), &lookup.records)
                 .await;
         }
-        if records.is_empty() {
+        if lookup.records.is_empty() {
             origin_addrs_task.abort();
             return DynamicHttp3ConnectOutcome::NoCandidates;
         }
-        let origin_addrs = take_finished_auto_http3_origin_addrs(origin_addrs_task).await;
+        let effective_host = &lookup.fallback_target;
+        let origin_addrs = if effective_host.eq_ignore_ascii_case(&host) {
+            take_finished_auto_http3_origin_addrs(origin_addrs_task).await
+        } else {
+            origin_addrs_task.abort();
+            crate::net::resolve_host_with_doh_tls(
+                effective_host,
+                self.config.dns_server.as_deref(),
+                self.config.doh_tls_config.clone(),
+                timeout,
+            )
+            .await
+            .unwrap_or_default()
+        };
         let addrs = auto_http3_addrs_for_records(
             self.config.dns_server.as_deref(),
             self.config.doh_tls_config.clone(),
             url,
-            &records,
+            effective_host,
+            &lookup.records,
             &origin_addrs,
             timeout,
         )
@@ -510,9 +524,12 @@ async fn lookup_auto_http3_https_records(
     dns_server: Option<&str>,
     host: &str,
     timeout: TimeoutBudget,
-) -> Vec<SvcbRecord> {
+) -> HttpsLookup {
     let Some(timeout) = auto_http3_lookup_timeout(timeout) else {
-        return Vec::new();
+        return HttpsLookup {
+            records: Vec::new(),
+            fallback_target: host.to_string(),
+        };
     };
     let resolver = dns_server
         .map(HttpsRecordResolver::Custom)
@@ -524,7 +541,10 @@ async fn lookup_auto_http3_https_records(
     .await
     .ok()
     .and_then(Result::ok)
-    .unwrap_or_default()
+    .unwrap_or_else(|| HttpsLookup {
+        records: Vec::new(),
+        fallback_target: host.to_string(),
+    })
 }
 
 fn auto_http3_lookup_timeout(timeout: TimeoutBudget) -> Option<Duration> {
@@ -540,6 +560,7 @@ async fn auto_http3_addrs_for_records(
     dns_server: Option<&str>,
     doh_tls_config: Option<rustls::ClientConfig>,
     url: &Url,
+    effective_host: &str,
     records: &[SvcbRecord],
     origin_addrs: &[SocketAddr],
     timeout: TimeoutBudget,
@@ -562,14 +583,14 @@ async fn auto_http3_addrs_for_records(
         let mut record_addrs = auto_http3_hint_addrs(record, origin_addrs, port);
         if record_addrs.is_empty() {
             let target = auto_http3_target_host(origin_host, &record.target);
-            if target.eq_ignore_ascii_case(origin_host) && !origin_addrs.is_empty() {
+            if target.eq_ignore_ascii_case(effective_host) && !origin_addrs.is_empty() {
                 record_addrs = origin_addrs
                     .iter()
                     .map(|addr| SocketAddr::new(addr.ip(), port))
                     .collect();
-            } else if target.eq_ignore_ascii_case(origin_host) {
+            } else if target.eq_ignore_ascii_case(effective_host) {
                 record_addrs = crate::net::resolve_host_with_doh_tls(
-                    origin_host,
+                    effective_host,
                     dns_server,
                     doh_tls_config.clone(),
                     timeout,
@@ -581,6 +602,18 @@ async fn auto_http3_addrs_for_records(
                 .collect();
             } else if let Ok(ip) = target.parse::<IpAddr>() {
                 record_addrs.push(SocketAddr::new(ip, port));
+            } else if !effective_host.eq_ignore_ascii_case(origin_host) {
+                record_addrs = crate::net::resolve_host_with_doh_tls(
+                    &target,
+                    dns_server,
+                    doh_tls_config.clone(),
+                    timeout,
+                )
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|addr| SocketAddr::new(addr.ip(), port))
+                .collect();
             }
         }
         append_unique_socket_addrs(&mut addrs, record_addrs);

--- a/src/tls/inspect.rs
+++ b/src/tls/inspect.rs
@@ -233,7 +233,7 @@ async fn lookup_inspect_ech_candidates(
         ))
         .await
     {
-        Ok(records) => records,
+        Ok(lookup) => lookup.records,
         Err(err) => {
             let authenticated = cli
                 .dns_server

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -15,7 +15,7 @@ use support::dns::{
     start_udp_dns_server_with_delayed_aaaa, start_udp_dns_server_with_delayed_https_and_resolution,
     start_udp_dns_server_with_delayed_resolution, start_udp_dns_server_with_failing_https,
     start_udp_dns_server_with_hosts, start_udp_dns_server_with_https,
-    start_udp_dns_server_with_https_target_dropping_target,
+    start_udp_dns_server_with_https_alias, start_udp_dns_server_with_https_target_dropping_target,
     start_udp_dns_server_with_https_targets_dropping_targets,
     start_udp_dns_server_with_toggleable_https, start_unresponsive_udp_dns_server,
 };
@@ -837,6 +837,34 @@ fn http3_go_harness_cases() {
     );
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "welcome h3");
+}
+
+#[test]
+fn https_alias_mode_uses_delayed_target_instead_of_origin_address() {
+    let tls = start_tls_server(|req| {
+        if req.path == "/alias-mode" {
+            return TestResponse::ok("alias target ok");
+        }
+        TestResponse::status(404, "Not Found", "")
+    });
+    let port = Url::parse(&tls.url).unwrap().port().unwrap();
+    let dns_addr = start_udp_dns_server_with_https_alias(
+        "fetch-alias-origin.test.",
+        Some(Ipv4Addr::new(127, 0, 0, 2)),
+        "fetch-alias-target.test.",
+        Ipv4Addr::LOCALHOST,
+        Duration::from_millis(40),
+    );
+
+    let res = run_fetch(&[
+        "--dns-server",
+        &dns_addr,
+        "--insecure",
+        &format!("https://fetch-alias-origin.test:{port}/alias-mode"),
+    ]);
+
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "alias target ok");
 }
 
 #[test]

--- a/tests/support/dns.rs
+++ b/tests/support/dns.rs
@@ -14,6 +14,45 @@ pub(crate) fn start_udp_dns_server(host: &'static str, ip: Ipv4Addr) -> String {
     start_udp_dns_server_with_hosts(vec![(host, ip)])
 }
 
+pub(crate) fn start_udp_dns_server_with_https_alias(
+    host: &'static str,
+    origin_ip: Option<Ipv4Addr>,
+    target: &'static str,
+    target_ip: Ipv4Addr,
+    https_delay: Duration,
+) -> String {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("bind udp dns server");
+    let addr = socket.local_addr().unwrap().to_string();
+    thread::spawn(move || {
+        let mut buf = [0_u8; 512];
+        while let Ok((n, peer)) = socket.recv_from(&mut buf) {
+            let Some((name, qtype, question_end)) = parse_dns_question(&buf[..n]) else {
+                continue;
+            };
+            let answer = if name == host && qtype == TYPE_HTTPS {
+                Some((TYPE_HTTPS, https_alias_rdata(target)))
+            } else if name == host && qtype == TYPE_A {
+                origin_ip.map(|ip| (TYPE_A, ip.octets().to_vec()))
+            } else if name == target && qtype == TYPE_A {
+                Some((TYPE_A, target_ip.octets().to_vec()))
+            } else {
+                None
+            };
+            let response = dns_response(&buf[..n], question_end, answer);
+            if name == host && qtype == TYPE_HTTPS && !https_delay.is_zero() {
+                let socket = socket.try_clone().expect("clone udp DNS socket");
+                thread::spawn(move || {
+                    thread::sleep(https_delay);
+                    let _ = socket.send_to(&response, peer);
+                });
+            } else {
+                let _ = socket.send_to(&response, peer);
+            }
+        }
+    });
+    addr
+}
+
 pub(crate) fn start_udp_dns_server_with_https(
     host: &'static str,
     ip: Ipv4Addr,
@@ -387,6 +426,13 @@ fn dns_response_many(query: &[u8], question_end: usize, answers: Vec<(u16, Vec<u
         resp.extend_from_slice(&data);
     }
     resp
+}
+
+fn https_alias_rdata(target: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&0_u16.to_be_bytes());
+    write_dns_name(&mut out, target);
+    out
 }
 
 fn https_rdata(port: u16, ipv4_hint: Ipv4Addr) -> Vec<u8> {


### PR DESCRIPTION
## Summary

- follow bounded HTTPS AliasMode chains and preserve the effective fallback target
- resolve TCP and HTTP/3 connections against alias targets while sharing timeout budgets
- add unit and integration coverage for aliases, loops, depth limits, mixed records, and delayed targets

## Validation

- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- `cargo test --locked --all-features --test cli --test formatting --test grpc --test har --test http --test install --test network --test terminal --test update --test websocket -- --test-threads=2`