### PR TITLE
fix(dns): validate DoH JSON answer owners

### DIFF
--- a/src/dns/doh.rs
+++ b/src/dns/doh.rs
@@ -215,26 +215,7 @@ async fn lookup_doh_json_records_with_client(
         return Err(doh_status_error(&response));
     }
 
-    let body = serde_json::from_slice::<DohResponse>(response.body())
-        .map_err(|err| DnsError(err.to_string()))?;
-
-    if body.status != 0 {
-        let name = rcode_name(body.status);
-        if name.is_empty() {
-            return Err(DnsError("no such host".to_string()));
-        }
-        return Err(DnsError(format!("no such host: {name}")));
-    }
-
-    Ok(body
-        .answer
-        .into_iter()
-        .map(|answer| DohRecord {
-            answer_type: answer.answer_type,
-            data: answer.data,
-            ttl: answer.ttl,
-        })
-        .collect())
+    doh_records_from_json_response(response.body(), host)
 }
 
 impl DohClient {
@@ -319,6 +300,52 @@ async fn buffer_response_with_limit(
         headers,
         body: Bytes::from(body),
     })
+}
+
+fn doh_records_from_json_response(
+    raw: &[u8],
+    expected_name: &str,
+) -> Result<Vec<DohRecord>, DnsError> {
+    let body =
+        serde_json::from_slice::<DohResponse>(raw).map_err(|err| DnsError(err.to_string()))?;
+    if body.status != 0 {
+        let name = rcode_name(body.status);
+        if name.is_empty() {
+            return Err(DnsError("no such host".to_string()));
+        }
+        return Err(DnsError(format!("no such host: {name}")));
+    }
+
+    let expected =
+        wire::parse_presentation_name(expected_name).map_err(|err| DnsError(err.to_string()))?;
+    let owners = body
+        .answer
+        .iter()
+        .map(|answer| wire::parse_presentation_name(&answer.name))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| DnsError(err.to_string()))?;
+    let types = body
+        .answer
+        .iter()
+        .map(|answer| Some(answer.answer_type))
+        .collect::<Vec<_>>();
+    let reachable = wire::reachable_answer_names(expected, &owners, &types, |index| {
+        wire::parse_presentation_name(&body.answer[index].data)
+            .map_err(|_| wire::malformed_rdata(wire::TYPE_CNAME))
+    })
+    .map_err(|err| DnsError(err.to_string()))?;
+
+    Ok(body
+        .answer
+        .into_iter()
+        .zip(owners)
+        .filter(|(_, owner)| reachable.contains(owner))
+        .map(|(answer, _)| DohRecord {
+            answer_type: answer.answer_type,
+            data: answer.data,
+            ttl: answer.ttl,
+        })
+        .collect())
 }
 
 fn ip_records(records: Vec<DohRecord>, answer_type: u16) -> Result<Vec<DnsRecord>, DnsError> {
@@ -566,6 +593,7 @@ struct DohResponse {
 
 #[derive(Debug, Deserialize)]
 struct DohAnswer {
+    name: String,
     #[serde(rename = "type")]
     answer_type: u16,
     data: String,
@@ -684,10 +712,10 @@ mod tests {
 
                     let response = match ty {
                         "A" => http::Response::new(
-                            r#"{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1"}]}"#.to_string(),
+                            r#"{"Status":0,"Answer":[{"name":"example.com.","type":1,"data":"127.0.0.1"}]}"#.to_string(),
                         ),
                         "AAAA" => http::Response::new(
-                            r#"{"Status":0,"Answer":[{"type":28,"data":"::1"}]}"#.to_string(),
+                            r#"{"Status":0,"Answer":[{"name":"example.com.","type":28,"data":"::1"}]}"#.to_string(),
                         ),
                         _ => http::Response::builder()
                             .status(400)
@@ -972,6 +1000,95 @@ mod tests {
         assert!(records.is_empty());
     }
 
+    #[test]
+    fn json_response_rejects_unrelated_address_owner() {
+        let raw =
+            br#"{"Status":0,"Answer":[{"name":"unrelated.example.","type":1,"data":"192.0.2.1"}]}"#;
+
+        let records = doh_records_from_json_response(raw, "example.com").unwrap();
+
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn json_response_accepts_valid_cname_chain() {
+        let raw = br#"{"Status":0,"Answer":[
+            {"name":"EXAMPLE.com.","type":5,"data":"Alias.Example."},
+            {"name":"alias.example.","type":1,"data":"192.0.2.1"}
+        ]}"#;
+
+        let records = doh_records_from_json_response(raw, "example.com").unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[1].data, "192.0.2.1");
+    }
+
+    #[test]
+    fn json_response_accepts_rrsig_with_cname() {
+        let raw = br#"{"Status":0,"Answer":[
+            {"name":"example.com.","type":5,"data":"alias.example."},
+            {"name":"example.com.","type":46,"data":"5 13 300 0 0 0 example. signature"},
+            {"name":"alias.example.","type":1,"data":"192.0.2.1"}
+        ]}"#;
+
+        let records = doh_records_from_json_response(raw, "example.com").unwrap();
+
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[2].data, "192.0.2.1");
+    }
+
+    #[test]
+    fn json_response_rejects_malformed_cname_chain() {
+        let raw = br#"{"Status":0,"Answer":[
+            {"name":"example.com.","type":5,"data":"first.example."},
+            {"name":"example.com.","type":5,"data":"second.example."}
+        ]}"#;
+
+        let err = doh_records_from_json_response(raw, "example.com").unwrap_err();
+
+        assert_eq!(err.to_string(), "DNS CNAME owner has conflicting targets");
+    }
+
+    #[test]
+    fn json_response_filters_mixed_reachable_and_unrelated_answers() {
+        let raw = br#"{"Status":0,"Answer":[
+            {"name":"example.com.","type":5,"data":"alias.example."},
+            {"name":"unrelated.example.","type":1,"data":"192.0.2.200"},
+            {"name":"alias.example.","type":1,"data":"192.0.2.1"},
+            {"name":"other.example.","type":28,"data":"2001:db8::1"}
+        ]}"#;
+
+        let records = doh_records_from_json_response(raw, "example.com").unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].answer_type, wire::TYPE_CNAME);
+        assert_eq!(records[1].data, "192.0.2.1");
+    }
+
+    #[test]
+    fn json_response_requires_valid_owner_names() {
+        let missing = br#"{"Status":0,"Answer":[{"type":1,"data":"192.0.2.1"}]}"#;
+        let malformed =
+            br#"{"Status":0,"Answer":[{"name":"bad..example.","type":1,"data":"192.0.2.1"}]}"#;
+
+        assert!(doh_records_from_json_response(missing, "example.com").is_err());
+        assert!(doh_records_from_json_response(malformed, "example.com").is_err());
+    }
+
+    #[test]
+    fn json_response_compares_escaped_owner_octets_without_loss() {
+        let raw = br#"{"Status":0,"Answer":[
+            {"name":"example.com.","type":5,"data":"\\255.example."},
+            {"name":"\\254.example.","type":1,"data":"192.0.2.200"},
+            {"name":"\\255.example.","type":1,"data":"192.0.2.1"}
+        ]}"#;
+
+        let records = doh_records_from_json_response(raw, "example.com").unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[1].data, "192.0.2.1");
+    }
+
     #[tokio::test]
     async fn lookup_doh_uses_rfc8484_wire_format() {
         let seen = Arc::new(Mutex::new(Vec::new()));
@@ -1053,11 +1170,11 @@ mod tests {
             seen.lock().unwrap().push(ty.clone());
             match ty.as_str() {
                 "A" => http::Response::new(
-                    r#"{"Status":0,"Answer":[{"type":5,"data":"alias.example"},{"type":1,"data":"127.0.0.1"}]}"#
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":5,"data":"alias.example"},{"name":"alias.example.","type":1,"data":"127.0.0.1"}]}"#
                         .to_string(),
                 ),
                 "AAAA" => http::Response::new(
-                    r#"{"Status":0,"Answer":[{"type":28,"data":"::1"}]}"#.to_string(),
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":28,"data":"::1"}]}"#.to_string(),
                 ),
                 _ => http::Response::builder()
                     .status(400)
@@ -1089,7 +1206,8 @@ mod tests {
                 .unwrap()
                 .push(request.body().clone());
             http::Response::new(
-                r#"{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1"}]}"#.to_string(),
+                r#"{"Status":0,"Answer":[{"name":"example.com.","type":1,"data":"127.0.0.1"}]}"#
+                    .to_string(),
             )
         })
         .await;
@@ -1183,7 +1301,7 @@ mod tests {
     async fn lookup_doh_type_returns_ttl() {
         let (url, task) = start_test_server(|_| {
             http::Response::new(
-                r#"{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1","TTL":123}]}"#.to_string(),
+                r#"{"Status":0,"Answer":[{"name":"example.com.","type":1,"data":"127.0.0.1","TTL":123}]}"#.to_string(),
             )
         })
         .await;

--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -930,15 +930,15 @@ mod tests {
                 .unwrap_or_default()
             {
                 "A" => http::Response::new(
-                    r#"{"Status":0,"Answer":[{"type":5,"data":"alias.example.com.","TTL":120},{"type":1,"data":"192.0.2.1","TTL":60}]}"#
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":5,"data":"alias.example.com.","TTL":120},{"name":"alias.example.com.","type":1,"data":"192.0.2.1","TTL":60}]}"#
                         .to_string(),
                 ),
                 "AAAA" => http::Response::new(
-                    r#"{"Status":0,"Answer":[{"type":28,"data":"2001:db8::1","TTL":300}]}"#
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":28,"data":"2001:db8::1","TTL":300}]}"#
                         .to_string(),
                 ),
                 "TXT" => http::Response::new(
-                    r#"{"Status":0,"Answer":[{"type":16,"data":"v=spf1 -all","TTL":180}]}"#
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":16,"data":"v=spf1 -all","TTL":180}]}"#
                         .to_string(),
                 ),
                 _ => http::Response::new(r#"{"Status":0}"#.to_string()),
@@ -985,9 +985,9 @@ mod tests {
             if query_type == "A" {
                 return http::Response::new(
                     r#"{"Status":0,"Answer":[
-                        {"type":1,"data":"192.0.2.1"},
-                        {"type":1,"data":"192.0.2.2","TTL":0},
-                        {"type":1,"data":"192.0.2.3","TTL":60}
+                        {"name":"example.com.","type":1,"data":"192.0.2.1"},
+                        {"name":"example.com.","type":1,"data":"192.0.2.2","TTL":0},
+                        {"name":"example.com.","type":1,"data":"192.0.2.3","TTL":60}
                     ]}"#
                     .to_string(),
                 );
@@ -1022,7 +1022,7 @@ mod tests {
                 .unwrap_or_default()
             {
                 "A" => http::Response::new(
-                    r#"{"Status":0,"Answer":[{"type":1,"data":"192.0.2.1","TTL":60}]}"#.to_string(),
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":1,"data":"192.0.2.1","TTL":60}]}"#.to_string(),
                 ),
                 "AAAA" => http::Response::new(r#"{"Status":3}"#.to_string()),
                 _ => http::Response::new(r#"{"Status":0}"#.to_string()),
@@ -1058,7 +1058,7 @@ mod tests {
                 .contains("type=TXT")
             {
                 return http::Response::new(
-                    r#"{"Status":0,"Answer":[{"type":16,"data":"txt \u001b[2J\r\nforged","TTL":60}]}"#
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":16,"data":"txt \u001b[2J\r\nforged","TTL":60}]}"#
                         .to_string(),
                 );
             }
@@ -1161,7 +1161,7 @@ mod tests {
                 .unwrap_or_default()
             {
                 "A" => http::Response::new(
-                    r#"{"Status":0,"Answer":[{"type":1,"data":"192.0.2.1","TTL":60}]}"#.to_string(),
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":1,"data":"192.0.2.1","TTL":60}]}"#.to_string(),
                 ),
                 _ => http::Response::new(r#"{"Status":0}"#.to_string()),
             }
@@ -1196,11 +1196,11 @@ mod tests {
                 .unwrap_or_default()
             {
                 "A" => http::Response::new(
-                    r#"{"Status":0,"Answer":[{"type":5,"data":"alias.example.com.","TTL":120},{"type":1,"data":"192.0.2.1","TTL":60}]}"#
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":5,"data":"alias.example.com.","TTL":120},{"name":"alias.example.com.","type":1,"data":"192.0.2.1","TTL":60}]}"#
                         .to_string(),
                 ),
                 "AAAA" => http::Response::new(
-                    r#"{"Status":0,"Answer":[{"type":5,"data":"alias.example.com.","TTL":119}]}"#
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":5,"data":"alias.example.com.","TTL":119}]}"#
                         .to_string(),
                 ),
                 _ => http::Response::new(r#"{"Status":0}"#.to_string()),

--- a/src/dns/wire.rs
+++ b/src/dns/wire.rs
@@ -10,6 +10,7 @@ pub(crate) const TYPE_MX: u16 = 15;
 pub(crate) const TYPE_TXT: u16 = 16;
 pub(crate) const TYPE_AAAA: u16 = 28;
 pub(crate) const TYPE_SRV: u16 = 33;
+pub(crate) const TYPE_RRSIG: u16 = 46;
 pub(crate) const TYPE_SVCB: u16 = 64;
 pub(crate) const TYPE_HTTPS: u16 = 65;
 pub(crate) const TYPE_CAA: u16 = 257;
@@ -210,7 +211,7 @@ impl RdataReader<'_> {
     }
 }
 
-fn malformed_rdata(typ: u16) -> WireError {
+pub(crate) fn malformed_rdata(typ: u16) -> WireError {
     WireError(format!("malformed DNS RDATA for type {typ}"))
 }
 
@@ -354,70 +355,23 @@ fn parse_response_inner<'a>(
         });
     }
 
-    // Index each owner once, then traverse only reachable CNAME owners. This
-    // keeps reverse-ordered answers linear in the number of records.
-    let mut cname_owners = HashMap::<CanonicalName, CnameOwner>::new();
-    for (index, record) in records.iter().enumerate() {
-        if record.class != expected_class {
-            continue;
+    let owners = records
+        .iter()
+        .map(|record| record.canonical_name.clone())
+        .collect::<Vec<_>>();
+    let types = records
+        .iter()
+        .map(|record| (record.class == expected_class).then_some(record.typ))
+        .collect::<Vec<_>>();
+    let reachable = reachable_answer_names(expected_canonical, &owners, &types, |index| {
+        let cname = &records[index];
+        let end = cname.data_offset + cname.data.len();
+        let parsed = read_parsed_name_bounded(raw, cname.data_offset, end)?;
+        if parsed.next != end {
+            return Err(malformed_rdata(TYPE_CNAME));
         }
-        let owner = cname_owners
-            .entry(record.canonical_name.clone())
-            .or_default();
-        if record.typ == TYPE_CNAME {
-            owner.cname_records.push(index);
-        } else {
-            owner.has_other_data = true;
-        }
-    }
-
-    // Use canonical label bytes for authorization. Presentation strings can
-    // map distinct invalid octets to the same text.
-    let mut reachable = HashSet::from([expected_canonical.clone()]);
-    let mut pending = VecDeque::from([expected_canonical]);
-    let mut depth = 0;
-    while let Some(owner_name) = pending.pop_front() {
-        let Some(owner) = cname_owners.get(&owner_name) else {
-            continue;
-        };
-        if owner.cname_records.is_empty() {
-            continue;
-        }
-        if owner.has_other_data {
-            return Err(WireError(
-                "DNS CNAME owner has conflicting answer data".to_string(),
-            ));
-        }
-        if depth == MAX_CNAME_DEPTH {
-            return Err(WireError("DNS CNAME chain exceeds depth limit".to_string()));
-        }
-
-        let mut target = None;
-        for &index in &owner.cname_records {
-            let cname = &records[index];
-            let end = cname.data_offset + cname.data.len();
-            let parsed = read_parsed_name_bounded(raw, cname.data_offset, end)?;
-            if parsed.next != end {
-                return Err(malformed_rdata(TYPE_CNAME));
-            }
-            if target
-                .as_ref()
-                .is_some_and(|prior| prior != &parsed.canonical)
-            {
-                return Err(WireError(
-                    "DNS CNAME owner has conflicting targets".to_string(),
-                ));
-            }
-            target = Some(parsed.canonical);
-        }
-
-        let target = target.expect("CNAME owner has at least one record");
-        if !reachable.insert(target.clone()) {
-            return Err(WireError("DNS CNAME chain contains a cycle".to_string()));
-        }
-        pending.push_back(target);
-        depth += 1;
-    }
+        Ok(parsed.canonical)
+    })?;
     records.retain(|record| reachable.contains(&record.canonical_name));
     Ok(records)
 }
@@ -437,7 +391,7 @@ fn read_name_bounded(
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct CanonicalName(Vec<Vec<u8>>);
+pub(crate) struct CanonicalName(Vec<Vec<u8>>);
 
 impl CanonicalName {
     fn from_text(name: &str) -> Self {
@@ -451,6 +405,145 @@ impl CanonicalName {
                 .collect(),
         )
     }
+}
+
+pub(crate) fn reachable_answer_names(
+    expected: CanonicalName,
+    owners: &[CanonicalName],
+    types: &[Option<u16>],
+    mut cname_target: impl FnMut(usize) -> Result<CanonicalName, WireError>,
+) -> Result<HashSet<CanonicalName>, WireError> {
+    assert_eq!(owners.len(), types.len());
+    if owners.len() > MAX_ANSWER_RECORDS {
+        return Err(WireError(
+            "DNS response has too many answer records".to_string(),
+        ));
+    }
+
+    // Index each owner once, then traverse only reachable CNAME owners. This
+    // keeps reverse-ordered answers linear in the number of records.
+    let mut cname_owners = HashMap::<CanonicalName, CnameOwner>::new();
+    for (index, (owner_name, typ)) in owners.iter().zip(types).enumerate() {
+        let Some(typ) = typ else {
+            continue;
+        };
+        let owner = cname_owners.entry(owner_name.clone()).or_default();
+        if *typ == TYPE_CNAME {
+            owner.cname_records.push(index);
+        } else if *typ != TYPE_RRSIG {
+            owner.has_other_data = true;
+        }
+    }
+
+    // Use canonical label bytes for authorization. Presentation strings can
+    // map distinct invalid octets to the same text.
+    let mut reachable = HashSet::from([expected.clone()]);
+    let mut pending = VecDeque::from([expected]);
+    let mut depth = 0;
+    while let Some(owner_name) = pending.pop_front() {
+        let Some(owner) = cname_owners.get(&owner_name) else {
+            continue;
+        };
+        if owner.cname_records.is_empty() {
+            continue;
+        }
+        if owner.has_other_data {
+            return Err(WireError(
+                "DNS CNAME owner has conflicting answer data".to_string(),
+            ));
+        }
+        if depth == MAX_CNAME_DEPTH {
+            return Err(WireError("DNS CNAME chain exceeds depth limit".to_string()));
+        }
+
+        let mut target = None;
+        for &index in &owner.cname_records {
+            let parsed = cname_target(index)?;
+            if target.as_ref().is_some_and(|prior| prior != &parsed) {
+                return Err(WireError(
+                    "DNS CNAME owner has conflicting targets".to_string(),
+                ));
+            }
+            target = Some(parsed);
+        }
+
+        let target = target.expect("CNAME owner has at least one record");
+        if !reachable.insert(target.clone()) {
+            return Err(WireError("DNS CNAME chain contains a cycle".to_string()));
+        }
+        pending.push_back(target);
+        depth += 1;
+    }
+    Ok(reachable)
+}
+
+pub(crate) fn parse_presentation_name(name: &str) -> Result<CanonicalName, WireError> {
+    if name == "." {
+        return Ok(CanonicalName(Vec::new()));
+    }
+    if name.is_empty() {
+        return Err(WireError("invalid DNS name".to_string()));
+    }
+
+    let bytes = name.as_bytes();
+    let mut labels = Vec::new();
+    let mut label = Vec::new();
+    let mut offset = 0;
+    while offset < bytes.len() {
+        match bytes[offset] {
+            b'.' => {
+                if label.is_empty() {
+                    return Err(WireError("invalid DNS name".to_string()));
+                }
+                labels.push(std::mem::take(&mut label));
+                offset += 1;
+                if offset == bytes.len() {
+                    break;
+                }
+            }
+            b'\\' => {
+                offset += 1;
+                if offset == bytes.len() {
+                    return Err(WireError("invalid DNS name escape".to_string()));
+                }
+                if offset + 2 < bytes.len()
+                    && bytes[offset..offset + 3].iter().all(u8::is_ascii_digit)
+                {
+                    let value = u16::from(bytes[offset] - b'0') * 100
+                        + u16::from(bytes[offset + 1] - b'0') * 10
+                        + u16::from(bytes[offset + 2] - b'0');
+                    if value > u16::from(u8::MAX) {
+                        return Err(WireError("invalid DNS name escape".to_string()));
+                    }
+                    label.push(value as u8);
+                    offset += 3;
+                } else {
+                    label.push(bytes[offset]);
+                    offset += 1;
+                }
+            }
+            octet => {
+                label.push(octet);
+                offset += 1;
+            }
+        }
+        if label.len() > 63 {
+            return Err(WireError("invalid DNS name label".to_string()));
+        }
+    }
+    if !label.is_empty() {
+        labels.push(label);
+    }
+    if labels.is_empty() || labels.iter().map(|label| label.len() + 1).sum::<usize>() + 1 > 255 {
+        return Err(WireError("invalid DNS name".to_string()));
+    }
+
+    Ok(CanonicalName(
+        labels
+            .into_iter()
+            .map(|label| label.into_iter().map(ascii_lowercase).collect())
+            .collect(),
+    ))
 }
 
 struct ParsedName {

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -238,7 +238,7 @@ fn inspect_ech_discovery_uses_custom_doh_tls_config() {
             seen_https_queries.fetch_add(1, Ordering::SeqCst);
         }
         let body = if req.path.contains("type=A") {
-            r#"{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1"}]}"#
+            r#"{"Status":0,"Answer":[{"name":"localhost.","type":1,"data":"127.0.0.1"}]}"#
         } else {
             r#"{"Status":0}"#
         };
@@ -274,7 +274,7 @@ fn authenticated_doh_failure_is_fatal_for_ech_auto() {
             return TestResponse::status(503, "Service Unavailable", "HTTPS lookup failed");
         }
         let body = if req.path.contains("type=A") {
-            r#"{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1"}]}"#
+            r#"{"Status":0,"Answer":[{"name":"localhost.","type":1,"data":"127.0.0.1"}]}"#
         } else {
             r#"{"Status":0}"#
         };
@@ -310,7 +310,7 @@ fn authenticated_doh_failure_is_fatal_for_auto_http3() {
             return TestResponse::status(503, "Service Unavailable", "HTTPS lookup failed");
         }
         let body = if req.path.contains("type=A") {
-            r#"{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1"}]}"#
+            r#"{"Status":0,"Answer":[{"name":"localhost.","type":1,"data":"127.0.0.1"}]}"#
         } else {
             r#"{"Status":0}"#
         };
@@ -1498,28 +1498,28 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
         if req.path.contains("/dns-query") {
             if req.path.contains("name=localhost") {
                 return TestResponse::ok(
-                    r#"{"Status":0,"Answer":[{"type":1,"data":"127.0.0.1"}]}"#,
+                    r#"{"Status":0,"Answer":[{"name":"localhost.","type":1,"data":"127.0.0.1"}]}"#,
                 )
                 .header("Content-Type", "application/dns-json")
                 .header("Connection", "close");
             }
             if req.path.contains("type=AAAA") {
                 return TestResponse::ok(
-                    r#"{"Status":0,"Answer":[{"type":28,"data":"2001:db8::1","TTL":300}]}"#,
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":28,"data":"2001:db8::1","TTL":300}]}"#,
                 )
                 .header("Content-Type", "application/dns-json")
                 .header("Connection", "close");
             }
             if req.path.contains("type=A") {
                 return TestResponse::ok(
-                    r#"{"Status":0,"Answer":[{"type":5,"data":"alias.example.com.","TTL":120},{"type":1,"data":"192.0.2.1","TTL":60}]}"#,
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":5,"data":"alias.example.com.","TTL":120},{"name":"alias.example.com.","type":1,"data":"192.0.2.1","TTL":60}]}"#,
                 )
                 .header("Content-Type", "application/dns-json")
                 .header("Connection", "close");
             }
             if req.path.contains("type=TXT") {
                 return TestResponse::ok(
-                    r#"{"Status":0,"Answer":[{"type":16,"data":"v=spf1 -all","TTL":180}]}"#,
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":16,"data":"v=spf1 -all","TTL":180}]}"#,
                 )
                 .header("Content-Type", "application/dns-json")
                 .header("Connection", "close");


### PR DESCRIPTION
## Summary
- validate DoH JSON answer owner names against the requested name
- follow only authorized CNAME chains and filter unrelated answers
- share bounded CNAME traversal rules between wire and JSON responses

## Validation
- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- full integration test suite with `--test-threads=2`