### PR TITLE
Honor system resolver policy for HTTPS records

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -216,9 +216,14 @@ for `--http 1`, `--http 2`, and `--http 3`.
 
 When `--http` is unset, direct HTTPS requests use DNS HTTPS/SVCB records to
 discover `h3`. With `--dns-server`, HTTPS-record discovery uses that custom
-UDP, TCP, DoT, DoQ, or DoH resolver. Without `--dns-server`, it uses the
-platform resolver, matching normal address lookup. HTTPS-record discovery and normal A/AAAA lookup
-run in parallel. `fetch` starts the TCP/TLS path as soon as normal DNS produces
+UDP, TCP, DoT, DoQ, or DoH resolver. Without `--dns-server`, it uses the platform resolver. On Linux, `fetch` first
+uses `systemd-resolved` through `resolvectl`. This path honors per-link and
+split-DNS routing. If that service or command interface is unavailable, `fetch`
+uses all valid name servers in `/etc/resolv.conf` and honors the `rotate`,
+`attempts`, and `timeout` options. The file fallback cannot honor NSS modules,
+per-link routing, or resolver configuration stored outside `resolv.conf`. Other
+Unix systems without a record-query API use the same file fallback. HTTPS-record
+discovery and normal A/AAAA lookup run in parallel. `fetch` starts the TCP/TLS path as soon as normal DNS produces
 a usable address, and a usable `h3` candidate that is discovered before TCP/TLS
 wins races QUIC setup against it. The request is sent once on the winning
 transport. With system, UDP, TCP, or plaintext HTTP DNS, a slow or failed
@@ -279,8 +284,9 @@ fetch --http 3 example.com
 
 By default, `fetch` negotiates the best available version:
 
-1. Uses DNS HTTPS/SVCB records from the platform resolver, or from
-   `--dns-server` when set, to discover `h3` candidates for direct HTTPS
+1. Uses DNS HTTPS/SVCB records from the platform resolver, or the documented
+   Unix resolver-file fallback, or from `--dns-server` when set, to discover
+   `h3` candidates for direct HTTPS
 2. Reuses fresh cached HTTP/3 alternatives learned from prior HTTPS/SVCB or
    `Alt-Svc` responses
 3. Resolves A and AAAA in parallel and starts TCP/TLS as soon as an address is

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -615,7 +615,9 @@ Aliases: `--http1`, `--http2`, `--http3`.
 When `--http` is unset, direct HTTPS requests use DNS HTTPS/SVCB records to
 discover `h3` endpoints. With `--dns-server`, HTTPS-record discovery uses that
 custom UDP, TCP, DoT, DoQ, or DoH resolver. Without `--dns-server`, it uses the
-platform resolver, matching normal address lookup. This discovery is
+platform resolver. On Linux, this uses `systemd-resolved` when available. The
+documented Unix resolver-file fallback cannot honor NSS or split-DNS policy.
+This discovery is
 opportunistic and does not delay the normal address lookup or TCP/TLS setup:
 `fetch` starts
 TCP/TLS as soon as normal DNS produces a usable address, while a usable `h3`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -396,8 +396,10 @@ Force a specific HTTP protocol version.
 
 When unset, direct HTTPS requests use DNS HTTPS/SVCB records to discover `h3`
 endpoints. With `dns-server`, HTTPS-record discovery uses that custom UDP, TCP,
-DoT, DoQ, or DoH resolver. Without `dns-server`, it uses the platform resolver,
-matching normal address lookup. Discovery runs in parallel with normal A/AAAA
+DoT, DoQ, or DoH resolver. Without `dns-server`, it uses the platform resolver.
+On Linux, this uses `systemd-resolved` when available. The documented Unix
+resolver-file fallback cannot honor NSS or split-DNS policy. Discovery runs in
+parallel with normal A/AAAA
 lookup and TCP/TLS setup. `fetch` starts TCP/TLS as soon as normal DNS produces a usable
 address, while a usable `h3` record discovered before TCP/TLS wins races QUIC
 setup against it. The request is sent once on the winning transport. System,

--- a/src/dns/svcb/system.rs
+++ b/src/dns/svcb/system.rs
@@ -1,17 +1,19 @@
 #[cfg(target_os = "macos")]
 use std::ffi::CString;
+#[cfg(all(unix, not(target_os = "macos")))]
+use std::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(not(all(unix, not(target_os = "macos"))))]
 use std::time::Duration;
 #[cfg(target_os = "macos")]
 use std::time::Instant;
 
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(unix, test))]
 use crate::dns::wire;
 use crate::duration::TimeoutBudget;
 use crate::error::FetchError;
 
 use super::SvcbRecord;
-#[cfg(any(target_os = "macos", windows, test))]
+#[cfg(any(target_os = "macos", target_os = "linux", windows, test))]
 use super::parse_rdata;
 
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -19,19 +21,320 @@ pub(super) async fn lookup_https_records(
     host: &str,
     timeout: TimeoutBudget,
 ) -> Result<Vec<SvcbRecord>, FetchError> {
-    let Some(server_addr) = resolv_conf_nameserver() else {
-        return Ok(Vec::new());
+    #[cfg(target_os = "linux")]
+    {
+        let service = lookup_with_systemd_resolved(host, timeout).await;
+        return route_system_lookup(service, lookup_with_resolv_conf(host, timeout)).await;
+    }
+    #[cfg(not(target_os = "linux"))]
+    lookup_with_resolv_conf(host, timeout).await
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[derive(Debug)]
+enum SystemServiceOutcome {
+    Records(Vec<SvcbRecord>),
+    Unavailable,
+    Error(FetchError),
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+async fn route_system_lookup<F>(
+    service: SystemServiceOutcome,
+    fallback: F,
+) -> Result<Vec<SvcbRecord>, FetchError>
+where
+    F: Future<Output = Result<Vec<SvcbRecord>, FetchError>>,
+{
+    match service {
+        SystemServiceOutcome::Records(records) => Ok(records),
+        SystemServiceOutcome::Unavailable => fallback.await,
+        SystemServiceOutcome::Error(err) => Err(err),
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+use std::future::Future;
+
+#[cfg(target_os = "linux")]
+async fn lookup_with_systemd_resolved(host: &str, timeout: TimeoutBudget) -> SystemServiceOutcome {
+    use std::process::Stdio;
+
+    let timeout = crate::dns::util::dns_transaction_budget(timeout);
+
+    let Some(program) = [
+        "/usr/bin/resolvectl",
+        "/bin/resolvectl",
+        "/usr/local/bin/resolvectl",
+        "/run/current-system/sw/bin/resolvectl",
+    ]
+    .into_iter()
+    .find(|path| std::path::Path::new(path).is_file()) else {
+        return SystemServiceOutcome::Unavailable;
     };
-    let records = crate::dns::custom::query_type(
-        &crate::dns::custom::ParsedDnsServer::Udp(server_addr),
-        host,
-        crate::dns::wire::TYPE_HTTPS,
-        "HTTPS",
-        timeout,
-        None,
-    )
-    .await?;
-    super::svcb_records_from_query(records)
+
+    let mut command = tokio::process::Command::new(program);
+    command
+        .args(["--raw=packet", "--type=TYPE65", "query", host])
+        .stdin(Stdio::null())
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(_) => return SystemServiceOutcome::Unavailable,
+    };
+    let stdout = child.stdout.take().expect("resolvectl stdout is piped");
+    let stderr = child.stderr.take().expect("resolvectl stderr is piped");
+    const MAX_SERVICE_OUTPUT: u64 = 1024 * 1024;
+    let result = timeout
+        .run(async {
+            use tokio::io::AsyncReadExt;
+
+            let read_stdout = async {
+                let mut bytes = Vec::new();
+                stdout
+                    .take(MAX_SERVICE_OUTPUT + 1)
+                    .read_to_end(&mut bytes)
+                    .await?;
+                Ok::<_, std::io::Error>(bytes)
+            };
+            let read_stderr = async {
+                let mut bytes = Vec::new();
+                stderr
+                    .take(MAX_SERVICE_OUTPUT + 1)
+                    .read_to_end(&mut bytes)
+                    .await?;
+                Ok::<_, std::io::Error>(bytes)
+            };
+            let (stdout, stderr, status) = tokio::try_join!(read_stdout, read_stderr, child.wait())
+                .map_err(|err| {
+                    FetchError::Runtime(format!("system resolver service failed: {err}"))
+                })?;
+            Ok((stdout, stderr, status))
+        })
+        .await;
+    let (stdout, stderr, status) = match result {
+        Ok(result) => result,
+        Err(err) => return SystemServiceOutcome::Error(err),
+    };
+    if stdout.len() as u64 > MAX_SERVICE_OUTPUT || stderr.len() as u64 > MAX_SERVICE_OUTPUT {
+        return SystemServiceOutcome::Error(FetchError::Runtime(
+            "system resolver service output is too large".to_string(),
+        ));
+    }
+
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&stderr);
+        return match classify_resolvectl_failure(&stderr) {
+            ResolvectlFailure::Unavailable => SystemServiceOutcome::Unavailable,
+            ResolvectlFailure::NegativeAnswer => SystemServiceOutcome::Records(Vec::new()),
+            ResolvectlFailure::Error => SystemServiceOutcome::Error(FetchError::Runtime(format!(
+                "system resolver service lookup failed ({status})"
+            ))),
+        };
+    }
+
+    match records_from_resolvectl_packets(host, &stdout) {
+        Ok(records) => SystemServiceOutcome::Records(records),
+        Err(err) => SystemServiceOutcome::Error(err),
+    }
+}
+
+#[cfg(any(test, target_os = "linux"))]
+#[derive(Debug, PartialEq, Eq)]
+enum ResolvectlFailure {
+    Unavailable,
+    NegativeAnswer,
+    Error,
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn classify_resolvectl_failure(stderr: &str) -> ResolvectlFailure {
+    let stderr = stderr.to_ascii_lowercase();
+    if [
+        "unknown option",
+        "unrecognized option",
+        "failed to connect to bus",
+        "could not connect",
+        "sd_bus_open_system",
+        "failed to get global data",
+        "service unknown",
+        "unit dbus-org.freedesktop.resolve1.service not found",
+        "unknown rr type",
+    ]
+    .iter()
+    .any(|message| stderr.contains(message))
+    {
+        ResolvectlFailure::Unavailable
+    } else if stderr.contains("not found")
+        || stderr.contains("does not have any rr of the requested type")
+    {
+        ResolvectlFailure::NegativeAnswer
+    } else {
+        ResolvectlFailure::Error
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn records_from_resolvectl_packets(
+    _host: &str,
+    packets: &[u8],
+) -> Result<Vec<SvcbRecord>, FetchError> {
+    let mut offset = 0;
+    let mut records = Vec::new();
+    while offset < packets.len() {
+        if records.len() >= 4096 {
+            return Err(FetchError::Runtime(
+                "too many records from system resolver".to_string(),
+            ));
+        }
+        let length_bytes: [u8; 8] = packets
+            .get(offset..offset + 8)
+            .and_then(|bytes| bytes.try_into().ok())
+            .ok_or_else(|| FetchError::Runtime("malformed system resolver output".to_string()))?;
+        offset += 8;
+        let length = usize::try_from(u64::from_le_bytes(length_bytes))
+            .map_err(|_| FetchError::Runtime("oversized system resolver record".to_string()))?;
+        let end = offset
+            .checked_add(length)
+            .filter(|end| *end <= packets.len())
+            .ok_or_else(|| FetchError::Runtime("malformed system resolver output".to_string()))?;
+        let resource = wire::parse_standalone_resource_record(&packets[offset..end])
+            .map_err(|err| FetchError::Runtime(err.to_string()))?;
+        offset = end;
+        if resource.typ != wire::TYPE_HTTPS || resource.class != wire::CLASS_IN {
+            continue;
+        }
+        let mut record = parse_rdata(resource.data).map_err(|err| {
+            FetchError::Runtime(format!("malformed HTTPS DNS record data: {err}"))
+        })?;
+        record.ttl = Some(resource.ttl);
+        records.push(record);
+    }
+    Ok(records)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvConf {
+    nameservers: Vec<std::net::SocketAddr>,
+    timeout: std::time::Duration,
+    attempts: usize,
+    rotate: bool,
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl Default for ResolvConf {
+    fn default() -> Self {
+        Self {
+            nameservers: Vec::new(),
+            timeout: std::time::Duration::from_secs(5),
+            attempts: 2,
+            rotate: false,
+        }
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+static RESOLVER_ROTATION: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(all(unix, not(target_os = "macos")))]
+async fn lookup_with_resolv_conf(
+    host: &str,
+    budget: TimeoutBudget,
+) -> Result<Vec<SvcbRecord>, FetchError> {
+    let contents = match tokio::fs::read_to_string("/etc/resolv.conf").await {
+        Ok(contents) => contents,
+        Err(_) => return Ok(Vec::new()),
+    };
+    lookup_with_resolv_conf_config(host, budget, &parse_resolv_conf(&contents)).await
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+async fn lookup_with_resolv_conf_config(
+    host: &str,
+    budget: TimeoutBudget,
+    config: &ResolvConf,
+) -> Result<Vec<SvcbRecord>, FetchError> {
+    if config.nameservers.is_empty() || config.attempts == 0 {
+        return Ok(Vec::new());
+    }
+    let start = if config.rotate {
+        RESOLVER_ROTATION.fetch_add(1, Ordering::Relaxed) % config.nameservers.len()
+    } else {
+        0
+    };
+    let mut last_error = None;
+    for _ in 0..config.attempts {
+        for index in 0..config.nameservers.len() {
+            let server = config.nameservers[(start + index) % config.nameservers.len()];
+            let remaining = budget.remaining()?;
+            let query_timeout = remaining.map_or(config.timeout, |value| value.min(config.timeout));
+            if query_timeout.is_zero() {
+                return Err(FetchError::Runtime("DNS lookup timed out".to_string()));
+            }
+            match crate::dns::resolver::query_udp_type(
+                &server,
+                host,
+                wire::TYPE_HTTPS,
+                TimeoutBudget::new(Some(query_timeout)),
+            )
+            .await
+            {
+                Ok(records) => {
+                    let records = records
+                        .into_iter()
+                        .map(|record| crate::dns::custom::DnsQueryRecord {
+                            typ: record.typ,
+                            ttl: Some(record.ttl),
+                            data: crate::dns::custom::DnsRecordData::Wire(record.data),
+                        })
+                        .collect();
+                    return super::svcb_records_from_query(records);
+                }
+                Err(err) if err.is_nxdomain() => return Ok(Vec::new()),
+                Err(err) => last_error = Some(err),
+            }
+        }
+    }
+    Err(FetchError::Runtime(format!(
+        "lookup {host}: {}",
+        last_error.map_or_else(|| "DNS lookup failed".to_string(), |err| err.to_string())
+    )))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn parse_resolv_conf(contents: &str) -> ResolvConf {
+    let mut config = ResolvConf::default();
+    for line in contents.lines() {
+        let line = line.split(['#', ';']).next().unwrap_or_default().trim();
+        let mut fields = line.split_whitespace();
+        match fields.next() {
+            Some("nameserver") => {
+                if let Some(ip) = fields.next().and_then(|value| value.parse().ok()) {
+                    config.nameservers.push(std::net::SocketAddr::new(ip, 53));
+                }
+            }
+            Some("options") => {
+                for option in fields {
+                    if option == "rotate" {
+                        config.rotate = true;
+                    } else if let Some(value) = option.strip_prefix("timeout:") {
+                        if let Ok(seconds) = value.parse::<u64>() {
+                            config.timeout = std::time::Duration::from_secs(seconds.clamp(1, 30));
+                        }
+                    } else if let Some(value) = option.strip_prefix("attempts:")
+                        && let Ok(attempts) = value.parse::<usize>()
+                    {
+                        config.attempts = attempts.min(5);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    config
 }
 
 #[cfg(not(all(unix, not(target_os = "macos"))))]
@@ -230,25 +533,6 @@ fn poll_timeout_ms(deadline: Option<Instant>) -> Option<libc::c_int> {
     Some(millis as libc::c_int)
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
-fn resolv_conf_nameserver() -> Option<std::net::SocketAddr> {
-    let resolv_conf = std::fs::read_to_string("/etc/resolv.conf").ok()?;
-    parse_resolv_conf_nameserver(&resolv_conf)
-}
-
-#[cfg(any(test, all(unix, not(target_os = "macos"))))]
-fn parse_resolv_conf_nameserver(contents: &str) -> Option<std::net::SocketAddr> {
-    contents.lines().find_map(|line| {
-        let line = line.split('#').next()?.trim();
-        let mut fields = line.split_whitespace();
-        if fields.next()? != "nameserver" {
-            return None;
-        }
-        let ip = fields.next()?.parse::<std::net::IpAddr>().ok()?;
-        Some(std::net::SocketAddr::new(ip, 53))
-    })
-}
-
 #[cfg(windows)]
 fn lookup_https_records_blocking(
     host: &str,
@@ -427,10 +711,12 @@ fn lookup_https_records_blocking(
 }
 
 #[cfg(test)]
-fn records_from_wire_response(raw: &[u8]) -> Result<Vec<SvcbRecord>, FetchError> {
-    let records =
-        wire::parse_response_without_id(raw, "example.com", wire::TYPE_HTTPS, wire::CLASS_IN)
-            .map_err(|err| FetchError::Runtime(err.to_string()))?;
+fn records_from_wire_response_for_host(
+    host: &str,
+    raw: &[u8],
+) -> Result<Vec<SvcbRecord>, FetchError> {
+    let records = wire::parse_response_without_id(raw, host, wire::TYPE_HTTPS, wire::CLASS_IN)
+        .map_err(|err| FetchError::Runtime(err.to_string()))?;
     records
         .into_iter()
         .filter(|record| record.class == wire::CLASS_IN && record.typ == wire::TYPE_HTTPS)
@@ -499,19 +785,141 @@ mod tests {
         out
     }
 
+    #[cfg(all(unix, not(target_os = "macos")))]
     #[test]
-    fn skips_malformed_nameserver_and_uses_following_valid_server() {
-        let nameserver =
-            parse_resolv_conf_nameserver("nameserver not-an-address\nnameserver 127.0.0.1\n");
+    fn parses_all_nameservers_and_resolver_options() {
+        let config = parse_resolv_conf(
+            "nameserver not-an-address\n\
+             nameserver 192.0.2.1\n\
+             nameserver 2001:db8::1 # vpn\n\
+             options timeout:9 attempts:4 rotate\n",
+        );
 
-        assert_eq!(nameserver, Some("127.0.0.1:53".parse().unwrap()));
+        assert_eq!(
+            config.nameservers,
+            [
+                "192.0.2.1:53".parse().unwrap(),
+                "[2001:db8::1]:53".parse().unwrap()
+            ]
+        );
+        assert_eq!(config.timeout, std::time::Duration::from_secs(9));
+        assert_eq!(config.attempts, 4);
+        assert!(config.rotate);
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[tokio::test]
+    async fn resolv_conf_lookup_fails_over_to_second_nameserver() {
+        let unavailable = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let unavailable_addr = unavailable.local_addr().unwrap();
+        drop(unavailable);
+        let server = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let server_addr = server.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let mut request = [0_u8; 512];
+            let (length, peer) = server.recv_from(&mut request).await.unwrap();
+            let mut response = request[..length].to_vec();
+            response[2] = 0x81;
+            response[3] = 0x80;
+            server.send_to(&response, peer).await.unwrap();
+        });
+        let config = ResolvConf {
+            nameservers: vec![unavailable_addr, server_addr],
+            timeout: std::time::Duration::from_millis(30),
+            attempts: 1,
+            rotate: false,
+        };
+
+        let records = lookup_with_resolv_conf_config(
+            "example.com",
+            TimeoutBudget::new(Some(std::time::Duration::from_secs(1))),
+            &config,
+        )
+        .await
+        .unwrap();
+
+        assert!(records.is_empty());
+        task.await.unwrap();
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[tokio::test]
+    async fn service_backend_prevents_fallback_routing() {
+        use std::sync::{Arc, atomic::AtomicBool};
+
+        let fallback_ran = Arc::new(AtomicBool::new(false));
+        let marker = Arc::clone(&fallback_ran);
+        let records = route_system_lookup(SystemServiceOutcome::Records(Vec::new()), async move {
+            marker.store(true, Ordering::Relaxed);
+            Ok(Vec::new())
+        })
+        .await
+        .unwrap();
+
+        assert!(records.is_empty());
+        assert!(!fallback_ran.load(Ordering::Relaxed));
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[tokio::test]
+    async fn unavailable_service_uses_resolver_file_fallback() {
+        use std::sync::{Arc, atomic::AtomicBool};
+
+        let fallback_ran = Arc::new(AtomicBool::new(false));
+        let marker = Arc::clone(&fallback_ran);
+        route_system_lookup(SystemServiceOutcome::Unavailable, async move {
+            marker.store(true, Ordering::Relaxed);
+            Ok(Vec::new())
+        })
+        .await
+        .unwrap();
+
+        assert!(fallback_ran.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn classifies_resolvectl_failures_without_bypassing_service_policy() {
+        assert_eq!(
+            classify_resolvectl_failure("example.com: resolve call failed: example.com not found"),
+            ResolvectlFailure::NegativeAnswer
+        );
+        assert_eq!(
+            classify_resolvectl_failure("example.com does not have any RR of the requested type"),
+            ResolvectlFailure::NegativeAnswer
+        );
+        assert_eq!(
+            classify_resolvectl_failure(
+                "example.com: resolve call failed: DNSSEC validation failed"
+            ),
+            ResolvectlFailure::Error
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolvectl_records_accept_canonical_owner_after_cname() {
+        let mut resource = Vec::new();
+        write_dns_name(&mut resource, "canonical.example").unwrap();
+        resource.extend_from_slice(&wire::TYPE_HTTPS.to_be_bytes());
+        resource.extend_from_slice(&wire::CLASS_IN.to_be_bytes());
+        resource.extend_from_slice(&30_u32.to_be_bytes());
+        let rdata = https_rdata();
+        resource.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
+        resource.extend_from_slice(&rdata);
+        let mut framed = (resource.len() as u64).to_le_bytes().to_vec();
+        framed.extend_from_slice(&resource);
+
+        let records = records_from_resolvectl_packets("alias.example", &framed).unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].ttl, Some(30));
     }
 
     #[test]
     fn parses_system_wire_response_without_generated_query_id() {
         let raw = dns_response_without_matching_query_id("example.com.", https_rdata());
 
-        let records = records_from_wire_response(&raw).unwrap();
+        let records = records_from_wire_response_for_host("example.com", &raw).unwrap();
 
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].priority, 1);
@@ -523,7 +931,7 @@ mod tests {
     fn rejects_unrelated_https_answer_owner() {
         let raw = dns_response_without_matching_query_id("unrelated.example.", https_rdata());
 
-        let records = records_from_wire_response(&raw).unwrap();
+        let records = records_from_wire_response_for_host("example.com", &raw).unwrap();
 
         assert!(records.is_empty());
     }

--- a/src/dns/wire.rs
+++ b/src/dns/wire.rs
@@ -314,6 +314,30 @@ pub(crate) fn parse_response_without_id<'a>(
     parse_response_inner(raw, None, expected_name, expected_type, expected_class)
 }
 
+pub(crate) fn parse_standalone_resource_record(
+    raw: &[u8],
+) -> Result<ResourceRecord<'_>, WireError> {
+    let name = read_parsed_name_bounded(raw, 0, raw.len())?;
+    let offset = name.next;
+    let typ = read_u16(raw, offset)?;
+    let class = read_u16(raw, offset + 2)?;
+    let ttl = read_u32(raw, offset + 4)?;
+    let rdlen = usize::from(read_u16(raw, offset + 8)?);
+    let data_offset = offset + 10;
+    let end = data_offset
+        .checked_add(rdlen)
+        .filter(|end| *end == raw.len())
+        .ok_or_else(|| WireError("malformed standalone DNS resource".to_string()))?;
+    Ok(ResourceRecord {
+        canonical_name: name.canonical,
+        typ,
+        class,
+        ttl,
+        data_offset,
+        data: &raw[data_offset..end],
+    })
+}
+
 fn parse_response_inner<'a>(
     raw: &'a [u8],
     expected_id: Option<u16>,


### PR DESCRIPTION
## Summary
- route Linux HTTPS RR discovery through systemd-resolved when available
- add bounded resolv.conf fallback with nameserver failover, attempts, timeout, and rotation
- document Unix fallback limits and add deterministic routing/failover tests

## Validation
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --lib --bins
- full integration test suite from AGENTS.md
- five read-only /review passes