### PR TITLE
Reject malformed SVCB RRsets atomically

### DIFF
--- a/src/dns/svcb.rs
+++ b/src/dns/svcb.rs
@@ -33,7 +33,7 @@ const SUPPORTED_MANDATORY_KEYS: &[u16] = &[
 pub(crate) struct SvcbRecord {
     pub(crate) priority: u16,
     pub(crate) target: String,
-    pub(crate) alpn: Vec<String>,
+    pub(crate) alpn: Vec<Vec<u8>>,
     pub(crate) no_default_alpn: bool,
     pub(crate) port: Option<u16>,
     pub(crate) ipv4_hint: Vec<Ipv4Addr>,
@@ -54,7 +54,7 @@ impl SvcbRecord {
     }
 
     pub(crate) fn advertises_alpn(&self, protocol: &str) -> bool {
-        self.alpn.iter().any(|alpn| alpn == protocol)
+        self.alpn.iter().any(|alpn| alpn == protocol.as_bytes())
     }
 }
 
@@ -63,6 +63,170 @@ struct SvcParam {
     key: u16,
     value: Vec<u8>,
 }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SvcbParseError {
+    ShortRdata,
+    InvalidTargetName,
+    TruncatedParamHeader {
+        offset: usize,
+    },
+    TruncatedParamValue {
+        key: u16,
+        expected: usize,
+        actual: usize,
+    },
+    DuplicateParam {
+        key: u16,
+    },
+    OutOfOrderParam {
+        previous: u16,
+        key: u16,
+    },
+    EmptyMandatory,
+    InvalidMandatoryLength {
+        length: usize,
+    },
+    MandatoryKeyZero,
+    DuplicateMandatoryKey {
+        key: u16,
+    },
+    OutOfOrderMandatoryKey {
+        previous: u16,
+        key: u16,
+    },
+    MissingMandatoryParam {
+        key: u16,
+    },
+    EmptyAlpn,
+    EmptyAlpnId,
+    TruncatedAlpnId {
+        expected: usize,
+        actual: usize,
+    },
+    NonEmptyNoDefaultAlpn,
+    NoDefaultAlpnWithoutAlpn,
+    InvalidPortLength {
+        length: usize,
+    },
+    EmptyIpv4Hint,
+    InvalidIpv4HintLength {
+        length: usize,
+    },
+    InvalidEchConfigListLength {
+        declared: Option<usize>,
+        actual: usize,
+    },
+    EmptyEchConfigList,
+    TruncatedEchConfigHeader {
+        offset: usize,
+        actual: usize,
+    },
+    TruncatedEchConfig {
+        offset: usize,
+        expected: usize,
+        actual: usize,
+    },
+    InvalidEchConfigContents(&'static str),
+    EmptyIpv6Hint,
+    InvalidIpv6HintLength {
+        length: usize,
+    },
+}
+
+impl std::fmt::Display for SvcbParseError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ShortRdata => write!(formatter, "RDATA is too short"),
+            Self::InvalidTargetName => write!(formatter, "TargetName is malformed"),
+            Self::TruncatedParamHeader { offset } => {
+                write!(formatter, "SvcParam header at offset {offset} is truncated")
+            }
+            Self::TruncatedParamValue {
+                key,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "SvcParam key {key} declares {expected} value bytes but only {actual} remain"
+            ),
+            Self::DuplicateParam { key } => write!(formatter, "SvcParam key {key} is repeated"),
+            Self::OutOfOrderParam { previous, key } => write!(
+                formatter,
+                "SvcParam key {key} is not greater than preceding key {previous}"
+            ),
+            Self::EmptyMandatory => write!(formatter, "mandatory has an empty value"),
+            Self::InvalidMandatoryLength { length } => write!(
+                formatter,
+                "mandatory value length {length} is not a nonzero multiple of 2"
+            ),
+            Self::MandatoryKeyZero => write!(formatter, "mandatory lists key 0 (mandatory)"),
+            Self::DuplicateMandatoryKey { key } => {
+                write!(formatter, "mandatory key {key} is repeated")
+            }
+            Self::OutOfOrderMandatoryKey { previous, key } => write!(
+                formatter,
+                "mandatory key {key} is not greater than preceding key {previous}"
+            ),
+            Self::MissingMandatoryParam { key } => {
+                write!(formatter, "mandatory lists absent SvcParam key {key}")
+            }
+            Self::EmptyAlpn => write!(formatter, "alpn has an empty value"),
+            Self::EmptyAlpnId => write!(formatter, "alpn contains an empty protocol ID"),
+            Self::TruncatedAlpnId { expected, actual } => write!(
+                formatter,
+                "alpn protocol ID declares {expected} bytes but only {actual} remain"
+            ),
+            Self::NonEmptyNoDefaultAlpn => {
+                write!(formatter, "no-default-alpn must have an empty value")
+            }
+            Self::NoDefaultAlpnWithoutAlpn => {
+                write!(formatter, "no-default-alpn is present without alpn")
+            }
+            Self::InvalidPortLength { length } => {
+                write!(formatter, "port value length is {length}, not 2")
+            }
+            Self::EmptyIpv4Hint => write!(formatter, "ipv4hint has an empty value"),
+            Self::InvalidIpv4HintLength { length } => write!(
+                formatter,
+                "ipv4hint value length {length} is not a nonzero multiple of 4"
+            ),
+            Self::InvalidEchConfigListLength { declared, actual } => match declared {
+                Some(declared) => write!(
+                    formatter,
+                    "ech ECHConfigList declares {declared} bytes but contains {actual}"
+                ),
+                None => write!(
+                    formatter,
+                    "ech ECHConfigList is shorter than its length prefix"
+                ),
+            },
+            Self::EmptyEchConfigList => write!(formatter, "ech ECHConfigList is empty"),
+            Self::TruncatedEchConfigHeader { offset, actual } => write!(
+                formatter,
+                "ech ECHConfig header at offset {offset} has only {actual} bytes"
+            ),
+            Self::TruncatedEchConfig {
+                offset,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "ech ECHConfig at offset {offset} declares {expected} content bytes but only {actual} remain"
+            ),
+            Self::InvalidEchConfigContents(reason) => {
+                write!(formatter, "ech ECHConfigContents is malformed: {reason}")
+            }
+            Self::EmptyIpv6Hint => write!(formatter, "ipv6hint has an empty value"),
+            Self::InvalidIpv6HintLength { length } => write!(
+                formatter,
+                "ipv6hint value length {length} is not a nonzero multiple of 16"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SvcbParseError {}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum HttpsRecordResolver<'a> {
@@ -80,22 +244,36 @@ pub(crate) struct HttpsLookup {
     pub(crate) fallback_target: String,
 }
 
-pub(crate) fn parse_rdata(raw: &[u8]) -> Option<SvcbRecord> {
+pub(crate) fn parse_rdata(raw: &[u8]) -> Result<SvcbRecord, SvcbParseError> {
     if raw.len() < 3 {
-        return None;
+        return Err(SvcbParseError::ShortRdata);
     }
     let priority = u16::from_be_bytes([raw[0], raw[1]]);
-    let (target, mut offset) = unpack_dns_name(raw, 2)?;
+    let (target, mut offset) = unpack_dns_name(raw, 2).ok_or(SvcbParseError::InvalidTargetName)?;
     let mut params = Vec::new();
+    let mut previous_key = None;
     while offset < raw.len() {
         if offset + 4 > raw.len() {
-            return None;
+            return Err(SvcbParseError::TruncatedParamHeader { offset });
         }
         let key = u16::from_be_bytes([raw[offset], raw[offset + 1]]);
+        if let Some(previous) = previous_key {
+            if key == previous {
+                return Err(SvcbParseError::DuplicateParam { key });
+            }
+            if key < previous {
+                return Err(SvcbParseError::OutOfOrderParam { previous, key });
+            }
+        }
+        previous_key = Some(key);
         let len = usize::from(u16::from_be_bytes([raw[offset + 2], raw[offset + 3]]));
         offset += 4;
         if offset + len > raw.len() {
-            return None;
+            return Err(SvcbParseError::TruncatedParamValue {
+                key,
+                expected: len,
+                actual: raw.len() - offset,
+            });
         }
         params.push(SvcParam {
             key,
@@ -103,10 +281,31 @@ pub(crate) fn parse_rdata(raw: &[u8]) -> Option<SvcbRecord> {
         });
         offset += len;
     }
+    if priority == 0 {
+        // RFC 9460 section 2.4.2 requires clients to ignore all SvcParams in
+        // AliasMode. Their wire framing and key order were validated above.
+        return Ok(SvcbRecord {
+            priority,
+            target,
+            alpn: Vec::new(),
+            no_default_alpn: false,
+            port: None,
+            ipv4_hint: Vec::new(),
+            ipv6_hint: Vec::new(),
+            ech: None,
+            mandatory: Vec::new(),
+            unsupported_mandatory: Vec::new(),
+            ttl: None,
+        });
+    }
     record_from_params(priority, target, &params)
 }
 
-fn record_from_params(priority: u16, target: String, params: &[SvcParam]) -> Option<SvcbRecord> {
+fn record_from_params(
+    priority: u16,
+    target: String,
+    params: &[SvcParam],
+) -> Result<SvcbRecord, SvcbParseError> {
     let mut record = SvcbRecord {
         priority,
         target,
@@ -131,19 +330,26 @@ fn record_from_params(priority: u16, target: String, params: &[SvcParam]) -> Opt
             }
             KEY_NO_DEFAULT_ALPN => {
                 if !param.value.is_empty() {
-                    return None;
+                    return Err(SvcbParseError::NonEmptyNoDefaultAlpn);
                 }
                 record.no_default_alpn = true;
             }
             KEY_PORT => {
                 if param.value.len() != 2 {
-                    return None;
+                    return Err(SvcbParseError::InvalidPortLength {
+                        length: param.value.len(),
+                    });
                 }
                 record.port = Some(u16::from_be_bytes([param.value[0], param.value[1]]));
             }
             KEY_IPV4HINT => {
+                if param.value.is_empty() {
+                    return Err(SvcbParseError::EmptyIpv4Hint);
+                }
                 if !param.value.len().is_multiple_of(4) {
-                    return None;
+                    return Err(SvcbParseError::InvalidIpv4HintLength {
+                        length: param.value.len(),
+                    });
                 }
                 record.ipv4_hint = param
                     .value
@@ -152,11 +358,17 @@ fn record_from_params(priority: u16, target: String, params: &[SvcParam]) -> Opt
                     .collect();
             }
             KEY_ECH => {
+                validate_ech_config_list(&param.value)?;
                 record.ech = Some(param.value.clone());
             }
             KEY_IPV6HINT => {
+                if param.value.is_empty() {
+                    return Err(SvcbParseError::EmptyIpv6Hint);
+                }
                 if !param.value.len().is_multiple_of(16) {
-                    return None;
+                    return Err(SvcbParseError::InvalidIpv6HintLength {
+                        length: param.value.len(),
+                    });
                 }
                 record.ipv6_hint = param
                     .value
@@ -172,40 +384,216 @@ fn record_from_params(priority: u16, target: String, params: &[SvcParam]) -> Opt
         }
     }
 
+    if record.no_default_alpn && record.alpn.is_empty() {
+        return Err(SvcbParseError::NoDefaultAlpnWithoutAlpn);
+    }
+    for key in &record.mandatory {
+        if params.binary_search_by_key(key, |param| param.key).is_err() {
+            return Err(SvcbParseError::MissingMandatoryParam { key: *key });
+        }
+    }
     record.unsupported_mandatory = record
         .mandatory
         .iter()
         .copied()
         .filter(|key| !SUPPORTED_MANDATORY_KEYS.contains(key))
         .collect();
-    Some(record)
+    Ok(record)
 }
 
-fn parse_mandatory(value: &[u8]) -> Option<Vec<u16>> {
-    if !value.len().is_multiple_of(2) {
-        return None;
+fn parse_mandatory(value: &[u8]) -> Result<Vec<u16>, SvcbParseError> {
+    if value.is_empty() {
+        return Err(SvcbParseError::EmptyMandatory);
     }
-    Some(
-        value
-            .chunks_exact(2)
-            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
-            .collect(),
-    )
+    if !value.len().is_multiple_of(2) {
+        return Err(SvcbParseError::InvalidMandatoryLength {
+            length: value.len(),
+        });
+    }
+    let mut keys = Vec::with_capacity(value.len() / 2);
+    for chunk in value.chunks_exact(2) {
+        let key = u16::from_be_bytes([chunk[0], chunk[1]]);
+        if key == KEY_MANDATORY {
+            return Err(SvcbParseError::MandatoryKeyZero);
+        }
+        if let Some(previous) = keys.last().copied() {
+            if key == previous {
+                return Err(SvcbParseError::DuplicateMandatoryKey { key });
+            }
+            if key < previous {
+                return Err(SvcbParseError::OutOfOrderMandatoryKey { previous, key });
+            }
+        }
+        keys.push(key);
+    }
+    Ok(keys)
 }
 
-fn parse_alpn(value: &[u8]) -> Option<Vec<String>> {
+fn parse_alpn(value: &[u8]) -> Result<Vec<Vec<u8>>, SvcbParseError> {
+    if value.is_empty() {
+        return Err(SvcbParseError::EmptyAlpn);
+    }
     let mut alpns = Vec::new();
     let mut offset = 0;
     while offset < value.len() {
         let len = usize::from(value[offset]);
         offset += 1;
-        if len == 0 || offset + len > value.len() {
-            return None;
+        if len == 0 {
+            return Err(SvcbParseError::EmptyAlpnId);
         }
-        alpns.push(String::from_utf8(value[offset..offset + len].to_vec()).ok()?);
+        if offset + len > value.len() {
+            return Err(SvcbParseError::TruncatedAlpnId {
+                expected: len,
+                actual: value.len() - offset,
+            });
+        }
+        alpns.push(value[offset..offset + len].to_vec());
         offset += len;
     }
-    Some(alpns)
+    Ok(alpns)
+}
+
+fn validate_ech_config_list(value: &[u8]) -> Result<(), SvcbParseError> {
+    let Some(length) = value
+        .get(..2)
+        .map(|bytes| usize::from(u16::from_be_bytes([bytes[0], bytes[1]])))
+    else {
+        return Err(SvcbParseError::InvalidEchConfigListLength {
+            declared: None,
+            actual: value.len(),
+        });
+    };
+    let actual = value.len() - 2;
+    if length != actual {
+        return Err(SvcbParseError::InvalidEchConfigListLength {
+            declared: Some(length),
+            actual,
+        });
+    }
+    if length == 0 {
+        return Err(SvcbParseError::EmptyEchConfigList);
+    }
+
+    let mut offset = 2;
+    while offset < value.len() {
+        let remaining = value.len() - offset;
+        if remaining < 4 {
+            return Err(SvcbParseError::TruncatedEchConfigHeader {
+                offset: offset - 2,
+                actual: remaining,
+            });
+        }
+        let version = u16::from_be_bytes([value[offset], value[offset + 1]]);
+        let contents_len = usize::from(u16::from_be_bytes([value[offset + 2], value[offset + 3]]));
+        let config_offset = offset - 2;
+        offset += 4;
+        let remaining = value.len() - offset;
+        if contents_len > remaining {
+            return Err(SvcbParseError::TruncatedEchConfig {
+                offset: config_offset,
+                expected: contents_len,
+                actual: remaining,
+            });
+        }
+        if version == 0xfe0d {
+            validate_ech_config_contents(&value[offset..offset + contents_len])?;
+        }
+        offset += contents_len;
+    }
+    Ok(())
+}
+
+fn validate_ech_config_contents(value: &[u8]) -> Result<(), SvcbParseError> {
+    let mut offset = 0;
+    take_ech_bytes(value, &mut offset, 1, "missing config_id")?;
+    take_ech_bytes(value, &mut offset, 2, "missing kem_id")?;
+
+    let public_key_len = read_ech_u16(value, &mut offset, "missing public_key length")?;
+    if public_key_len == 0 {
+        return Err(SvcbParseError::InvalidEchConfigContents(
+            "public_key is empty",
+        ));
+    }
+    take_ech_bytes(value, &mut offset, public_key_len, "truncated public_key")?;
+
+    let suites_len = read_ech_u16(value, &mut offset, "missing cipher suite list length")?;
+    if suites_len == 0 || !suites_len.is_multiple_of(4) {
+        return Err(SvcbParseError::InvalidEchConfigContents(
+            "cipher suite list length is not a nonzero multiple of 4",
+        ));
+    }
+    take_ech_bytes(
+        value,
+        &mut offset,
+        suites_len,
+        "truncated cipher suite list",
+    )?;
+    take_ech_bytes(value, &mut offset, 1, "missing maximum_name_length")?;
+
+    let public_name_len = usize::from(
+        *take_ech_bytes(value, &mut offset, 1, "missing public_name length")?
+            .first()
+            .expect("one byte was requested"),
+    );
+    if public_name_len == 0 {
+        return Err(SvcbParseError::InvalidEchConfigContents(
+            "public_name is empty",
+        ));
+    }
+    take_ech_bytes(value, &mut offset, public_name_len, "truncated public_name")?;
+
+    let extensions_len = read_ech_u16(value, &mut offset, "missing extensions length")?;
+    let extensions = take_ech_bytes(value, &mut offset, extensions_len, "truncated extensions")?;
+    let mut extension_offset = 0;
+    while extension_offset < extensions.len() {
+        take_ech_bytes(
+            extensions,
+            &mut extension_offset,
+            2,
+            "truncated extension type",
+        )?;
+        let data_len = read_ech_u16(
+            extensions,
+            &mut extension_offset,
+            "truncated extension length",
+        )?;
+        take_ech_bytes(
+            extensions,
+            &mut extension_offset,
+            data_len,
+            "truncated extension data",
+        )?;
+    }
+    if offset != value.len() {
+        return Err(SvcbParseError::InvalidEchConfigContents(
+            "trailing bytes after extensions",
+        ));
+    }
+    Ok(())
+}
+
+fn read_ech_u16(
+    value: &[u8],
+    offset: &mut usize,
+    reason: &'static str,
+) -> Result<usize, SvcbParseError> {
+    let bytes = take_ech_bytes(value, offset, 2, reason)?;
+    Ok(usize::from(u16::from_be_bytes([bytes[0], bytes[1]])))
+}
+
+fn take_ech_bytes<'a>(
+    value: &'a [u8],
+    offset: &mut usize,
+    length: usize,
+    reason: &'static str,
+) -> Result<&'a [u8], SvcbParseError> {
+    let end = offset
+        .checked_add(length)
+        .filter(|end| *end <= value.len())
+        .ok_or(SvcbParseError::InvalidEchConfigContents(reason))?;
+    let bytes = &value[*offset..end];
+    *offset = end;
+    Ok(bytes)
 }
 
 pub(crate) fn format_rdata(raw: &[u8]) -> Option<String> {
@@ -363,8 +751,8 @@ pub(super) fn svcb_records_from_query(
                     FetchError::Runtime("malformed HTTPS DNS record data".to_string())
                 })?,
             };
-            let mut parsed = parse_rdata(&raw).ok_or_else(|| {
-                FetchError::Runtime("malformed HTTPS DNS record data".to_string())
+            let mut parsed = parse_rdata(&raw).map_err(|err| {
+                FetchError::Runtime(format!("malformed HTTPS DNS record data: {err}"))
             })?;
             parsed.ttl = record.ttl;
             Ok(parsed)
@@ -405,9 +793,14 @@ fn format_svc_param(key: u16, value: &[u8]) -> String {
             format!("Mandatory={}", keys.join(","))
         }
         KEY_MANDATORY => format!("Mandatory=0x{}", hex_encode(value)),
-        KEY_ALPN => match parse_alpn(value) {
-            Some(alpns) => format!("ALPN={}", alpns.join(",")),
-            None => format!("ALPN=0x{}", hex_encode(value)),
+        KEY_ALPN => match parse_alpn(value).and_then(|alpns| {
+            alpns
+                .into_iter()
+                .map(|alpn| String::from_utf8(alpn).map_err(|_| SvcbParseError::EmptyAlpn))
+                .collect::<Result<Vec<_>, _>>()
+        }) {
+            Ok(alpns) => format!("ALPN={}", alpns.join(",")),
+            Err(_) => format!("ALPN=0x{}", hex_encode(value)),
         },
         KEY_NO_DEFAULT_ALPN => "NoDefaultALPN".to_string(),
         KEY_PORT if value.len() == 2 => {
@@ -582,7 +975,7 @@ mod tests {
 
         assert_eq!(got.priority, 1);
         assert_eq!(got.target, ".");
-        assert_eq!(got.alpn, ["h3"]);
+        assert_eq!(got.alpn, [b"h3".to_vec()]);
         assert_eq!(got.port, Some(4433));
         assert_eq!(got.ipv4_hint, [Ipv4Addr::new(192, 0, 2, 1)]);
         assert_eq!(got.ipv6_hint, [Ipv6Addr::LOCALHOST]);
@@ -609,6 +1002,7 @@ mod tests {
             vec![
                 param(KEY_MANDATORY, &[0, 1, 0, 9]),
                 param(KEY_ALPN, &[2, b'h', b'3']),
+                param(9, &[]),
             ],
         );
 
@@ -621,24 +1015,267 @@ mod tests {
 
     #[test]
     fn rejects_malformed_records() {
-        assert_eq!(parse_rdata(&[0, 1]), None);
+        assert_eq!(parse_rdata(&[0, 1]), Err(SvcbParseError::ShortRdata));
 
         let bad_alpn = record(1, &[], vec![param(KEY_ALPN, &[3, b'h', b'3'])]);
-        assert_eq!(parse_rdata(&bad_alpn), None);
+        assert!(matches!(
+            parse_rdata(&bad_alpn),
+            Err(SvcbParseError::TruncatedAlpnId { .. })
+        ));
 
         let bad_port = record(1, &[], vec![param(KEY_PORT, &[1])]);
-        assert_eq!(parse_rdata(&bad_port), None);
+        assert_eq!(
+            parse_rdata(&bad_port),
+            Err(SvcbParseError::InvalidPortLength { length: 1 })
+        );
     }
 
     #[test]
-    fn malformed_https_record_rejects_the_lookup() {
-        let result = svcb_records_from_query(vec![crate::dns::custom::DnsQueryRecord {
-            typ: DNS_TYPE_HTTPS,
-            ttl: Some(60),
-            data: DnsRecordData::Wire(vec![0, 1]),
-        }]);
+    fn rejects_invalid_svcparams_with_detailed_errors() {
+        let cases = [
+            (
+                "duplicate SvcParam",
+                record(
+                    1,
+                    &[],
+                    vec![
+                        param(KEY_ALPN, &[2, b'h', b'3']),
+                        param(KEY_ALPN, &[2, b'h', b'2']),
+                    ],
+                ),
+                SvcbParseError::DuplicateParam { key: KEY_ALPN },
+            ),
+            (
+                "descending SvcParams",
+                record(
+                    1,
+                    &[],
+                    vec![
+                        param(KEY_PORT, &[1, 187]),
+                        param(KEY_ALPN, &[2, b'h', b'3']),
+                    ],
+                ),
+                SvcbParseError::OutOfOrderParam {
+                    previous: KEY_PORT,
+                    key: KEY_ALPN,
+                },
+            ),
+            (
+                "empty mandatory",
+                record(1, &[], vec![param(KEY_MANDATORY, &[])]),
+                SvcbParseError::EmptyMandatory,
+            ),
+            (
+                "mandatory lists itself",
+                record(1, &[], vec![param(KEY_MANDATORY, &[0, 0])]),
+                SvcbParseError::MandatoryKeyZero,
+            ),
+            (
+                "duplicate mandatory key",
+                record(
+                    1,
+                    &[],
+                    vec![
+                        param(KEY_MANDATORY, &[0, 1, 0, 1]),
+                        param(KEY_ALPN, &[2, b'h', b'3']),
+                    ],
+                ),
+                SvcbParseError::DuplicateMandatoryKey { key: KEY_ALPN },
+            ),
+            (
+                "descending mandatory keys",
+                record(
+                    1,
+                    &[],
+                    vec![
+                        param(KEY_MANDATORY, &[0, 3, 0, 1]),
+                        param(KEY_ALPN, &[2, b'h', b'3']),
+                        param(KEY_PORT, &[1, 187]),
+                    ],
+                ),
+                SvcbParseError::OutOfOrderMandatoryKey {
+                    previous: KEY_PORT,
+                    key: KEY_ALPN,
+                },
+            ),
+            (
+                "missing mandatory SvcParam",
+                record(
+                    1,
+                    &[],
+                    vec![
+                        param(KEY_MANDATORY, &[0, 1, 0, 3]),
+                        param(KEY_ALPN, &[2, b'h', b'3']),
+                    ],
+                ),
+                SvcbParseError::MissingMandatoryParam { key: KEY_PORT },
+            ),
+            (
+                "empty alpn",
+                record(1, &[], vec![param(KEY_ALPN, &[])]),
+                SvcbParseError::EmptyAlpn,
+            ),
+            (
+                "no-default-alpn without alpn",
+                record(1, &[], vec![param(KEY_NO_DEFAULT_ALPN, &[])]),
+                SvcbParseError::NoDefaultAlpnWithoutAlpn,
+            ),
+            (
+                "nonempty no-default-alpn",
+                record(1, &[], vec![param(KEY_NO_DEFAULT_ALPN, &[1])]),
+                SvcbParseError::NonEmptyNoDefaultAlpn,
+            ),
+            (
+                "empty ipv4hint",
+                record(1, &[], vec![param(KEY_IPV4HINT, &[])]),
+                SvcbParseError::EmptyIpv4Hint,
+            ),
+            (
+                "empty ech",
+                record(1, &[], vec![param(KEY_ECH, &[])]),
+                SvcbParseError::InvalidEchConfigListLength {
+                    declared: None,
+                    actual: 0,
+                },
+            ),
+            (
+                "empty ECHConfigList",
+                record(1, &[], vec![param(KEY_ECH, &[0, 0])]),
+                SvcbParseError::EmptyEchConfigList,
+            ),
+            (
+                "truncated ECHConfig header",
+                record(1, &[], vec![param(KEY_ECH, &[0, 3, 0xfe, 0x0d, 0])]),
+                SvcbParseError::TruncatedEchConfigHeader {
+                    offset: 0,
+                    actual: 3,
+                },
+            ),
+            (
+                "truncated ECHConfig body",
+                record(1, &[], vec![param(KEY_ECH, &[0, 5, 0xfe, 0x0d, 0, 2, 9])]),
+                SvcbParseError::TruncatedEchConfig {
+                    offset: 0,
+                    expected: 2,
+                    actual: 1,
+                },
+            ),
+            (
+                "empty ipv6hint",
+                record(1, &[], vec![param(KEY_IPV6HINT, &[])]),
+                SvcbParseError::EmptyIpv6Hint,
+            ),
+        ];
 
-        assert!(result.unwrap_err().to_string().contains("malformed HTTPS"));
+        for (label, raw, expected) in cases {
+            assert_eq!(parse_rdata(&raw), Err(expected), "{label}");
+        }
+    }
+
+    #[test]
+    fn alias_mode_ignores_well_framed_svcparams() {
+        let raw = record(
+            0,
+            &["alias", "example"],
+            vec![param(KEY_NO_DEFAULT_ALPN, &[1])],
+        );
+
+        let parsed = parse_rdata(&raw).unwrap();
+
+        assert!(parsed.is_alias_mode());
+        assert_eq!(parsed.target, "alias.example.");
+        assert!(!parsed.no_default_alpn);
+    }
+
+    #[test]
+    fn accepts_framed_ech_config_list() {
+        let contents = [
+            0, // config_id
+            0, 0x20, // kem_id
+            0, 1, 7, // public_key
+            0, 4, 0, 1, 0, 1, // cipher suites
+            0, // maximum_name_length
+            1, b'x', // public_name
+            0, 0, // extensions
+        ];
+        let mut value = Vec::new();
+        value.extend_from_slice(&((contents.len() + 4) as u16).to_be_bytes());
+        value.extend_from_slice(&0xfe0d_u16.to_be_bytes());
+        value.extend_from_slice(&(contents.len() as u16).to_be_bytes());
+        value.extend_from_slice(&contents);
+        let raw = record(1, &[], vec![param(KEY_ECH, &value)]);
+
+        assert_eq!(
+            parse_rdata(&raw).unwrap().ech.as_deref(),
+            Some(value.as_slice())
+        );
+    }
+
+    #[test]
+    fn accepts_opaque_alpn_protocol_ids() {
+        let raw = record(1, &[], vec![param(KEY_ALPN, &[1, 0xff])]);
+
+        assert_eq!(parse_rdata(&raw).unwrap().alpn, [vec![0xff]]);
+    }
+
+    #[test]
+    fn accepts_repeated_alpn_protocol_ids() {
+        let raw = record(
+            1,
+            &[],
+            vec![param(KEY_ALPN, &[2, b'h', b'3', 2, b'h', b'3'])],
+        );
+
+        assert_eq!(
+            parse_rdata(&raw).unwrap().alpn,
+            [b"h3".to_vec(), b"h3".to_vec()]
+        );
+    }
+
+    #[test]
+    fn accepts_self_consistent_alpn_parameters() {
+        let raw = record(
+            1,
+            &[],
+            vec![
+                param(KEY_ALPN, &[2, b'h', b'3']),
+                param(KEY_NO_DEFAULT_ALPN, &[]),
+            ],
+        );
+
+        let parsed = parse_rdata(&raw).unwrap();
+
+        assert_eq!(parsed.alpn, [b"h3".to_vec()]);
+        assert!(parsed.no_default_alpn);
+    }
+
+    #[test]
+    fn malformed_https_record_rejects_the_entire_rrset() {
+        let valid = record(1, &[], vec![param(KEY_ALPN, &[2, b'h', b'3'])]);
+        let malformed = record(
+            2,
+            &[],
+            vec![
+                param(KEY_ALPN, &[2, b'h', b'3']),
+                param(KEY_ALPN, &[2, b'h', b'2']),
+            ],
+        );
+        let result = svcb_records_from_query(vec![
+            crate::dns::custom::DnsQueryRecord {
+                typ: DNS_TYPE_HTTPS,
+                ttl: Some(60),
+                data: DnsRecordData::Wire(valid),
+            },
+            crate::dns::custom::DnsQueryRecord {
+                typ: DNS_TYPE_HTTPS,
+                ttl: Some(60),
+                data: DnsRecordData::Wire(malformed),
+            },
+        ]);
+
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("malformed HTTPS"), "{error}");
+        assert!(error.contains("key 1 is repeated"), "{error}");
     }
 
     #[tokio::test]
@@ -849,7 +1486,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(lookup.fallback_target, "alias.example");
-        assert_eq!(lookup.records[0].alpn, ["h2"]);
+        assert_eq!(lookup.records[0].alpn, [b"h2".to_vec()]);
         server.join().unwrap();
     }
 

--- a/src/dns/svcb/system.rs
+++ b/src/dns/svcb/system.rs
@@ -140,9 +140,14 @@ fn lookup_https_records_blocking(
         }
         if rrtype == wire::TYPE_HTTPS && rrclass == wire::CLASS_IN && !rdata.is_null() {
             let raw = unsafe { std::slice::from_raw_parts(rdata.cast::<u8>(), usize::from(rdlen)) };
-            if let Some(mut record) = parse_rdata(raw) {
-                record.ttl = Some(ttl);
-                state.records.push(record);
+            match parse_rdata(raw) {
+                Ok(mut record) => {
+                    record.ttl = Some(ttl);
+                    state.records.push(record);
+                }
+                Err(err) => {
+                    state.error = Some(format!("malformed HTTPS DNS record data: {err}"));
+                }
             }
         }
         if flags & K_DNS_SERVICE_FLAGS_MORE_COMING == 0 {
@@ -288,12 +293,16 @@ fn lookup_https_records_blocking(
     while !current.is_null() {
         let dns_record = unsafe { &*current };
         if dns_record.wType == DNS_TYPE_HTTPS {
-            if let Some(raw) = windows_svcb_rdata(dns_record) {
-                if let Some(mut parsed_record) = parse_rdata(&raw) {
-                    parsed_record.ttl = Some(dns_record.dwTtl);
-                    parsed.push(parsed_record);
-                }
-            }
+            let raw = windows_svcb_rdata(dns_record).ok_or_else(|| {
+                FetchError::Runtime(
+                    "malformed HTTPS DNS record data from system resolver".to_string(),
+                )
+            })?;
+            let mut parsed_record = parse_rdata(&raw).map_err(|err| {
+                FetchError::Runtime(format!("malformed HTTPS DNS record data: {err}"))
+            })?;
+            parsed_record.ttl = Some(dns_record.dwTtl);
+            parsed.push(parsed_record);
         }
         current = dns_record.pNext;
     }
@@ -422,16 +431,17 @@ fn records_from_wire_response(raw: &[u8]) -> Result<Vec<SvcbRecord>, FetchError>
     let records =
         wire::parse_response_without_id(raw, "example.com", wire::TYPE_HTTPS, wire::CLASS_IN)
             .map_err(|err| FetchError::Runtime(err.to_string()))?;
-    Ok(records
+    records
         .into_iter()
         .filter(|record| record.class == wire::CLASS_IN && record.typ == wire::TYPE_HTTPS)
-        .filter_map(|record| {
-            parse_rdata(record.data).map(|mut parsed| {
-                parsed.ttl = Some(record.ttl);
-                parsed
-            })
+        .map(|record| {
+            let mut parsed = parse_rdata(record.data).map_err(|err| {
+                FetchError::Runtime(format!("malformed HTTPS DNS record data: {err}"))
+            })?;
+            parsed.ttl = Some(record.ttl);
+            Ok(parsed)
         })
-        .collect())
+        .collect()
 }
 
 #[cfg(any(windows, test))]
@@ -506,7 +516,7 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].priority, 1);
         assert_eq!(records[0].target, ".");
-        assert_eq!(records[0].alpn, ["h3"]);
+        assert_eq!(records[0].alpn, [b"h3".to_vec()]);
     }
 
     #[test]

--- a/src/dns/wire.rs
+++ b/src/dns/wire.rs
@@ -160,10 +160,9 @@ pub(crate) fn decode_rdata<'a>(
         }
         TYPE_CAA if len >= 2 && usize::from(raw[1]) <= len - 2 => Ok(DecodedRdata::Raw(raw)),
         TYPE_CAA => Err(malformed_rdata(typ)),
-        TYPE_SVCB | TYPE_HTTPS if crate::dns::svcb::parse_rdata(raw).is_some() => {
-            Ok(DecodedRdata::Raw(raw))
-        }
-        TYPE_SVCB | TYPE_HTTPS => Err(malformed_rdata(typ)),
+        TYPE_SVCB | TYPE_HTTPS => crate::dns::svcb::parse_rdata(raw)
+            .map(|_| DecodedRdata::Raw(raw))
+            .map_err(|err| WireError(format!("malformed DNS RDATA for type {typ}: {err}"))),
         _ => Ok(DecodedRdata::Raw(raw)),
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1396,7 +1396,7 @@ mod tests {
         SvcbRecord {
             priority,
             target: target.to_string(),
-            alpn: alpn.iter().map(|value| value.to_string()).collect(),
+            alpn: alpn.iter().map(|value| value.as_bytes().to_vec()).collect(),
             no_default_alpn: false,
             port,
             ipv4_hint: Vec::new(),

--- a/src/http/http3_cache.rs
+++ b/src/http/http3_cache.rs
@@ -800,7 +800,7 @@ mod tests {
         SvcbRecord {
             priority: 1,
             target: target.to_string(),
-            alpn: vec!["h3".to_string()],
+            alpn: vec![b"h3".to_vec()],
             no_default_alpn: false,
             port,
             ipv4_hint: Vec::new(),

--- a/src/http/transport/tests.rs
+++ b/src/http/transport/tests.rs
@@ -90,7 +90,7 @@ fn https_record(priority: u16, target: &str, alpn: &[&str], port: Option<u16>) -
     SvcbRecord {
         priority,
         target: target.to_string(),
-        alpn: alpn.iter().map(|value| value.to_string()).collect(),
+        alpn: alpn.iter().map(|value| value.as_bytes().to_vec()).collect(),
         no_default_alpn: false,
         port,
         ipv4_hint: Vec::new(),


### PR DESCRIPTION
## Summary
- return detailed SVCB parsing errors and reject malformed HTTPS RRsets atomically
- enforce ordered unique SvcParams, complete mandatory declarations, key-specific values, ALPN consistency, and ECH framing
- preserve opaque ALPN IDs and apply strict parsing across custom and system resolver paths
- add table-driven malformed-record and consistency tests

## Validation
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- `cargo test --locked --all-features --test cli --test formatting --test grpc --test har --test http --test install --test network --test terminal --test update --test websocket -- --test-threads=2`