### PR TITLE
fix(dns): account for HTTP age in DoH TTLs

### DIFF
--- a/src/dns/doh.rs
+++ b/src/dns/doh.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use bytes::Bytes;
-use http::header::{ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT};
+use http::header::{ACCEPT, AGE, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT};
 use http::{HeaderMap, HeaderValue, Method, StatusCode};
 use serde::Deserialize;
 use url::Url;
@@ -186,8 +186,12 @@ async fn lookup_doh_wire_records_with_client(
         return Err(WireDohError::Fallback);
     }
 
+    let age = doh_response_age(response.headers());
     match doh_records_from_wire_response(response.body(), id, host, dns_type) {
-        Ok(records) => Ok(records),
+        Ok(mut records) => {
+            subtract_age_from_ttls(&mut records, age);
+            Ok(records)
+        }
         Err(err) if is_dns_message_response(&response) || is_dns_wire_error(&err) => {
             Err(WireDohError::Fatal(err))
         }
@@ -215,7 +219,9 @@ async fn lookup_doh_json_records_with_client(
         return Err(doh_status_error(&response));
     }
 
-    doh_records_from_json_response(response.body(), host)
+    let mut records = doh_records_from_json_response(response.body(), host)?;
+    subtract_age_from_ttls(&mut records, doh_response_age(response.headers()));
+    Ok(records)
 }
 
 impl DohClient {
@@ -346,6 +352,29 @@ fn doh_records_from_json_response(
             ttl: answer.ttl,
         })
         .collect())
+}
+
+fn doh_response_age(headers: &HeaderMap) -> u32 {
+    let Some(value) = headers.get_all(AGE).iter().next() else {
+        return 0;
+    };
+    // RFC 9111 requires recipients to use the first member when a broken
+    // sender generates a list-based Age field.
+    let first = value.as_bytes().split(|byte| *byte == b',').next().unwrap();
+    let first = first.trim_ascii();
+    if first.is_empty() || first.iter().any(|byte| !byte.is_ascii_digit()) {
+        return 0;
+    }
+    first.iter().fold(0_u32, |age, byte| {
+        age.saturating_mul(10)
+            .saturating_add(u32::from(byte - b'0'))
+    })
+}
+
+fn subtract_age_from_ttls(records: &mut [DohRecord], age: u32) {
+    for record in records {
+        record.ttl = record.ttl.map(|ttl| ttl.saturating_sub(age));
+    }
 }
 
 fn ip_records(records: Vec<DohRecord>, answer_type: u16) -> Result<Vec<DnsRecord>, DnsError> {
@@ -657,10 +686,18 @@ mod tests {
                     let (parts, body) = response.into_parts();
                     let status = parts.status.as_u16();
                     let reason = parts.status.canonical_reason().unwrap_or("");
-                    let raw = format!(
-                        "HTTP/1.1 {status} {reason}\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{body}",
+                    let mut raw = format!(
+                        "HTTP/1.1 {status} {reason}\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n",
                         body.len()
                     );
+                    for (name, value) in &parts.headers {
+                        raw.push_str(name.as_str());
+                        raw.push_str(": ");
+                        raw.push_str(value.to_str().unwrap());
+                        raw.push_str("\r\n");
+                    }
+                    raw.push_str("\r\n");
+                    raw.push_str(&body);
                     let _ = stream.write_all(raw.as_bytes()).await;
                 });
             }
@@ -1298,11 +1335,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lookup_doh_type_returns_ttl() {
+    async fn lookup_doh_type_subtracts_age_from_json_ttl() {
         let (url, task) = start_test_server(|_| {
-            http::Response::new(
-                r#"{"Status":0,"Answer":[{"name":"example.com.","type":1,"data":"127.0.0.1","TTL":123}]}"#.to_string(),
-            )
+            http::Response::builder()
+                .header(AGE, "23")
+                .body(
+                    r#"{"Status":0,"Answer":[{"name":"example.com.","type":1,"data":"127.0.0.1","TTL":123}]}"#
+                        .to_string(),
+                )
+                .unwrap()
         })
         .await;
 
@@ -1312,8 +1353,55 @@ mod tests {
 
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].ip.to_string(), "127.0.0.1");
-        assert_eq!(records[0].ttl, Some(123));
+        assert_eq!(records[0].ttl, Some(100));
         task.abort();
+    }
+
+    #[tokio::test]
+    async fn lookup_doh_records_saturates_wire_https_ttl_at_zero() {
+        let (url, task) = start_wire_test_server(|request| {
+            let body = wire_response(&request.body, vec![(wire::TYPE_HTTPS, 20, vec![0, 1, 0])]);
+            http::Response::builder()
+                .header(CONTENT_TYPE, APPLICATION_DNS_MESSAGE)
+                .header(AGE, "30")
+                .body(body)
+                .unwrap()
+        })
+        .await;
+        let client = client(None).unwrap();
+
+        let records = lookup_doh_records_with_client(&client, &url, "example.com", "HTTPS")
+            .await
+            .unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].ttl, Some(0));
+        task.abort();
+    }
+
+    #[test]
+    fn doh_age_parsing_is_conservative_and_saturating() {
+        for (value, expected) in [
+            (None, 0),
+            (Some("0"), 0),
+            (Some("123"), 123),
+            (Some(" 12"), 12),
+            (Some("12, 13"), 12),
+            (Some(""), 0),
+            (Some("not-a-number"), 0),
+            (Some("999999999999999999999999"), u32::MAX),
+        ] {
+            let mut headers = HeaderMap::new();
+            if let Some(value) = value {
+                headers.insert(AGE, HeaderValue::from_str(value).unwrap());
+            }
+            assert_eq!(doh_response_age(&headers), expected, "Age: {value:?}");
+        }
+
+        let mut repeated = HeaderMap::new();
+        repeated.append(AGE, HeaderValue::from_static("7"));
+        repeated.append(AGE, HeaderValue::from_static("9"));
+        assert_eq!(doh_response_age(&repeated), 7);
     }
 
     #[test]

--- a/src/dns/inspect.rs
+++ b/src/dns/inspect.rs
@@ -903,10 +903,18 @@ mod tests {
                     let (parts, body) = response.into_parts();
                     let status = parts.status.as_u16();
                     let reason = parts.status.canonical_reason().unwrap_or("");
-                    let raw = format!(
-                        "HTTP/1.1 {status} {reason}\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{body}",
+                    let mut raw = format!(
+                        "HTTP/1.1 {status} {reason}\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n",
                         body.len()
                     );
+                    for (name, value) in &parts.headers {
+                        raw.push_str(name.as_str());
+                        raw.push_str(": ");
+                        raw.push_str(value.to_str().unwrap());
+                        raw.push_str("\r\n");
+                    }
+                    raw.push_str("\r\n");
+                    raw.push_str(&body);
                     let _ = stream.writable().await;
                     let _ = stream.try_write(raw.as_bytes());
                 });
@@ -969,6 +977,40 @@ mod tests {
         for want in wants {
             assert!(out.contains(&want), "output missing {want:?}:\n{out}");
         }
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn test_inspect_doh_subtracts_http_age_from_ttls() {
+        let (server_url, task) = start_test_server(|request| {
+            let query_type = request
+                .uri()
+                .query()
+                .unwrap_or_default()
+                .split('&')
+                .find_map(|part| part.strip_prefix("type="))
+                .unwrap_or_default();
+            let body = if query_type == "A" {
+                r#"{"Status":0,"Answer":[{"name":"example.com.","type":1,"data":"192.0.2.1","TTL":90}]}"#
+            } else {
+                r#"{"Status":0}"#
+            };
+            http::Response::builder()
+                .header(http::header::AGE, "30")
+                .body(body.to_string())
+                .unwrap()
+        })
+        .await;
+
+        let out = inspect(
+            &Url::parse("https://example.com").unwrap(),
+            Some(server_url.as_str()),
+        )
+        .await
+        .unwrap();
+
+        assert!(out.contains("192.0.2.1 (TTL 1m)"), "output: {out}");
+        assert!(!out.contains("TTL 1m30s"), "output: {out}");
         task.abort();
     }
 

--- a/src/http/http3_cache.rs
+++ b/src/http/http3_cache.rs
@@ -14,7 +14,7 @@ use url::Url;
 use crate::dns::svcb::SvcbRecord;
 use crate::fileutil::FileLock;
 
-const CACHE_VERSION: u32 = 1;
+const CACHE_VERSION: u32 = 2;
 const MAX_CANDIDATES_PER_ORIGIN: usize = 4;
 const MAX_SHARDS: usize = 1024;
 const MAX_RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
@@ -822,6 +822,23 @@ mod tests {
         assert_eq!(key.resolver_key, "system");
     }
 
+    #[test]
+    fn rejects_cache_entries_from_before_doh_age_handling() {
+        let dir = TempDir::new().unwrap();
+        let cache = Http3Cache::with_dir(dir.path().to_path_buf());
+        let (key, path) = cache.key_and_path(&test_url(), None).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let legacy = ShardFile {
+            version: 1,
+            origin: key.origin.clone(),
+            resolver_key: key.resolver_key.clone(),
+            candidates: Vec::new(),
+        };
+        fs::write(&path, serde_json::to_vec(&legacy).unwrap()).unwrap();
+
+        assert!(cache.read_valid_shard(&path, &key).is_none());
+    }
+
     #[tokio::test]
     async fn stores_https_records_per_origin_shard() {
         let dir = TempDir::new().unwrap();
@@ -853,6 +870,17 @@ mod tests {
         let cache = Http3Cache::with_dir(dir.path().to_path_buf());
         cache
             .store_https_records(&test_url(), None, &[record(".", Some(9443), None)])
+            .await;
+
+        assert!(cache.candidates(&test_url(), None).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn does_not_cache_expired_https_records() {
+        let dir = TempDir::new().unwrap();
+        let cache = Http3Cache::with_dir(dir.path().to_path_buf());
+        cache
+            .store_https_records(&test_url(), None, &[record(".", Some(9443), Some(0))])
             .await;
 
         assert!(cache.candidates(&test_url(), None).await.is_empty());


### PR DESCRIPTION
## Summary
- parse HTTP Age for DoH responses and subtract it from wire and JSON TTLs
- expose adjusted TTLs to DNS inspection and HTTPS record caching
- invalidate legacy HTTP/3 cache entries with overstated DoH lifetimes

## Validation
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --lib --bins
- cargo test --locked --all-features --test cli --test formatting --test grpc --test har --test http --test install --test network --test terminal --test update --test websocket -- --test-threads=2