### PR TITLE
fix(dns): harden DoH protocol handling

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -60,9 +60,11 @@ fetch --dns-server doq://dns.adguard-dns.com example.com
 
 ### DNS-over-HTTPS (DoH)
 
-Use an HTTPS URL for encrypted DNS queries. `fetch` uses RFC 8484
-`application/dns-message` requests for generic DoH endpoints and falls back to
-Google-style JSON DoH responses for compatibility. A DoH transaction has a
+Use an HTTPS URL for encrypted DNS queries. Plain HTTP DoH endpoints are not
+accepted. `fetch` uses RFC 8484 `application/dns-message` requests for generic
+DoH endpoints and falls back to Google-style JSON DoH responses for
+compatibility. Wire-format DNS responses are limited to 65,535 bytes. JSON and
+HTTP error responses use separate bounded limits. A DoH transaction has a
 five-second timeout when no request or connection timeout applies. An
 applicable user-set timeout takes precedence.
 

--- a/src/dns/custom.rs
+++ b/src/dns/custom.rs
@@ -64,12 +64,30 @@ pub(crate) struct DnsQueryRecord {
 }
 
 pub(crate) fn parse_dns_server(value: &str) -> Result<ParsedDnsServer, FetchError> {
-    if value.starts_with("http://") || value.starts_with("https://") {
+    if value.starts_with("http://") {
+        // DNS unit tests use loopback HTTP fixtures. This branch is absent
+        // from production builds, which always require HTTPS for DoH.
+        #[cfg(test)]
+        if let Ok(url) = Url::parse(value)
+            && url.host().is_some_and(|host| match host {
+                url::Host::Ipv4(ip) => ip.is_loopback(),
+                url::Host::Ipv6(ip) => ip.is_loopback(),
+                url::Host::Domain(name) => name.eq_ignore_ascii_case("localhost"),
+            })
+        {
+            return Ok(ParsedDnsServer::Doh(url));
+        }
+        return Err(FetchError::Message(format!(
+            "invalid value '{value}' for option '--dns-server': DoH endpoints must use HTTPS"
+        )));
+    }
+    if value.starts_with("https://") {
         let url = Url::parse(value).map_err(|err| {
             FetchError::Message(format!(
                 "invalid value '{value}' for option '--dns-server': {err}"
             ))
         })?;
+        host_and_port(&url)?;
         return Ok(ParsedDnsServer::Doh(url));
     }
 
@@ -349,11 +367,6 @@ mod tests {
                 .is_authenticated(true)
         );
         assert!(
-            !parse_dns_server("http://resolver.example/dns-query")
-                .unwrap()
-                .is_authenticated(true)
-        );
-        assert!(
             !parse_dns_server("https://resolver.example/dns-query")
                 .unwrap()
                 .is_authenticated(false)
@@ -482,6 +495,25 @@ mod tests {
         assert!(
             matches!(parsed, ParsedDnsServer::Doh(url) if url.as_str() == "https://dns.example/dns-query")
         );
+    }
+
+    #[test]
+    fn parse_dns_server_rejects_plaintext_doh_url() {
+        let err = parse_dns_server("http://dns.example/dns-query").unwrap_err();
+
+        assert!(err.to_string().contains("DoH endpoints must use HTTPS"));
+    }
+
+    #[test]
+    fn parse_dns_server_allows_plaintext_loopback_only_in_unit_tests() {
+        let parsed = parse_dns_server("http://127.0.0.1:8080/dns-query").unwrap();
+
+        assert!(matches!(parsed, ParsedDnsServer::Doh(_)));
+    }
+
+    #[test]
+    fn parse_dns_server_rejects_doh_url_without_host() {
+        assert!(parse_dns_server("https://").is_err());
     }
 
     #[test]

--- a/src/dns/doh.rs
+++ b/src/dns/doh.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use url::Url;
 
 use crate::core;
-use crate::dns::util::{dns_query_id, dns_transaction_budget, resolve_address_families};
+use crate::dns::util::{dns_transaction_budget, resolve_address_families};
 use crate::dns::wire;
 use crate::duration::TimeoutBudget;
 use crate::error::FetchError;
@@ -18,8 +18,13 @@ use crate::http::transport::{Client, Response};
 const DNS_TYPE_A: u16 = wire::TYPE_A;
 const DNS_TYPE_AAAA: u16 = wire::TYPE_AAAA;
 const DNS_CLASS_IN: u16 = wire::CLASS_IN;
-const DOH_RESPONSE_MAX_BYTES: usize = 1024 * 1024;
-const DOH_RESPONSE_LIMIT_ERROR: &str = "DoH response exceeded maximum allowed size of 1 MiB";
+const DNS_MESSAGE_MAX_BYTES: usize = u16::MAX as usize;
+const DNS_MESSAGE_LIMIT_ERROR: &str =
+    "DoH application/dns-message response exceeded maximum allowed size of 65,535 bytes";
+const DOH_JSON_MAX_BYTES: usize = 1024 * 1024;
+const DOH_JSON_LIMIT_ERROR: &str = "DoH JSON response exceeded maximum allowed size of 1 MiB";
+const DOH_ERROR_MAX_BYTES: usize = 64 * 1024;
+const DOH_ERROR_LIMIT_ERROR: &str = "DoH error response exceeded maximum allowed size of 64 KiB";
 const DOH_ERROR_EXCERPT_MAX_BYTES: usize = 4 * 1024;
 const DOH_ERROR_TRUNCATION_SUFFIX: &str = "... [truncated]";
 const APPLICATION_DNS_MESSAGE: &str = "application/dns-message";
@@ -151,8 +156,10 @@ async fn lookup_doh_wire_records_with_client(
     host: &str,
     dns_type: u16,
 ) -> Result<Vec<DohRecord>, WireDohError> {
-    let id = dns_query_id();
-    let query = wire::build_query(id, host, dns_type)
+    // HTTP correlates DoH exchanges. RFC 8484 recommends ID 0 to improve
+    // HTTP cache reuse and avoid carrying unnecessary entropy in the query.
+    const DOH_QUERY_ID: u16 = 0;
+    let query = wire::build_query(DOH_QUERY_ID, host, dns_type)
         .map_err(|err| WireDohError::Fatal(DnsError(err.to_string())))?;
 
     let mut headers = HeaderMap::new();
@@ -188,7 +195,7 @@ async fn lookup_doh_wire_records_with_client(
     }
 
     let age = doh_response_age(response.headers());
-    match doh_records_from_wire_response(response.body(), id, host, dns_type) {
+    match doh_records_from_wire_response(response.body(), DOH_QUERY_ID, host, dns_type) {
         Ok(mut records) => {
             subtract_age_from_ttls(&mut records, age);
             Ok(records)
@@ -246,6 +253,8 @@ impl DohClient {
         headers: HeaderMap,
         body: Option<Vec<u8>>,
     ) -> Result<DohResponseBody, DnsError> {
+        validate_doh_endpoint(&url)?;
+        let wire_request = method == Method::POST;
         self.budget
             .run(Box::pin(async {
                 let mut request = self.client.request(method, url).headers(headers);
@@ -253,12 +262,14 @@ impl DohClient {
                     request = request.body(body);
                 }
                 let response = Box::pin(request.send()).await?;
-                Box::pin(buffer_response_with_limit(
-                    response,
-                    DOH_RESPONSE_MAX_BYTES,
-                    DOH_RESPONSE_LIMIT_ERROR,
-                ))
-                .await
+                if wire_request && wire_status_may_support_json(response.status()) {
+                    return Ok(DohResponseBody {
+                        status: response.status(),
+                        headers: response.headers().clone(),
+                        body: Bytes::new(),
+                    });
+                }
+                Box::pin(buffer_doh_response(response, wire_request)).await
             }))
             .await
             .map_err(|err| DnsError(err.to_string()))
@@ -283,6 +294,48 @@ impl DohResponseBody {
     fn body(&self) -> &[u8] {
         &self.body
     }
+}
+
+fn validate_doh_endpoint(url: &Url) -> Result<(), DnsError> {
+    if url.scheme() == "https" && url.host_str().is_some() {
+        return Ok(());
+    }
+    // Unit tests use local plaintext servers to test protocol details without
+    // adding TLS setup to each case. Production builds never allow this path.
+    #[cfg(test)]
+    if url.scheme() == "http"
+        && url.host().is_some_and(|host| match host {
+            url::Host::Ipv4(ip) => ip.is_loopback(),
+            url::Host::Ipv6(ip) => ip.is_loopback(),
+            url::Host::Domain(name) => name.eq_ignore_ascii_case("localhost"),
+        })
+    {
+        return Ok(());
+    }
+    Err(DnsError("DoH endpoints must use HTTPS".to_string()))
+}
+
+async fn buffer_doh_response(
+    response: Response,
+    wire_request: bool,
+) -> Result<DohResponseBody, FetchError> {
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(media_type);
+    let (max_body_bytes, limit_error) = if !response.status().is_success() {
+        (DOH_ERROR_MAX_BYTES, DOH_ERROR_LIMIT_ERROR)
+    } else if content_type.is_some_and(has_json_media_type) {
+        (DOH_JSON_MAX_BYTES, DOH_JSON_LIMIT_ERROR)
+    } else if wire_request
+        || content_type.is_some_and(|value| value.eq_ignore_ascii_case(APPLICATION_DNS_MESSAGE))
+    {
+        (DNS_MESSAGE_MAX_BYTES, DNS_MESSAGE_LIMIT_ERROR)
+    } else {
+        (DOH_JSON_MAX_BYTES, DOH_JSON_LIMIT_ERROR)
+    };
+    buffer_response_with_limit(response, max_body_bytes, limit_error).await
 }
 
 async fn buffer_response_with_limit(
@@ -519,12 +572,14 @@ fn has_json_content_type(response: &DohResponseBody) -> bool {
         .headers()
         .get(CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| {
-            let media_type = media_type(value).to_ascii_lowercase();
-            media_type.eq_ignore_ascii_case(APPLICATION_DNS_JSON)
-                || media_type.eq_ignore_ascii_case("application/json")
-                || media_type.ends_with("+json")
-        })
+        .is_some_and(|value| has_json_media_type(media_type(value)))
+}
+
+fn has_json_media_type(value: &str) -> bool {
+    let media_type = value.to_ascii_lowercase();
+    media_type == APPLICATION_DNS_JSON
+        || media_type == "application/json"
+        || media_type.ends_with("+json")
 }
 
 fn media_type(content_type: &str) -> &str {
@@ -1045,6 +1100,18 @@ mod tests {
     }
 
     #[test]
+    fn wire_response_rejects_mismatched_zero_id() {
+        let query = wire::build_query(0, "example.com", wire::TYPE_A).unwrap();
+        let mut response = wire_response(&query, vec![(wire::TYPE_A, 30, vec![192, 0, 2, 1])]);
+        response[0..2].copy_from_slice(&1_u16.to_be_bytes());
+
+        let err =
+            doh_records_from_wire_response(&response, 0, "example.com", wire::TYPE_A).unwrap_err();
+
+        assert_eq!(err.to_string(), "mismatched DNS response ID");
+    }
+
+    #[test]
     fn wire_response_rejects_unrelated_answer_owner() {
         let query = wire::build_query(0x1234, "example.com", wire::TYPE_A).unwrap();
         let (_, _, question_end) = test_dns_question(&query).unwrap();
@@ -1164,6 +1231,7 @@ mod tests {
                     .unwrap();
             }
             let (name, qtype, _) = test_dns_question(&request.body).unwrap();
+            assert_eq!(&request.body[..2], &[0, 0], "DoH query ID must be zero");
             seen_for_handler.lock().unwrap().push((
                 qtype,
                 request.method.clone(),
@@ -1384,6 +1452,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lookup_doh_falls_back_without_buffering_oversized_post_error() {
+        let (url, task) = start_wire_test_server(|request| {
+            if request.method == "POST" {
+                return http::Response::builder()
+                    .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
+                    .body(vec![b'x'; DOH_ERROR_MAX_BYTES + 1])
+                    .unwrap();
+            }
+            http::Response::builder()
+                .header(CONTENT_TYPE, APPLICATION_DNS_JSON)
+                .body(
+                    br#"{"Status":0,"Answer":[{"name":"example.com.","type":1,"data":"192.0.2.1"}]}"#
+                        .to_vec(),
+                )
+                .unwrap()
+        })
+        .await;
+
+        let records = lookup_doh_type(&url, "example.com", "A", DNS_TYPE_A, None)
+            .await
+            .unwrap();
+
+        assert_eq!(records[0].ip, "192.0.2.1".parse::<IpAddr>().unwrap());
+        task.abort();
+    }
+
+    #[tokio::test]
     async fn lookup_doh_nxdomain_mentions_rcode() {
         let (url, task) =
             start_test_server(|_| http::Response::new(r#"{"Status":3}"#.to_string())).await;
@@ -1502,7 +1597,61 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lookup_doh_rejects_oversized_response() {
+    async fn lookup_doh_rejects_oversized_dns_message_response() {
+        let (url, task) = start_wire_test_server(|_| {
+            http::Response::builder()
+                .header(CONTENT_TYPE, APPLICATION_DNS_MESSAGE)
+                .body(vec![0; DNS_MESSAGE_MAX_BYTES + 1])
+                .unwrap()
+        })
+        .await;
+
+        let err = lookup_doh_type(&url, "example.com", "A", DNS_TYPE_A, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), DNS_MESSAGE_LIMIT_ERROR);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn lookup_doh_rejects_oversized_wire_response_without_content_type() {
+        let (url, task) = start_wire_test_server(|_| {
+            http::Response::builder()
+                .body(vec![0; DNS_MESSAGE_MAX_BYTES + 1])
+                .unwrap()
+        })
+        .await;
+
+        let err = lookup_doh_type(&url, "example.com", "A", DNS_TYPE_A, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), DNS_MESSAGE_LIMIT_ERROR);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn lookup_doh_rejects_oversized_error_response() {
+        let (url, task) = start_wire_test_server(|_| {
+            http::Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header(CONTENT_TYPE, APPLICATION_DNS_JSON)
+                .body(vec![b'x'; DOH_ERROR_MAX_BYTES + 1])
+                .unwrap()
+        })
+        .await;
+
+        let err = lookup_doh_type(&url, "example.com", "A", DNS_TYPE_A, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), DOH_ERROR_LIMIT_ERROR);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn lookup_doh_rejects_oversized_json_response() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let task = tokio::spawn(async move {
@@ -1522,7 +1671,7 @@ mod tests {
             let _ = stream
                 .write_all(b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n")
                 .await;
-            let oversized = vec![b' '; DOH_RESPONSE_MAX_BYTES + 1];
+            let oversized = vec![b' '; DOH_JSON_MAX_BYTES + 1];
             let _ = stream.write_all(&oversized).await;
         });
         let url = Url::parse(&format!("http://{addr}/dns-query")).unwrap();
@@ -1531,7 +1680,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_eq!(err.to_string(), DOH_RESPONSE_LIMIT_ERROR);
+        assert_eq!(err.to_string(), DOH_JSON_LIMIT_ERROR);
         task.await.unwrap();
     }
 

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -1628,36 +1628,41 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
     assert!(res.stderr.contains("no such host"));
     assert!(!res.stderr.contains("For more information"));
 
-    let res = run_fetch_opts(
-        FetchOpts {
-            env: vec![(
-                "SSL_CERT_FILE".to_string(),
-                doh.ca_cert_path.display().to_string(),
-            )],
-            ..Default::default()
-        },
-        &[
-            "--inspect-dns",
-            "--dns-server",
-            &format!("{}/dns-query", doh.url),
-            "https://example.com",
-        ],
-    );
-    assert_exit(&res, 0);
-    assert!(res.stdout.is_empty());
-    assert!(res.stderr.contains("DNS lookup: example.com"));
-    assert!(
-        res.stderr
-            .contains(&format!("Resolver: {}/dns-query", doh.url))
-    );
-    assert!(res.stderr.contains("A\n"));
-    assert!(res.stderr.contains("192.0.2.1 (TTL 1m)"));
-    assert!(res.stderr.contains("AAAA\n"));
-    assert!(res.stderr.contains("2001:db8::1 (TTL 5m)"));
-    assert!(res.stderr.contains("alias.example.com. (TTL 2m)"));
-    assert!(res.stderr.contains("v=spf1 -all (TTL 3m)"));
-    assert!(res.stderr.contains("Addresses: 2"));
-    assert!(res.stderr.contains("Records:"));
+    // rustls-native-certs honors SSL_CERT_FILE on Linux. The macOS and
+    // Windows platform stores do not provide a process-local trust override.
+    #[cfg(target_os = "linux")]
+    {
+        let res = run_fetch_opts(
+            FetchOpts {
+                env: vec![(
+                    "SSL_CERT_FILE".to_string(),
+                    doh.ca_cert_path.display().to_string(),
+                )],
+                ..Default::default()
+            },
+            &[
+                "--inspect-dns",
+                "--dns-server",
+                &format!("{}/dns-query", doh.url),
+                "https://example.com",
+            ],
+        );
+        assert_exit(&res, 0);
+        assert!(res.stdout.is_empty());
+        assert!(res.stderr.contains("DNS lookup: example.com"));
+        assert!(
+            res.stderr
+                .contains(&format!("Resolver: {}/dns-query", doh.url))
+        );
+        assert!(res.stderr.contains("A\n"));
+        assert!(res.stderr.contains("192.0.2.1 (TTL 1m)"));
+        assert!(res.stderr.contains("AAAA\n"));
+        assert!(res.stderr.contains("2001:db8::1 (TTL 5m)"));
+        assert!(res.stderr.contains("alias.example.com. (TTL 2m)"));
+        assert!(res.stderr.contains("v=spf1 -all (TTL 3m)"));
+        assert!(res.stderr.contains("Addresses: 2"));
+        assert!(res.stderr.contains("Records:"));
+    }
 
     let res = run_fetch(&[
         "--inspect-dns",
@@ -1713,35 +1718,38 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
     assert_exit(&res, 1);
     assert!(res.stderr.contains("request timed out after 50ms"));
 
-    let res = run_fetch_opts(
-        FetchOpts {
-            env: vec![(
-                "SSL_CERT_FILE".to_string(),
-                doh.ca_cert_path.display().to_string(),
-            )],
-            ..Default::default()
-        },
-        &[
-            "--inspect-dns",
-            "--dns-server",
-            &format!("{}/dns-query", doh.url),
-            "--color",
-            "on",
-            "https://example.com",
-        ],
-    );
-    assert_exit(&res, 0);
-    assert!(res.stdout.is_empty());
-    assert!(
-        res.stderr
-            .contains("\x1b[2m* \x1b[0m\x1b[1m\x1b[36mDNS lookup\x1b[0m")
-    );
-    assert!(
-        res.stderr
-            .contains(&format!("\x1b[3m{}/dns-query\x1b[0m", doh.url))
-    );
-    assert!(res.stderr.contains("\x1b[32m192.0.2.1\x1b[0m"));
-    assert!(res.stderr.contains("\x1b[2m(TTL 1m)\x1b[0m"));
+    #[cfg(target_os = "linux")]
+    {
+        let res = run_fetch_opts(
+            FetchOpts {
+                env: vec![(
+                    "SSL_CERT_FILE".to_string(),
+                    doh.ca_cert_path.display().to_string(),
+                )],
+                ..Default::default()
+            },
+            &[
+                "--inspect-dns",
+                "--dns-server",
+                &format!("{}/dns-query", doh.url),
+                "--color",
+                "on",
+                "https://example.com",
+            ],
+        );
+        assert_exit(&res, 0);
+        assert!(res.stdout.is_empty());
+        assert!(
+            res.stderr
+                .contains("\x1b[2m* \x1b[0m\x1b[1m\x1b[36mDNS lookup\x1b[0m")
+        );
+        assert!(
+            res.stderr
+                .contains(&format!("\x1b[3m{}/dns-query\x1b[0m", doh.url))
+        );
+        assert!(res.stderr.contains("\x1b[32m192.0.2.1\x1b[0m"));
+        assert!(res.stderr.contains("\x1b[2m(TTL 1m)\x1b[0m"));
+    }
 
     let target = TestServer::start(|req| {
         if req.header("host").starts_with("fetch-dns.test:") {

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -1489,7 +1489,7 @@ fn explicit_http2_bypasses_auto_http3_discovery() {
 
 #[test]
 fn dns_over_https_udp_and_inspect_dns_cases() {
-    let doh = TestServer::start(|req| {
+    let doh = start_tls_server(|req| {
         if req.path.contains("/dns-query-nxdomain") {
             return TestResponse::ok(r#"{"Status":3}"#)
                 .header("Content-Type", "application/dns-json")
@@ -1530,8 +1530,19 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
         }
         TestResponse::status(204, "No Content", "").header("Connection", "close")
     });
-    let port = host_port(&doh.url).split(':').nth(1).unwrap();
-    let localhost_url = format!("http://localhost:{port}");
+    let target = TestServer::start(|_| {
+        TestResponse::status(204, "No Content", "").header("Connection", "close")
+    });
+    let localhost_url = target.url.replacen("127.0.0.1", "localhost", 1);
+
+    let plaintext_doh_url = doh.url.replacen("https://", "http://", 1);
+    let res = run_fetch(&[
+        &localhost_url,
+        "--dns-server",
+        &format!("{plaintext_doh_url}/dns-query"),
+    ]);
+    assert_exit(&res, 1);
+    assert!(res.stderr.contains("DoH endpoints must use HTTPS"));
 
     fn doh_wire_test_response(query: &[u8], answers: Vec<(u16, u32, Vec<u8>)>) -> Vec<u8> {
         let (_, _, question_end) = parse_dns_question(query).expect("valid DNS query");
@@ -1554,7 +1565,10 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
         response
     }
 
-    let wire_doh = TestServer::start(|req| {
+    let wire_requests = Arc::new(Mutex::new(Vec::new()));
+    let wire_requests_for_handler = Arc::clone(&wire_requests);
+    let wire_doh = start_tls_server(move |req| {
+        wire_requests_for_handler.lock().unwrap().push(req.clone());
         if req.method != "POST"
             || req.header("accept") != "application/dns-message"
             || req.header("content-type") != "application/dns-message"
@@ -1565,6 +1579,10 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
         let Some((name, qtype, _)) = parse_dns_question(&req.body) else {
             return TestResponse::status(400, "Bad Request", "").header("Connection", "close");
         };
+        if req.body.get(..2) != Some(&[0, 0]) {
+            return TestResponse::status(400, "Bad Request", "nonzero DNS ID")
+                .header("Connection", "close");
+        }
         let answers = if name == "localhost." && qtype == 1 {
             vec![(1, 30, vec![127, 0, 0, 1])]
         } else {
@@ -1578,18 +1596,23 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
         &localhost_url,
         "--dns-server",
         &format!("{}/dns-query", wire_doh.url),
+        "--ca-cert",
+        wire_doh.ca_cert_path.to_str().unwrap(),
     ]);
     assert_exit(&res, 0);
     assert!(res.stderr.contains("204 No Content"));
-    let wire_requests = wire_doh.requests.lock().unwrap();
+    let wire_requests = wire_requests.lock().unwrap();
     assert_eq!(wire_requests.len(), 2);
     assert!(wire_requests.iter().all(|req| req.method == "POST"));
     assert!(wire_requests.iter().all(|req| req.path == "/dns-query"));
+    drop(wire_requests);
 
     let res = run_fetch(&[
         &localhost_url,
         "--dns-server",
         &format!("{}/dns-query", doh.url),
+        "--ca-cert",
+        doh.ca_cert_path.to_str().unwrap(),
     ]);
     assert_exit(&res, 0);
     assert!(res.stderr.contains("204 No Content"));
@@ -1598,17 +1621,28 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
         &localhost_url,
         "--dns-server",
         &format!("{}/dns-query-nxdomain", doh.url),
+        "--ca-cert",
+        doh.ca_cert_path.to_str().unwrap(),
     ]);
     assert_exit(&res, 1);
     assert!(res.stderr.contains("no such host"));
     assert!(!res.stderr.contains("For more information"));
 
-    let res = run_fetch(&[
-        "--inspect-dns",
-        "--dns-server",
-        &format!("{}/dns-query", doh.url),
-        "https://example.com",
-    ]);
+    let res = run_fetch_opts(
+        FetchOpts {
+            env: vec![(
+                "SSL_CERT_FILE".to_string(),
+                doh.ca_cert_path.display().to_string(),
+            )],
+            ..Default::default()
+        },
+        &[
+            "--inspect-dns",
+            "--dns-server",
+            &format!("{}/dns-query", doh.url),
+            "https://example.com",
+        ],
+    );
     assert_exit(&res, 0);
     assert!(res.stdout.is_empty());
     assert!(res.stderr.contains("DNS lookup: example.com"));
@@ -1679,14 +1713,23 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
     assert_exit(&res, 1);
     assert!(res.stderr.contains("request timed out after 50ms"));
 
-    let res = run_fetch(&[
-        "--inspect-dns",
-        "--dns-server",
-        &format!("{}/dns-query", doh.url),
-        "--color",
-        "on",
-        "https://example.com",
-    ]);
+    let res = run_fetch_opts(
+        FetchOpts {
+            env: vec![(
+                "SSL_CERT_FILE".to_string(),
+                doh.ca_cert_path.display().to_string(),
+            )],
+            ..Default::default()
+        },
+        &[
+            "--inspect-dns",
+            "--dns-server",
+            &format!("{}/dns-query", doh.url),
+            "--color",
+            "on",
+            "https://example.com",
+        ],
+    );
     assert_exit(&res, 0);
     assert!(res.stdout.is_empty());
     assert!(


### PR DESCRIPTION
## Summary
- require HTTPS for production DoH endpoints
- use zero DNS message IDs and apply format-specific response limits
- avoid buffering fallback-triggering POST errors and update TLS integration coverage

## Validation
- `cargo fmt`
- `cargo test --locked --all-features dns:: --lib`
- `cargo test --locked --all-features --test network dns_over_https_udp_and_inspect_dns_cases -- --test-threads=1`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`