### PR TITLE
Supplement SVCB address hints with target resolution

### DIFF
--- a/src/dns/svcb.rs
+++ b/src/dns/svcb.rs
@@ -730,6 +730,33 @@ pub(crate) async fn lookup_https_records_with_doh_tls_config(
     unreachable!("alias depth is bounded by the loop")
 }
 
+/// Order ServiceMode records by priority and randomize records that have the
+/// same priority. RFC 9460 requires clients to avoid always selecting the
+/// first record from an equal-priority group.
+pub(crate) fn randomized_service_records(records: &[SvcbRecord]) -> Vec<&SvcbRecord> {
+    use rand::seq::SliceRandom;
+
+    let mut ordered = records
+        .iter()
+        .filter(|record| !record.is_alias_mode())
+        .collect::<Vec<_>>();
+    ordered.sort_by_key(|record| record.priority);
+
+    let mut start = 0;
+    let mut rng = rand::rng();
+    while start < ordered.len() {
+        let priority = ordered[start].priority;
+        let end = start
+            + ordered[start..]
+                .iter()
+                .take_while(|record| record.priority == priority)
+                .count();
+        ordered[start..end].shuffle(&mut rng);
+        start = end;
+    }
+    ordered
+}
+
 fn canonical_host(host: &str) -> String {
     host.trim_end_matches('.').to_ascii_lowercase()
 }
@@ -956,6 +983,25 @@ mod tests {
             }
         });
         (addr, handle)
+    }
+
+    #[test]
+    fn equal_priority_service_records_are_randomized() {
+        let first = parse_rdata(&record(1, &["first"], vec![])).unwrap();
+        let second = parse_rdata(&record(1, &["second"], vec![])).unwrap();
+        let later = parse_rdata(&record(2, &["later"], vec![])).unwrap();
+        let records = [first, second, later];
+        let mut saw_first = false;
+        let mut saw_second = false;
+
+        for _ in 0..64 {
+            let ordered = randomized_service_records(&records);
+            assert_eq!(ordered[2].priority, 2);
+            saw_first |= ordered[0].target == "first.";
+            saw_second |= ordered[0].target == "second.";
+        }
+
+        assert!(saw_first && saw_second);
     }
 
     #[test]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -349,7 +349,6 @@ async fn resolve_dns_for_client_inner(
                 empty_https_lookup(host),
             )
         };
-        let alias_followed = !https_lookup.fallback_target.eq_ignore_ascii_case(host);
         let addrs = resolve_custom_alias_fallback(
             cli,
             dns_server,
@@ -363,15 +362,10 @@ async fn resolve_dns_for_client_inner(
         let timing_addrs = dns_timing_addrs(addrs.iter().copied());
         let socket_addrs = custom::socket_addrs_for_override(&addrs);
         let auto_http3_config = auto_http3_config_for_records(
-            Some(dns_server),
-            doh_tls_config_for_cli(cli)?,
-            url,
             &https_records,
+            &https_lookup.fallback_target,
             &socket_addrs,
-            auto_http3_discovery,
-            alias_followed,
-        )
-        .await;
+        );
         if auto_http3 {
             Http3Cache::new()
                 .store_https_records(url, Some(dns_server), &https_records)
@@ -387,7 +381,7 @@ async fn resolve_dns_for_client_inner(
                 }),
             }),
             runtime_dns_resolution: None,
-            dns_server: None,
+            dns_server: Some(dns_server.to_string()),
             auto_http3: auto_http3_config,
             auto_http3_discovery: false,
             ech_https_records: https_records,
@@ -448,7 +442,6 @@ async fn resolve_dns_for_client_inner(
             empty_https_lookup(host),
         )
     };
-    let alias_followed = !https_records.fallback_target.eq_ignore_ascii_case(host);
     let socket_addrs = resolve_system_alias_fallback(
         host,
         port,
@@ -457,18 +450,11 @@ async fn resolve_dns_for_client_inner(
         socket_addrs,
     )
     .await?;
+    let effective_host = https_records.fallback_target;
     let https_records = https_records.records;
     let addrs = dns_timing_addrs(socket_addrs.iter().map(|addr| addr.ip()));
-    let auto_http3_config = auto_http3_config_for_records(
-        None,
-        None,
-        url,
-        &https_records,
-        &socket_addrs,
-        auto_http3_discovery,
-        alias_followed,
-    )
-    .await;
+    let auto_http3_config =
+        auto_http3_config_for_records(&https_records, &effective_host, &socket_addrs);
     if auto_http3 {
         Http3Cache::new()
             .store_https_records(url, None, &https_records)
@@ -744,137 +730,21 @@ fn auto_http3_allowed(
             .is_some_and(|host| host.parse::<IpAddr>().is_err())
 }
 
-#[derive(Clone)]
-struct AutoHttp3ResolveConfig<'a> {
-    dns_server: Option<&'a str>,
-    doh_tls_config: Option<rustls::ClientConfig>,
-}
-
-async fn auto_http3_config_for_records(
-    dns_server: Option<&str>,
-    doh_tls_config: Option<rustls::ClientConfig>,
-    url: &Url,
+fn auto_http3_config_for_records(
     records: &[SvcbRecord],
+    effective_host: &str,
     origin_addrs: &[SocketAddr],
-    discovery_budget: Option<AutoHttp3DiscoveryBudget>,
-    allow_target_dns_lookup: bool,
 ) -> Option<AutoHttp3Config> {
-    let origin_host = url.host_str()?;
-    let origin_port = url.port_or_known_default()?;
-    let mut sorted = records.iter().collect::<Vec<_>>();
-    sorted.sort_by_key(|record| record.priority);
-
-    let mut addrs = Vec::new();
-    for record in sorted {
-        if record.is_alias_mode() || !record.is_usable() || !record.advertises_alpn("h3") {
-            continue;
-        }
-        let port = record.port.unwrap_or(origin_port);
-        let record_addrs = auto_http3_record_addrs(
-            AutoHttp3ResolveConfig {
-                dns_server,
-                doh_tls_config: doh_tls_config.clone(),
-            },
-            origin_host,
-            record,
-            origin_addrs,
-            port,
-            discovery_budget,
-            allow_target_dns_lookup,
-        )
-        .await;
-        append_unique_socket_addrs(&mut addrs, record_addrs);
-    }
-
-    (!addrs.is_empty()).then_some(AutoHttp3Config { addrs })
-}
-
-async fn auto_http3_record_addrs(
-    resolver: AutoHttp3ResolveConfig<'_>,
-    origin_host: &str,
-    record: &SvcbRecord,
-    origin_addrs: &[SocketAddr],
-    port: u16,
-    discovery_budget: Option<AutoHttp3DiscoveryBudget>,
-    allow_target_dns_lookup: bool,
-) -> Vec<SocketAddr> {
-    let hinted = auto_http3_hint_addrs(record, origin_addrs, port);
-    if !hinted.is_empty() {
-        return hinted;
-    }
-
-    let target = auto_http3_target_host(origin_host, &record.target);
-    if target.eq_ignore_ascii_case(origin_host) && !origin_addrs.is_empty() {
-        return origin_addrs
-            .iter()
-            .map(|addr| SocketAddr::new(addr.ip(), port))
-            .collect();
-    }
-    if let Ok(ip) = target.parse::<IpAddr>() {
-        return vec![SocketAddr::new(ip, port)];
-    }
-    if !allow_target_dns_lookup {
-        return Vec::new();
-    }
-    let Some(timeout) = discovery_budget.and_then(AutoHttp3DiscoveryBudget::remaining) else {
-        return Vec::new();
-    };
-    let timeout = TimeoutBudget::new(Some(timeout));
-    let Ok(mut addrs) = timeout
-        .run(crate::net::resolve_host_with_doh_tls(
-            &target,
-            resolver.dns_server,
-            resolver.doh_tls_config,
-            timeout,
-        ))
-        .await
-    else {
-        return Vec::new();
-    };
-    for addr in &mut addrs {
-        addr.set_port(port);
-    }
-    addrs
-}
-
-fn auto_http3_hint_addrs(
-    record: &SvcbRecord,
-    origin_addrs: &[SocketAddr],
-    port: u16,
-) -> Vec<SocketAddr> {
-    let ipv4 = record
-        .ipv4_hint
+    let records = records
         .iter()
-        .copied()
-        .map(|addr| SocketAddr::new(IpAddr::V4(addr), port))
+        .filter(|record| record.is_usable() && record.advertises_alpn("h3"))
+        .cloned()
         .collect::<Vec<_>>();
-    let ipv6 = record
-        .ipv6_hint
-        .iter()
-        .copied()
-        .map(|addr| SocketAddr::new(IpAddr::V6(addr), port))
-        .collect::<Vec<_>>();
-
-    match origin_addrs.first().map(|addr| addr.ip()) {
-        Some(IpAddr::V4(_)) => crate::net::interleave_socket_addr_families(&ipv4, &ipv6),
-        Some(IpAddr::V6(_)) | None => crate::net::interleave_socket_addr_families(&ipv6, &ipv4),
-    }
-}
-
-fn auto_http3_target_host(origin_host: &str, target: &str) -> String {
-    if target == "." {
-        origin_host.to_string()
-    } else {
-        target.trim_end_matches('.').to_string()
-    }
-}
-
-fn append_unique_socket_addrs(target: &mut Vec<SocketAddr>, addrs: Vec<SocketAddr>) {
-    for addr in addrs {
-        if !target.contains(&addr) {
-            target.push(addr);
-        }
-    }
+    (!records.is_empty()).then(|| AutoHttp3Config {
+        records,
+        effective_host: effective_host.to_string(),
+        origin_addrs: origin_addrs.to_vec(),
+    })
 }
 
 fn configure_http3_local_address(
@@ -1408,10 +1278,6 @@ mod tests {
         }
     }
 
-    fn auto_http3_test_discovery_budget() -> Option<AutoHttp3DiscoveryBudget> {
-        AutoHttp3DiscoveryBudget::new(TimeoutBudget::new(None))
-    }
-
     #[test]
     fn websocket_effective_proxy_preserves_authorization() {
         let selected = effective_proxy_for_websocket(
@@ -1486,159 +1352,37 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn auto_http3_candidate_builder_uses_h3_records_and_port_overrides() {
-        let url = Url::parse("https://example.com:8443/").unwrap();
-        let origin_addrs = [SocketAddr::new("127.0.0.1".parse().unwrap(), 8443)];
-        let records = [
-            https_record(5, ".", &["h2"], Some(9443)),
-            https_record(1, ".", &["h3", "h2"], Some(9443)),
-        ];
-
-        let got = auto_http3_config_for_records(
-            None,
-            None,
-            &url,
-            &records,
-            &origin_addrs,
-            auto_http3_test_discovery_budget(),
-            false,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            got.addrs,
-            [SocketAddr::new("127.0.0.1".parse().unwrap(), 9443)]
-        );
-    }
-
-    #[tokio::test]
-    async fn auto_http3_candidate_builder_orders_hints_by_resolver_family_preference() {
-        let url = Url::parse("https://example.com/").unwrap();
-        let mut record = https_record(1, ".", &["h3"], None);
-        record.ipv4_hint = vec!["192.0.2.1".parse().unwrap(), "192.0.2.2".parse().unwrap()];
-        record.ipv6_hint = vec![
-            "2001:db8::1".parse().unwrap(),
-            "2001:db8::2".parse().unwrap(),
-        ];
-
-        let ipv4_first = auto_http3_config_for_records(
-            None,
-            None,
-            &url,
-            &[record.clone()],
-            &[
-                SocketAddr::new("198.51.100.1".parse().unwrap(), 443),
-                SocketAddr::new("2001:db8::10".parse().unwrap(), 443),
-            ],
-            auto_http3_test_discovery_budget(),
-            false,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            ipv4_first.addrs,
-            [
-                SocketAddr::new("192.0.2.1".parse().unwrap(), 443),
-                SocketAddr::new("2001:db8::1".parse().unwrap(), 443),
-                SocketAddr::new("192.0.2.2".parse().unwrap(), 443),
-                SocketAddr::new("2001:db8::2".parse().unwrap(), 443),
-            ]
-        );
-
-        let ipv6_first = auto_http3_config_for_records(
-            None,
-            None,
-            &url,
-            &[record],
-            &[
-                SocketAddr::new("2001:db8::10".parse().unwrap(), 443),
-                SocketAddr::new("198.51.100.1".parse().unwrap(), 443),
-            ],
-            auto_http3_test_discovery_budget(),
-            false,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            ipv6_first.addrs,
-            [
-                SocketAddr::new("2001:db8::1".parse().unwrap(), 443),
-                SocketAddr::new("192.0.2.1".parse().unwrap(), 443),
-                SocketAddr::new("2001:db8::2".parse().unwrap(), 443),
-                SocketAddr::new("192.0.2.2".parse().unwrap(), 443),
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn auto_http3_candidate_builder_ignores_missing_or_unusable_h3() {
-        let url = Url::parse("https://example.com/").unwrap();
+    #[test]
+    fn auto_http3_candidate_builder_keeps_usable_records_for_transport_resolution() {
         let origin_addrs = [SocketAddr::new("127.0.0.1".parse().unwrap(), 443)];
-        assert!(
-            auto_http3_config_for_records(
-                None,
-                None,
-                &url,
-                &[],
-                &origin_addrs,
-                auto_http3_test_discovery_budget(),
-                false,
-            )
-            .await
-            .is_none()
-        );
-        assert!(
-            auto_http3_config_for_records(
-                None,
-                None,
-                &url,
-                &[https_record(1, ".", &["h2"], None)],
-                &origin_addrs,
-                auto_http3_test_discovery_budget(),
-                false,
-            )
-            .await
-            .is_none()
-        );
+        let records = [
+            https_record(5, ".", &["h2"], None),
+            https_record(1, "h3.example.com.", &["h3"], Some(9443)),
+        ];
+
+        let got = auto_http3_config_for_records(&records, "example.com", &origin_addrs).unwrap();
+
+        assert_eq!(got.records.len(), 1);
+        assert_eq!(got.records[0].target, "h3.example.com.");
+        assert_eq!(got.effective_host, "example.com");
+        assert_eq!(got.origin_addrs, origin_addrs);
+    }
+
+    #[test]
+    fn auto_http3_candidate_builder_ignores_unusable_records() {
         let mut unsupported = https_record(1, ".", &["h3"], None);
         unsupported.unsupported_mandatory = vec![9];
+
+        assert!(auto_http3_config_for_records(&[], "example.com", &[]).is_none());
         assert!(
             auto_http3_config_for_records(
-                None,
-                None,
-                &url,
-                &[unsupported],
-                &origin_addrs,
-                auto_http3_test_discovery_budget(),
-                false,
+                &[https_record(1, ".", &["h2"], None)],
+                "example.com",
+                &[],
             )
-            .await
             .is_none()
         );
-    }
-
-    #[tokio::test]
-    async fn auto_http3_candidate_builder_skips_target_dns_when_not_allowed() {
-        let url = Url::parse("https://example.com/").unwrap();
-        let origin_addrs = [SocketAddr::new("127.0.0.1".parse().unwrap(), 443)];
-
-        assert!(
-            auto_http3_config_for_records(
-                None,
-                None,
-                &url,
-                &[https_record(1, "h3.example.com.", &["h3"], None)],
-                &origin_addrs,
-                auto_http3_test_discovery_budget(),
-                false,
-            )
-            .await
-            .is_none()
-        );
+        assert!(auto_http3_config_for_records(&[unsupported], "example.com", &[]).is_none());
     }
 
     #[test]

--- a/src/http/transport/h3.rs
+++ b/src/http/transport/h3.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
+use futures_util::StreamExt;
 use http::header::HeaderMap;
 use http::{Method, Request, Version};
 use quinn::crypto::rustls::QuicClientConfig;
@@ -27,7 +28,9 @@ type H3SendRequest = h3::client::SendRequest<h3_quinn::OpenStreams, Bytes>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct AutoHttp3Config {
-    pub(crate) addrs: Vec<SocketAddr>,
+    pub(crate) records: Vec<SvcbRecord>,
+    pub(crate) effective_host: String,
+    pub(crate) origin_addrs: Vec<SocketAddr>,
 }
 
 #[derive(Clone)]
@@ -40,6 +43,22 @@ pub(super) struct H3PooledClient {
 struct Http3ConnectResult {
     client: H3PooledClient,
     timing: TransportTiming,
+}
+
+struct SvcbConnectCandidates<'a> {
+    effective_host: &'a str,
+    records: &'a [SvcbRecord],
+    origin_addrs: &'a [SocketAddr],
+    discovery_start: std::time::Instant,
+}
+
+#[derive(Clone, Copy)]
+struct SvcbRecordConnect<'a> {
+    origin_host: &'a str,
+    origin_port: u16,
+    effective_host: &'a str,
+    origin_addrs: &'a [SocketAddr],
+    discovery_start: std::time::Instant,
 }
 
 enum AutoRaceWinner {
@@ -204,31 +223,20 @@ impl Client {
             take_finished_auto_http3_origin_addrs(origin_addrs_task).await
         } else {
             origin_addrs_task.abort();
-            crate::net::resolve_host_with_doh_tls(
-                effective_host,
-                self.config.dns_server.as_deref(),
-                self.config.doh_tls_config.clone(),
+            Vec::new()
+        };
+        match self
+            .connect_http3_client_with_records(
+                url,
+                origin,
+                SvcbConnectCandidates {
+                    effective_host,
+                    records: &lookup.records,
+                    origin_addrs: &origin_addrs,
+                    discovery_start,
+                },
                 timeout,
             )
-            .await
-            .unwrap_or_default()
-        };
-        let addrs = auto_http3_addrs_for_records(
-            self.config.dns_server.as_deref(),
-            self.config.doh_tls_config.clone(),
-            url,
-            effective_host,
-            &lookup.records,
-            &origin_addrs,
-            timeout,
-        )
-        .await;
-        if addrs.is_empty() {
-            return DynamicHttp3ConnectOutcome::NoCandidates;
-        }
-        record_dns_addrs_trace(&self.config, url, &addrs, discovery_start.elapsed());
-        match self
-            .connect_http3_client_with_addrs(url, origin, addrs, timeout)
             .await
         {
             Ok(result) => DynamicHttp3ConnectOutcome::Connected(result),
@@ -556,79 +564,30 @@ fn auto_http3_lookup_timeout(timeout: TimeoutBudget) -> Option<Duration> {
     }
 }
 
-async fn auto_http3_addrs_for_records(
-    dns_server: Option<&str>,
-    doh_tls_config: Option<rustls::ClientConfig>,
-    url: &Url,
-    effective_host: &str,
-    records: &[SvcbRecord],
-    origin_addrs: &[SocketAddr],
-    timeout: TimeoutBudget,
-) -> Vec<SocketAddr> {
-    let Some(origin_host) = url.host_str() else {
-        return Vec::new();
-    };
-    let Some(origin_port) = url.port_or_known_default() else {
-        return Vec::new();
-    };
-    let mut sorted = records.iter().collect::<Vec<_>>();
-    sorted.sort_by_key(|record| record.priority);
-
-    let mut addrs = Vec::new();
-    for record in sorted {
-        if record.is_alias_mode() || !record.is_usable() || !record.advertises_alpn("h3") {
-            continue;
-        }
-        let port = record.port.unwrap_or(origin_port);
-        let mut record_addrs = auto_http3_hint_addrs(record, origin_addrs, port);
-        if record_addrs.is_empty() {
-            let target = auto_http3_target_host(origin_host, &record.target);
-            if target.eq_ignore_ascii_case(effective_host) && !origin_addrs.is_empty() {
-                record_addrs = origin_addrs
-                    .iter()
-                    .map(|addr| SocketAddr::new(addr.ip(), port))
-                    .collect();
-            } else if target.eq_ignore_ascii_case(effective_host) {
-                record_addrs = crate::net::resolve_host_with_doh_tls(
-                    effective_host,
-                    dns_server,
-                    doh_tls_config.clone(),
-                    timeout,
-                )
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .map(|addr| SocketAddr::new(addr.ip(), port))
-                .collect();
-            } else if let Ok(ip) = target.parse::<IpAddr>() {
-                record_addrs.push(SocketAddr::new(ip, port));
-            } else if !effective_host.eq_ignore_ascii_case(origin_host) {
-                record_addrs = crate::net::resolve_host_with_doh_tls(
-                    &target,
-                    dns_server,
-                    doh_tls_config.clone(),
-                    timeout,
-                )
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .map(|addr| SocketAddr::new(addr.ip(), port))
-                .collect();
-            }
-        }
-        append_unique_socket_addrs(&mut addrs, record_addrs);
-    }
-    addrs
-}
-
 async fn auto_http3_addrs_for_cached_candidates(
     dns_server: Option<&str>,
     doh_tls_config: Option<rustls::ClientConfig>,
     candidates: &[Http3CacheCandidate],
     timeout: TimeoutBudget,
 ) -> Vec<SocketAddr> {
+    use rand::seq::SliceRandom;
+
     let mut sorted = candidates.iter().collect::<Vec<_>>();
     sorted.sort_by_key(|candidate| candidate.priority.unwrap_or(u16::MAX));
+    {
+        let mut start = 0;
+        let mut rng = rand::rng();
+        while start < sorted.len() {
+            let priority = sorted[start].priority.unwrap_or(u16::MAX);
+            let end = start
+                + sorted[start..]
+                    .iter()
+                    .take_while(|candidate| candidate.priority.unwrap_or(u16::MAX) == priority)
+                    .count();
+            sorted[start..end].shuffle(&mut rng);
+            start = end;
+        }
+    }
     let mut addrs = Vec::new();
     for candidate in sorted {
         let record_addrs = if let Ok(ip) = candidate.alt_host.parse::<IpAddr>() {
@@ -802,15 +761,19 @@ impl Client {
             });
         }
         let mut fresh_error = None;
-        if let Some(addrs) = self
-            .config
-            .auto_http3
-            .as_ref()
-            .map(|config| config.addrs.clone())
-            .filter(|addrs| !addrs.is_empty())
-        {
+        if let Some(config) = &self.config.auto_http3 {
             match self
-                .connect_http3_client_with_addrs(url, origin.clone(), addrs, timeout)
+                .connect_http3_client_with_records(
+                    url,
+                    origin.clone(),
+                    SvcbConnectCandidates {
+                        effective_host: &config.effective_host,
+                        records: &config.records,
+                        origin_addrs: &config.origin_addrs,
+                        discovery_start: std::time::Instant::now(),
+                    },
+                    timeout,
+                )
                 .await
             {
                 Ok(result) => return Ok(result),
@@ -828,6 +791,139 @@ impl Client {
         Err(fresh_error
             .or(cached_error)
             .unwrap_or_else(|| Error::connect("no HTTP/3 candidates discovered")))
+    }
+
+    async fn connect_http3_client_with_records(
+        &self,
+        url: &Url,
+        origin: String,
+        candidates: SvcbConnectCandidates<'_>,
+        timeout: TimeoutBudget,
+    ) -> Result<Http3ConnectResult, Error> {
+        let SvcbConnectCandidates {
+            effective_host,
+            records,
+            origin_addrs,
+            discovery_start,
+        } = candidates;
+        let origin_host = url
+            .host_str()
+            .ok_or_else(|| Error::request("URL host is required"))?;
+        let origin_port = url
+            .port_or_known_default()
+            .ok_or_else(|| Error::request("URL port is required"))?;
+        let records = crate::dns::svcb::randomized_service_records(records)
+            .into_iter()
+            .filter(|record| record.is_usable() && record.advertises_alpn("h3"))
+            .cloned()
+            .collect::<Vec<_>>();
+        let connect = SvcbRecordConnect {
+            origin_host,
+            origin_port,
+            effective_host,
+            origin_addrs,
+            discovery_start,
+        };
+        let mut start = 0;
+        let mut last_error = None;
+        while start < records.len() {
+            let priority = records[start].priority;
+            let end = start
+                + records[start..]
+                    .iter()
+                    .take_while(|record| record.priority == priority)
+                    .count();
+            let mut attempts = records[start..end]
+                .iter()
+                .map(|record| {
+                    self.connect_http3_client_with_record(
+                        url,
+                        origin.clone(),
+                        record,
+                        connect,
+                        timeout,
+                    )
+                })
+                .collect::<futures_util::stream::FuturesUnordered<_>>();
+            while let Some(result) = attempts.next().await {
+                match result {
+                    Ok(result) => return Ok(result),
+                    Err(err) => last_error = Some(err),
+                }
+            }
+            start = end;
+        }
+
+        Err(last_error.unwrap_or_else(|| Error::connect("no HTTP/3 candidates discovered")))
+    }
+
+    async fn connect_http3_client_with_record(
+        &self,
+        url: &Url,
+        origin: String,
+        record: &SvcbRecord,
+        connect: SvcbRecordConnect<'_>,
+        timeout: TimeoutBudget,
+    ) -> Result<Http3ConnectResult, Error> {
+        let port = record.port.unwrap_or(connect.origin_port);
+        let hints = auto_http3_hint_addrs(record, connect.origin_addrs, port);
+        let target = auto_http3_target_host(connect.origin_host, &record.target);
+        let resolve = async {
+            if target.eq_ignore_ascii_case(connect.effective_host)
+                && !connect.origin_addrs.is_empty()
+            {
+                connect
+                    .origin_addrs
+                    .iter()
+                    .map(|addr| SocketAddr::new(addr.ip(), port))
+                    .collect()
+            } else if let Ok(ip) = target.parse::<IpAddr>() {
+                vec![SocketAddr::new(ip, port)]
+            } else {
+                crate::net::resolve_host_with_doh_tls(
+                    &target,
+                    self.config.dns_server.as_deref(),
+                    self.config.doh_tls_config.clone(),
+                    timeout,
+                )
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|addr| SocketAddr::new(addr.ip(), port))
+                .collect::<Vec<_>>()
+            }
+        };
+        tokio::pin!(resolve);
+
+        let authoritative = if hints.is_empty() {
+            resolve.await
+        } else {
+            record_dns_addrs_trace(&self.config, url, &hints, connect.discovery_start.elapsed());
+            let hint_connect =
+                self.connect_http3_client_with_addrs(url, origin.clone(), hints.clone(), timeout);
+            tokio::pin!(hint_connect);
+            tokio::select! {
+                result = &mut hint_connect => match result {
+                    Ok(result) => return Ok(result),
+                    Err(_) => resolve.await,
+                },
+                addrs = &mut resolve => {
+                    if addrs.is_empty() {
+                        return hint_connect.await;
+                    }
+                    addrs
+                }
+            }
+        };
+
+        if authoritative.is_empty() {
+            return Err(Error::connect("SVCB TargetName resolved no addresses"));
+        }
+        let mut addrs = authoritative;
+        append_unique_socket_addrs(&mut addrs, hints);
+        record_dns_addrs_trace(&self.config, url, &addrs, connect.discovery_start.elapsed());
+        self.connect_http3_client_with_addrs(url, origin, addrs, timeout)
+            .await
     }
 
     async fn connect_cached_auto_http3_client(

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -15,7 +15,8 @@ use support::dns::{
     start_udp_dns_server_with_delayed_aaaa, start_udp_dns_server_with_delayed_https_and_resolution,
     start_udp_dns_server_with_delayed_resolution, start_udp_dns_server_with_failing_https,
     start_udp_dns_server_with_hosts, start_udp_dns_server_with_https,
-    start_udp_dns_server_with_https_alias, start_udp_dns_server_with_https_target_dropping_target,
+    start_udp_dns_server_with_https_alias, start_udp_dns_server_with_https_target_and_stale_hint,
+    start_udp_dns_server_with_https_target_dropping_target,
     start_udp_dns_server_with_https_targets_dropping_targets,
     start_udp_dns_server_with_toggleable_https, start_unresponsive_udp_dns_server,
 };
@@ -898,6 +899,38 @@ fn default_https_uses_http3_from_https_dns_record() {
 }
 
 #[test]
+fn default_https_supplements_stale_hint_with_non_origin_target_lookup() {
+    let h3 = start_http3_server(|req| {
+        if req.path == "/auto-h3-target" {
+            return H3Response::ok("authoritative target wins");
+        }
+        H3Response::status(404, "not found")
+    });
+    let h3_port = Url::parse(&h3.url).unwrap().port().unwrap();
+    let (dns_addr, target_queries) = start_udp_dns_server_with_https_target_and_stale_hint(
+        "localhost.",
+        Ipv4Addr::LOCALHOST,
+        "h3-target.localhost.",
+        Ipv4Addr::LOCALHOST,
+        Ipv4Addr::new(127, 0, 0, 2),
+        h3_port,
+    );
+
+    let res = run_fetch(&[
+        "--dns-server",
+        &dns_addr,
+        "--ca-cert",
+        h3.ca_cert_path.to_str().unwrap(),
+        &format!("https://localhost:{h3_port}/auto-h3-target"),
+    ]);
+
+    assert_exit(&res, 0);
+    assert_eq!(res.stdout, "authoritative target wins");
+    assert!(res.stderr.contains("HTTP/3.0 200 OK"), "{}", res.stderr);
+    assert!(target_queries.load(Ordering::SeqCst) > 0);
+}
+
+#[test]
 fn default_https_uses_cached_http3_from_https_dns_record() {
     let cache_dir = TempDir::new().unwrap();
     let h3 = start_http3_server(|req| match req.path.as_str() {
@@ -1274,7 +1307,7 @@ fn default_https_auto_http3_does_not_wait_for_dropped_svcb_target_dns_record() {
 }
 
 #[test]
-fn default_https_auto_http3_skips_svcb_target_dns_resolution_by_default() {
+fn default_https_auto_http3_target_resolution_does_not_block_tcp_fallback() {
     let tls = start_tls_server(|req| {
         if req.path == "/auto-h3-multiple-dropped-svcb-targets" {
             return TestResponse::ok("tcp without target lookup");
@@ -1282,7 +1315,7 @@ fn default_https_auto_http3_skips_svcb_target_dns_resolution_by_default() {
         TestResponse::status(404, "Not Found", "")
     });
     let tls_port = Url::parse(&tls.url).unwrap().port().unwrap();
-    let (dns_addr, target_queries) = start_udp_dns_server_with_https_targets_dropping_targets(
+    let (dns_addr, _target_queries) = start_udp_dns_server_with_https_targets_dropping_targets(
         "localhost.",
         Ipv4Addr::new(127, 0, 0, 1),
         vec![
@@ -1295,6 +1328,7 @@ fn default_https_auto_http3_skips_svcb_target_dns_resolution_by_default() {
         tls_port,
     );
 
+    let start = std::time::Instant::now();
     let res = run_fetch(&[
         "--dns-server",
         &dns_addr,
@@ -1302,13 +1336,13 @@ fn default_https_auto_http3_skips_svcb_target_dns_resolution_by_default() {
         tls.ca_cert_path.to_str().unwrap(),
         &format!("https://localhost:{tls_port}/auto-h3-multiple-dropped-svcb-targets"),
     ]);
+    let elapsed = start.elapsed();
 
     assert_exit(&res, 0);
     assert_eq!(res.stdout, "tcp without target lookup");
-    assert_eq!(
-        target_queries.load(Ordering::SeqCst),
-        0,
-        "auto-H3 target-name resolution should not delay default TCP requests\nstderr:\n{}",
+    assert!(
+        elapsed < Duration::from_secs(4),
+        "SVCB TargetName lookups delayed TCP fallback: {elapsed:?}\nstderr:\n{}",
         res.stderr
     );
 }

--- a/tests/support/dns.rs
+++ b/tests/support/dns.rs
@@ -80,6 +80,44 @@ pub(crate) fn start_udp_dns_server_with_https(
     addr
 }
 
+pub(crate) fn start_udp_dns_server_with_https_target_and_stale_hint(
+    host: &'static str,
+    origin_ip: Ipv4Addr,
+    target: &'static str,
+    target_ip: Ipv4Addr,
+    stale_hint: Ipv4Addr,
+    https_port: u16,
+) -> (String, Arc<AtomicUsize>) {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("bind udp dns server");
+    let addr = socket.local_addr().unwrap().to_string();
+    let target_queries = Arc::new(AtomicUsize::new(0));
+    let queries_for_thread = target_queries.clone();
+    thread::spawn(move || {
+        let mut buf = [0_u8; 512];
+        while let Ok((n, peer)) = socket.recv_from(&mut buf) {
+            let Some((name, qtype, question_end)) = parse_dns_question(&buf[..n]) else {
+                continue;
+            };
+            let answer = if name == host && qtype == TYPE_A {
+                Some((TYPE_A, origin_ip.octets().to_vec()))
+            } else if name == host && qtype == TYPE_HTTPS {
+                Some((
+                    TYPE_HTTPS,
+                    https_target_with_hint_rdata(https_port, target, stale_hint),
+                ))
+            } else if name == target && qtype == TYPE_A {
+                queries_for_thread.fetch_add(1, Ordering::SeqCst);
+                Some((TYPE_A, target_ip.octets().to_vec()))
+            } else {
+                None
+            };
+            let response = dns_response(&buf[..n], question_end, answer);
+            let _ = socket.send_to(&response, peer);
+        }
+    });
+    (addr, target_queries)
+}
+
 pub(crate) fn start_udp_dns_server_with_toggleable_https(
     host: &'static str,
     ip: Ipv4Addr,
@@ -451,6 +489,12 @@ fn https_target_rdata(port: u16, target: &str) -> Vec<u8> {
     write_dns_name(&mut out, target);
     write_svc_param(&mut out, 1, &[2, b'h', b'3']);
     write_svc_param(&mut out, 3, &port.to_be_bytes());
+    out
+}
+
+fn https_target_with_hint_rdata(port: u16, target: &str, ipv4_hint: Ipv4Addr) -> Vec<u8> {
+    let mut out = https_target_rdata(port, target);
+    write_svc_param(&mut out, 4, &ipv4_hint.octets());
     out
 }
 


### PR DESCRIPTION
## Summary
- resolve effective SVCB TargetName A/AAAA records while racing address hints
- preserve custom resolver scope and keep TCP fallback independent
- randomize equal-priority service records and cached candidates
- add stale-hint, non-origin target, and fallback timing coverage

## Validation
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --lib --bins
- cargo test --locked --all-features --test cli --test formatting --test grpc --test har --test http --test install --test network --test terminal --test update --test websocket -- --test-threads=2