### PR TITLE
fix(dns): add default DoH transaction timeout

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -62,7 +62,9 @@ fetch --dns-server doq://dns.adguard-dns.com example.com
 
 Use an HTTPS URL for encrypted DNS queries. `fetch` uses RFC 8484
 `application/dns-message` requests for generic DoH endpoints and falls back to
-Google-style JSON DoH responses for compatibility.
+Google-style JSON DoH responses for compatibility. A DoH transaction has a
+five-second timeout when no request or connection timeout applies. An
+applicable user-set timeout takes precedence.
 
 ```sh
 # Cloudflare DoH

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -451,7 +451,8 @@ DNS over QUIC (DoQ), and DNS-over-HTTPS (DoH) for requests and DNS/TLS
 inspection. Bare `IP[:PORT]` values use UDP DNS, which advertises EDNS(0) and
 retries truncated responses over TCP. DoH URLs are queried with RFC 8484
 wire-format requests, with Google-style JSON DoH retained as a compatibility
-fallback.
+fallback. A DoH transaction has a five-second timeout when no request or
+connection timeout applies. An applicable user-set timeout takes precedence.
 
 ```sh
 fetch --dns-server 8.8.8.8 example.com

--- a/src/dns/doh.rs
+++ b/src/dns/doh.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use url::Url;
 
 use crate::core;
-use crate::dns::util::{dns_query_id, resolve_address_families};
+use crate::dns::util::{dns_query_id, dns_transaction_budget, resolve_address_families};
 use crate::dns::wire;
 use crate::duration::TimeoutBudget;
 use crate::error::FetchError;
@@ -103,6 +103,7 @@ pub(crate) fn client_with_budget_and_tls_config(
     budget: TimeoutBudget,
     tls_config: Option<rustls::ClientConfig>,
 ) -> Result<DohClient, DnsError> {
+    let budget = dns_transaction_budget(budget);
     let tls_config = match tls_config {
         Some(config) => config,
         None => {
@@ -812,6 +813,31 @@ mod tests {
         )
     }
 
+    async fn start_stalling_response_server(
+        send_partial_body: bool,
+    ) -> (Url, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            if send_partial_body {
+                let Some(_) = read_wire_test_request(&mut stream).await else {
+                    return;
+                };
+                let _ = stream
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\ncontent-length: 100\r\ncontent-type: application/dns-message\r\nconnection: close\r\n\r\n\0",
+                    )
+                    .await;
+            }
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+        (
+            Url::parse(&format!("http://{addr}/dns-query")).unwrap(),
+            task,
+        )
+    }
+
     async fn start_delayed_415_fallback_server(
         post_delay: Duration,
     ) -> (Url, tokio::task::JoinHandle<()>) {
@@ -1300,6 +1326,40 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(400),
             "lookup took {elapsed:?}, expected parallel A/AAAA queries near {delay:?}"
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn lookup_doh_default_timeout_covers_response_headers() {
+        let (url, task) = start_stalling_response_server(false).await;
+        let start = Instant::now();
+
+        let err = lookup_doh_type(&url, "example.com", "A", DNS_TYPE_A, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "request timed out after 5s");
+        assert!(
+            start.elapsed() < Duration::from_secs(7),
+            "DoH response headers exceeded the default timeout"
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn lookup_doh_default_timeout_covers_slow_body() {
+        let (url, task) = start_stalling_response_server(true).await;
+        let start = Instant::now();
+
+        let err = lookup_doh_type(&url, "example.com", "A", DNS_TYPE_A, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "request timed out after 5s");
+        assert!(
+            start.elapsed() < Duration::from_secs(7),
+            "DoH response body exceeded the default timeout"
         );
         task.abort();
     }

--- a/src/dns/util.rs
+++ b/src/dns/util.rs
@@ -1,13 +1,23 @@
 use std::time::Duration;
 
-pub(crate) const DEFAULT_UDP_DNS_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const DEFAULT_DNS_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(crate) fn dns_query_id() -> u16 {
     rand::random::<u16>()
 }
 
+pub(crate) fn dns_transaction_budget(
+    budget: crate::duration::TimeoutBudget,
+) -> crate::duration::TimeoutBudget {
+    if budget.timeout().is_some() {
+        budget
+    } else {
+        crate::duration::TimeoutBudget::new(Some(DEFAULT_DNS_TRANSACTION_TIMEOUT))
+    }
+}
+
 pub(crate) fn udp_dns_timeout(timeout: Option<Duration>) -> Duration {
-    timeout.unwrap_or(DEFAULT_UDP_DNS_TIMEOUT)
+    timeout.unwrap_or(DEFAULT_DNS_TRANSACTION_TIMEOUT)
 }
 
 /// Resolve both address families without making a positive result depend on


### PR DESCRIPTION
## Summary
- apply a five-second default budget to DoH transactions
- preserve applicable request and connection timeout budgets
- test stalled response headers and bodies
- document the default timeout behavior

## Validation
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- full integration test suite with `--test-threads=2`