### PR TITLE
fix(dns): validate custom resolver URLs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -451,8 +451,12 @@ DNS over QUIC (DoQ), and DNS-over-HTTPS (DoH) for requests and DNS/TLS
 inspection. Bare `IP[:PORT]` values use UDP DNS, which advertises EDNS(0) and
 retries truncated responses over TCP. DoH URLs are queried with RFC 8484
 wire-format requests, with Google-style JSON DoH retained as a compatibility
-fallback. A DoH transaction has a five-second timeout when no request or
-connection timeout applies. An applicable user-set timeout takes precedence.
+fallback. A DoH endpoint must be an absolute HTTPS URL with a host. Its path
+and query configure the endpoint. Credentials and fragments are not allowed.
+UDP, TCP, DoT, and DoQ URLs do not allow credentials, paths, queries, or
+fragments. Resolver ports must be greater than zero. A DoH transaction has a
+five-second timeout when no request or connection timeout applies. An
+applicable user-set timeout takes precedence.
 
 ```sh
 fetch --dns-server 8.8.8.8 example.com

--- a/src/dns/custom.rs
+++ b/src/dns/custom.rs
@@ -64,51 +64,39 @@ pub(crate) struct DnsQueryRecord {
 }
 
 pub(crate) fn parse_dns_server(value: &str) -> Result<ParsedDnsServer, FetchError> {
-    if value.starts_with("http://") {
-        // DNS unit tests use loopback HTTP fixtures. This branch is absent
-        // from production builds, which always require HTTPS for DoH.
-        #[cfg(test)]
-        if let Ok(url) = Url::parse(value)
-            && url.host().is_some_and(|host| match host {
-                url::Host::Ipv4(ip) => ip.is_loopback(),
-                url::Host::Ipv6(ip) => ip.is_loopback(),
-                url::Host::Domain(name) => name.eq_ignore_ascii_case("localhost"),
-            })
-        {
-            return Ok(ParsedDnsServer::Doh(url));
-        }
-        return Err(FetchError::Message(format!(
-            "invalid value '{value}' for option '--dns-server': DoH endpoints must use HTTPS"
-        )));
-    }
-    if value.starts_with("https://") {
-        let url = Url::parse(value).map_err(|err| {
-            FetchError::Message(format!(
-                "invalid value '{value}' for option '--dns-server': {err}"
-            ))
-        })?;
-        host_and_port(&url)?;
-        return Ok(ParsedDnsServer::Doh(url));
+    if let Some(addr) = parse_bare_dns_server(value) {
+        // Bare IP[:PORT] is treated as udp:// for backward compatibility.
+        return nonzero_socket_addr(value, addr).map(ParsedDnsServer::Udp);
     }
 
     let url = if value.contains("://") {
-        Url::parse(value).map_err(|err| {
-            FetchError::Message(format!(
-                "invalid value '{value}' for option '--dns-server': {err}"
-            ))
-        })?
-    } else if let Some(addr) = parse_bare_dns_server(value) {
-        // Bare IP[:PORT] is treated as udp:// for backward compatibility.
-        return Ok(ParsedDnsServer::Udp(addr));
+        Url::parse(value)
     } else {
-        Url::parse(&format!("udp://{value}")).map_err(|err| {
-            FetchError::Message(format!(
-                "invalid value '{value}' for option '--dns-server': {err}"
-            ))
-        })?
-    };
+        Url::parse(&format!("udp://{value}"))
+    }
+    .map_err(|err| dns_server_error(value, &err.to_string()))?;
 
     let scheme = url.scheme();
+    if scheme == "http" || scheme == "https" {
+        validate_doh_url(value, &url)?;
+        if scheme == "https" {
+            return Ok(ParsedDnsServer::Doh(url));
+        }
+
+        // DNS unit tests use loopback HTTP fixtures. This branch is absent
+        // from production builds, which always require HTTPS for DoH.
+        #[cfg(test)]
+        if url.host().is_some_and(|host| match host {
+            url::Host::Ipv4(ip) => ip.is_loopback(),
+            url::Host::Ipv6(ip) => ip.is_loopback(),
+            url::Host::Domain(name) => name.eq_ignore_ascii_case("localhost"),
+        }) {
+            return Ok(ParsedDnsServer::Doh(url));
+        }
+        return Err(dns_server_error(value, "DoH endpoints must use HTTPS"));
+    }
+
+    validate_non_http_url(value, &url)?;
     let (host, port) = host_and_port(&url)?;
     match scheme {
         "udp" => Ok(ParsedDnsServer::Udp(socket_addr(
@@ -131,10 +119,57 @@ pub(crate) fn parse_dns_server(value: &str) -> Result<ParsedDnsServer, FetchErro
             host,
             port: port.unwrap_or(DEFAULT_DNS_OVER_QUIC_PORT),
         }),
-        _ => Err(FetchError::Message(format!(
-            "invalid value '{value}' for option '--dns-server': unsupported scheme '{scheme}'"
-        ))),
+        _ => Err(dns_server_error(
+            value,
+            &format!("unsupported scheme '{scheme}'"),
+        )),
     }
+}
+
+fn validate_doh_url(value: &str, url: &Url) -> Result<(), FetchError> {
+    host_and_port(url)?;
+    validate_nonzero_port(value, url.port())?;
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(dns_server_error(value, "credentials are not allowed"));
+    }
+    if url.fragment().is_some() {
+        return Err(dns_server_error(value, "fragments are not allowed"));
+    }
+    Ok(())
+}
+
+fn validate_non_http_url(value: &str, url: &Url) -> Result<(), FetchError> {
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(dns_server_error(value, "credentials are not allowed"));
+    }
+    if !url.path().is_empty() {
+        return Err(dns_server_error(value, "paths are not allowed"));
+    }
+    if url.query().is_some() {
+        return Err(dns_server_error(value, "queries are not allowed"));
+    }
+    if url.fragment().is_some() {
+        return Err(dns_server_error(value, "fragments are not allowed"));
+    }
+    validate_nonzero_port(value, url.port())
+}
+
+fn validate_nonzero_port(value: &str, port: Option<u16>) -> Result<(), FetchError> {
+    if port == Some(0) {
+        return Err(dns_server_error(value, "port must be greater than zero"));
+    }
+    Ok(())
+}
+
+fn nonzero_socket_addr(value: &str, addr: SocketAddr) -> Result<SocketAddr, FetchError> {
+    validate_nonzero_port(value, Some(addr.port()))?;
+    Ok(addr)
+}
+
+fn dns_server_error(value: &str, message: &str) -> FetchError {
+    FetchError::Message(format!(
+        "invalid value '{value}' for option '--dns-server': {message}"
+    ))
 }
 
 fn parse_bare_dns_server(value: &str) -> Option<SocketAddr> {
@@ -298,8 +333,8 @@ pub(crate) async fn query_type(
     }
 }
 
-pub(crate) async fn lookup_ips(
-    dns_server: &str,
+pub(crate) async fn lookup_ips_with_server(
+    dns_server: &ParsedDnsServer,
     host: &str,
     timeout: Option<Duration>,
 ) -> Result<Vec<IpAddr>, FetchError> {
@@ -307,11 +342,11 @@ pub(crate) async fn lookup_ips(
         return Ok(vec![ip]);
     }
 
-    match parse_dns_server(dns_server)? {
-        ParsedDnsServer::Udp(addr) => crate::dns::resolver::lookup_udp_addr(&addr, host, timeout)
+    match dns_server {
+        ParsedDnsServer::Udp(addr) => crate::dns::resolver::lookup_udp_addr(addr, host, timeout)
             .await
             .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}"))),
-        ParsedDnsServer::Tcp(addr) => crate::dns::resolver::lookup_tcp_addr(&addr, host, timeout)
+        ParsedDnsServer::Tcp(addr) => crate::dns::resolver::lookup_tcp_addr(addr, host, timeout)
             .await
             .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}"))),
         ParsedDnsServer::Tls {
@@ -320,9 +355,9 @@ pub(crate) async fn lookup_ips(
             port,
         } => {
             let resolve_start = std::time::Instant::now();
-            let addrs = resolve_server_host(&server_host, port, timeout).await?;
+            let addrs = resolve_server_host(server_host, *port, timeout).await?;
             let remaining = timeout.map(|t| t.saturating_sub(resolve_start.elapsed()));
-            crate::dns::resolver::lookup_tls(&server_name, &addrs, host, remaining, false)
+            crate::dns::resolver::lookup_tls(server_name, &addrs, host, remaining, false)
                 .await
                 .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))
         }
@@ -332,13 +367,13 @@ pub(crate) async fn lookup_ips(
             port,
         } => {
             let resolve_start = std::time::Instant::now();
-            let addrs = resolve_server_host(&server_host, port, timeout).await?;
+            let addrs = resolve_server_host(server_host, *port, timeout).await?;
             let remaining = timeout.map(|t| t.saturating_sub(resolve_start.elapsed()));
-            crate::dns::resolver::lookup_quic(&server_name, &addrs, host, remaining, false)
+            crate::dns::resolver::lookup_quic(server_name, &addrs, host, remaining, false)
                 .await
                 .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))
         }
-        ParsedDnsServer::Doh(url) => crate::dns::doh::lookup_doh(&url, host, timeout)
+        ParsedDnsServer::Doh(url) => crate::dns::doh::lookup_doh(url, host, timeout)
             .await
             .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}"))),
     }
@@ -491,10 +526,73 @@ mod tests {
 
     #[test]
     fn parse_dns_server_accepts_doh_url() {
-        let parsed = parse_dns_server("https://dns.example/dns-query").unwrap();
+        let parsed = parse_dns_server("https://dns.example/dns-query?profile=secure").unwrap();
         assert!(
-            matches!(parsed, ParsedDnsServer::Doh(url) if url.as_str() == "https://dns.example/dns-query")
+            matches!(parsed, ParsedDnsServer::Doh(url) if url.as_str() == "https://dns.example/dns-query?profile=secure")
         );
+    }
+
+    #[test]
+    fn parse_dns_server_normalizes_mixed_case_schemes() {
+        assert!(matches!(
+            parse_dns_server("UdP://1.1.1.1").unwrap(),
+            ParsedDnsServer::Udp(_)
+        ));
+        assert!(matches!(
+            parse_dns_server("TcP://1.1.1.1").unwrap(),
+            ParsedDnsServer::Tcp(_)
+        ));
+        assert!(matches!(
+            parse_dns_server("DoT://dns.example").unwrap(),
+            ParsedDnsServer::Tls { .. }
+        ));
+        assert!(matches!(
+            parse_dns_server("DoQ://dns.example").unwrap(),
+            ParsedDnsServer::Quic { .. }
+        ));
+        assert!(matches!(
+            parse_dns_server("HtTpS://dns.example/dns-query").unwrap(),
+            ParsedDnsServer::Doh(url) if url.scheme() == "https"
+        ));
+    }
+
+    #[test]
+    fn parse_dns_server_rejects_non_http_url_components() {
+        for scheme in ["udp", "tcp", "tls", "dot", "quic", "doq"] {
+            for suffix in ["/dns-query", "?profile=x", "#fragment"] {
+                let value = format!("{scheme}://1.1.1.1{suffix}");
+                assert!(parse_dns_server(&value).is_err(), "accepted {value}");
+            }
+            for authority in ["user@1.1.1.1", "user:pass@1.1.1.1"] {
+                let value = format!("{scheme}://{authority}");
+                assert!(parse_dns_server(&value).is_err(), "accepted {value}");
+            }
+        }
+    }
+
+    #[test]
+    fn parse_dns_server_rejects_doh_credentials_and_fragments() {
+        for value in [
+            "https://user@dns.example/dns-query",
+            "https://user:pass@dns.example/dns-query",
+            "https://dns.example/dns-query#fragment",
+        ] {
+            assert!(parse_dns_server(value).is_err(), "accepted {value}");
+        }
+    }
+
+    #[test]
+    fn parse_dns_server_rejects_port_zero() {
+        for value in [
+            "1.1.1.1:0",
+            "udp://1.1.1.1:0",
+            "tcp://1.1.1.1:0",
+            "tls://dns.example:0",
+            "doq://dns.example:0",
+            "https://dns.example:0/dns-query",
+        ] {
+            assert!(parse_dns_server(value).is_err(), "accepted {value}");
+        }
     }
 
     #[test]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -849,17 +849,15 @@ async fn lookup_custom_ips_with_doh_tls(
     host: &str,
     timeout: TimeoutBudget,
 ) -> Result<Vec<IpAddr>, FetchError> {
-    if dns_server.starts_with("http://") || dns_server.starts_with("https://") {
-        return crate::net::resolve_host_with_doh_tls(
-            host,
-            Some(dns_server),
-            doh_tls_config_for_cli(cli)?,
-            timeout,
-        )
-        .await
-        .map(|addrs| addrs.into_iter().map(|addr| addr.ip()).collect());
-    }
-    custom::lookup_ips(dns_server, host, timeout.timeout()).await
+    let server = custom::parse_dns_server(dns_server)?;
+    crate::net::resolve_host_with_dns_server(
+        host,
+        Some(&server),
+        doh_tls_config_for_server(cli, &server)?,
+        timeout,
+    )
+    .await
+    .map(|addrs| addrs.into_iter().map(|addr| addr.ip()).collect())
 }
 
 pub(crate) fn doh_tls_config_for_cli(
@@ -868,7 +866,15 @@ pub(crate) fn doh_tls_config_for_cli(
     let Some(dns_server) = cli.dns_server.as_deref() else {
         return Ok(None);
     };
-    if !(dns_server.starts_with("http://") || dns_server.starts_with("https://")) {
+    let server = custom::parse_dns_server(dns_server)?;
+    doh_tls_config_for_server(cli, &server)
+}
+
+fn doh_tls_config_for_server(
+    cli: &Cli,
+    server: &custom::ParsedDnsServer,
+) -> Result<Option<rustls::ClientConfig>, FetchError> {
+    if !matches!(server, custom::ParsedDnsServer::Doh(_)) {
         return Ok(None);
     }
     let min_tls = cli.min_tls.as_deref().or(cli.tls.as_deref());

--- a/src/net.rs
+++ b/src/net.rs
@@ -131,10 +131,22 @@ pub(crate) async fn resolve_host_with_doh_tls(
     doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<Vec<SocketAddr>, FetchError> {
+    let dns_server = dns_server
+        .map(crate::dns::custom::parse_dns_server)
+        .transpose()?;
+    resolve_host_with_dns_server(host, dns_server.as_ref(), doh_tls_config, timeout).await
+}
+
+pub(crate) async fn resolve_host_with_dns_server(
+    host: &str,
+    dns_server: Option<&crate::dns::custom::ParsedDnsServer>,
+    doh_tls_config: Option<rustls::ClientConfig>,
+    timeout: TimeoutBudget,
+) -> Result<Vec<SocketAddr>, FetchError> {
     if let Ok(ip) = host.parse::<IpAddr>() {
         return Ok(vec![SocketAddr::new(ip, 0)]);
     }
-    let Some(dns_server) = dns_server else {
+    let Some(server) = dns_server else {
         return resolve_system_host_with(
             host,
             timeout,
@@ -147,11 +159,11 @@ pub(crate) async fn resolve_host_with_doh_tls(
         .await;
     };
 
-    let addrs = if is_doh_dns_server(dns_server) {
-        let shared_doh = shared_doh_resolver(dns_server, host, timeout, doh_tls_config.as_ref())?;
-        resolve_doh_ips(host, dns_server, Some(&shared_doh), timeout).await?
+    let addrs = if matches!(server, crate::dns::custom::ParsedDnsServer::Doh(_)) {
+        let shared_doh = shared_doh_resolver(server, host, timeout, doh_tls_config.as_ref())?;
+        resolve_doh_ips(host, &shared_doh).await?
     } else {
-        crate::dns::custom::lookup_ips(dns_server, host, timeout.remaining()?).await?
+        crate::dns::custom::lookup_ips_with_server(server, host, timeout.remaining()?).await?
     };
     Ok(addrs
         .into_iter()
@@ -179,7 +191,7 @@ async fn resolve_system_host_with(
 async fn resolve_host_family(
     host: &str,
     port: u16,
-    dns_server: Option<&str>,
+    dns_server: Option<&crate::dns::custom::ParsedDnsServer>,
     shared_doh: Option<&SharedDohResolver>,
     family: AddressFamily,
     timeout: TimeoutBudget,
@@ -205,7 +217,7 @@ async fn resolve_host_family(
 
 async fn resolve_custom_host_family(
     host: &str,
-    dns_server: &str,
+    dns_server: &crate::dns::custom::ParsedDnsServer,
     shared_doh: Option<&SharedDohResolver>,
     family: AddressFamily,
     timeout: TimeoutBudget,
@@ -214,9 +226,9 @@ async fn resolve_custom_host_family(
         AddressFamily::Ipv4 => ("A", crate::dns::wire::TYPE_A),
         AddressFamily::Ipv6 => ("AAAA", crate::dns::wire::TYPE_AAAA),
     };
-    match crate::dns::custom::parse_dns_server(dns_server)? {
+    match dns_server {
         crate::dns::custom::ParsedDnsServer::Doh(_) => {
-            resolve_doh_host_family(host, dns_server, shared_doh, label, answer_type, timeout).await
+            resolve_doh_host_family(host, shared_doh, label, answer_type).await
         }
         crate::dns::custom::ParsedDnsServer::Udp(addr) => {
             let server_addr = addr.to_string();
@@ -228,7 +240,7 @@ async fn resolve_custom_host_family(
         }
         crate::dns::custom::ParsedDnsServer::Tcp(addr) => {
             let timeout = crate::dns::util::udp_dns_timeout(timeout.remaining()?);
-            crate::dns::resolver::lookup_tcp_type(&addr, host, answer_type, timeout)
+            crate::dns::resolver::lookup_tcp_type(addr, host, answer_type, timeout)
                 .await
                 .map(|records| records.into_iter().map(|record| record.ip).collect())
                 .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))
@@ -239,11 +251,11 @@ async fn resolve_custom_host_family(
             port,
         } => {
             let addrs =
-                crate::dns::custom::resolve_server_host(&server_host, port, timeout.remaining()?)
+                crate::dns::custom::resolve_server_host(server_host, *port, timeout.remaining()?)
                     .await?;
             let timeout = crate::dns::util::udp_dns_timeout(timeout.remaining()?);
             crate::dns::resolver::lookup_tls_type(
-                &server_name,
+                server_name,
                 &addrs,
                 host,
                 answer_type,
@@ -260,11 +272,11 @@ async fn resolve_custom_host_family(
             port,
         } => {
             let addrs =
-                crate::dns::custom::resolve_server_host(&server_host, port, timeout.remaining()?)
+                crate::dns::custom::resolve_server_host(server_host, *port, timeout.remaining()?)
                     .await?;
             let timeout = crate::dns::util::udp_dns_timeout(timeout.remaining()?);
             crate::dns::resolver::lookup_quic_type(
-                &server_name,
+                server_name,
                 &addrs,
                 host,
                 answer_type,
@@ -279,50 +291,32 @@ async fn resolve_custom_host_family(
 }
 
 fn shared_doh_resolver(
-    dns_server: &str,
+    dns_server: &crate::dns::custom::ParsedDnsServer,
     host: &str,
     timeout: TimeoutBudget,
     doh_tls_config: Option<&rustls::ClientConfig>,
 ) -> Result<SharedDohResolver, FetchError> {
-    let server_url = parse_doh_dns_server(dns_server)?;
+    let crate::dns::custom::ParsedDnsServer::Doh(server_url) = dns_server else {
+        return Err(FetchError::Message(
+            "DNS server is not a DoH endpoint".to_string(),
+        ));
+    };
     let client =
         crate::dns::doh::client_with_budget_and_tls_config(timeout, doh_tls_config.cloned())
             .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))?;
-    Ok(SharedDohResolver { server_url, client })
-}
-
-fn is_doh_dns_server(dns_server: &str) -> bool {
-    dns_server.starts_with("http://") || dns_server.starts_with("https://")
-}
-
-fn parse_doh_dns_server(dns_server: &str) -> Result<Url, FetchError> {
-    Url::parse(dns_server)
-        .map_err(|err| FetchError::Message(format!("invalid dns-server '{dns_server}': {err}")))
+    Ok(SharedDohResolver {
+        server_url: server_url.clone(),
+        client,
+    })
 }
 
 async fn resolve_doh_ips(
     host: &str,
-    dns_server: &str,
-    shared_doh: Option<&SharedDohResolver>,
-    timeout: TimeoutBudget,
+    shared_doh: &SharedDohResolver,
 ) -> Result<Vec<IpAddr>, FetchError> {
     crate::dns::util::resolve_address_families(
-        resolve_doh_host_family(
-            host,
-            dns_server,
-            shared_doh,
-            "A",
-            crate::dns::wire::TYPE_A,
-            timeout,
-        ),
-        resolve_doh_host_family(
-            host,
-            dns_server,
-            shared_doh,
-            "AAAA",
-            crate::dns::wire::TYPE_AAAA,
-            timeout,
-        ),
+        resolve_doh_host_family(host, Some(shared_doh), "A", crate::dns::wire::TYPE_A),
+        resolve_doh_host_family(host, Some(shared_doh), "AAAA", crate::dns::wire::TYPE_AAAA),
         HAPPY_EYEBALLS_RESOLUTION_DELAY,
         FetchError::Runtime(format!("lookup {host}: no such host")),
     )
@@ -331,32 +325,19 @@ async fn resolve_doh_ips(
 
 async fn resolve_doh_host_family(
     host: &str,
-    dns_server: &str,
     shared_doh: Option<&SharedDohResolver>,
     label: &str,
     answer_type: u16,
-    timeout: TimeoutBudget,
 ) -> Result<Vec<IpAddr>, FetchError> {
-    let records = if let Some(shared_doh) = shared_doh {
-        crate::dns::doh::lookup_doh_type_with_client(
-            &shared_doh.client,
-            &shared_doh.server_url,
-            host,
-            label,
-            answer_type,
-        )
-        .await
-    } else {
-        let server_url = parse_doh_dns_server(dns_server)?;
-        crate::dns::doh::lookup_doh_type(
-            &server_url,
-            host,
-            label,
-            answer_type,
-            timeout.remaining()?,
-        )
-        .await
-    };
+    let shared_doh = shared_doh.expect("DoH resolver is initialized for a parsed DoH server");
+    let records = crate::dns::doh::lookup_doh_type_with_client(
+        &shared_doh.client,
+        &shared_doh.server_url,
+        host,
+        label,
+        answer_type,
+    )
+    .await;
     records
         .map(|records| records.into_iter().map(|record| record.ip).collect())
         .map_err(|err| FetchError::Runtime(format!("lookup {host}: {err}")))
@@ -555,20 +536,21 @@ pub(crate) async fn connect_host_happy_eyeballs_traced(
     doh_tls_config: Option<rustls::ClientConfig>,
     timeout: TimeoutBudget,
 ) -> Result<TcpConnectTrace, FetchError> {
-    let shared_doh = match dns_server.filter(|s| is_doh_dns_server(s)) {
-        Some(server) => Some(shared_doh_resolver(
-            server,
-            host,
-            timeout,
-            doh_tls_config.as_ref(),
-        )?),
-        None => None,
-    };
+    let dns_server = dns_server
+        .map(crate::dns::custom::parse_dns_server)
+        .transpose()?;
+    let shared_doh =
+        match dns_server.as_ref() {
+            Some(server @ crate::dns::custom::ParsedDnsServer::Doh(_)) => Some(
+                shared_doh_resolver(server, host, timeout, doh_tls_config.as_ref())?,
+            ),
+            _ => None,
+        };
     let dns_start = Instant::now();
     let mut ipv4 = Box::pin(resolve_host_family(
         host,
         port,
-        dns_server,
+        dns_server.as_ref(),
         shared_doh.as_ref(),
         AddressFamily::Ipv4,
         timeout,
@@ -576,7 +558,7 @@ pub(crate) async fn connect_host_happy_eyeballs_traced(
     let mut ipv6 = Box::pin(resolve_host_family(
         host,
         port,
-        dns_server,
+        dns_server.as_ref(),
         shared_doh.as_ref(),
         AddressFamily::Ipv6,
         timeout,

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -1617,6 +1617,17 @@ fn dns_over_https_udp_and_inspect_dns_cases() {
     assert_exit(&res, 0);
     assert!(res.stderr.contains("204 No Content"));
 
+    let mixed_case_doh_url = doh.url.replacen("https://", "HtTpS://", 1);
+    let res = run_fetch(&[
+        &localhost_url,
+        "--dns-server",
+        &format!("{mixed_case_doh_url}/dns-query"),
+        "--ca-cert",
+        doh.ca_cert_path.to_str().unwrap(),
+    ]);
+    assert_exit(&res, 0);
+    assert!(res.stderr.contains("204 No Content"));
+
     let res = run_fetch(&[
         &localhost_url,
         "--dns-server",


### PR DESCRIPTION
## Summary
- parse custom DNS server values once and reuse the validated representation
- reject invalid URL components and zero resolver ports
- support mixed-case resolver schemes and document the accepted URL forms

## Validation
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- `cargo test --locked --all-features --test cli --test formatting --test grpc --test har --test http --test install --test network --test terminal --test update --test websocket -- --test-threads=2`
