### PR TITLE
test: handle Windows connection refusal errors

### DIFF
--- a/src/dns/wire.rs
+++ b/src/dns/wire.rs
@@ -319,6 +319,7 @@ pub(crate) fn parse_response_without_id<'a>(
     parse_response_inner(raw, None, expected_name, expected_type, expected_class)
 }
 
+#[cfg(target_os = "linux")]
 pub(crate) fn parse_standalone_resource_record(
     raw: &[u8],
 ) -> Result<ResourceRecord<'_>, WireError> {

--- a/tests/support/common.rs
+++ b/tests/support/common.rs
@@ -186,7 +186,8 @@ pub(crate) fn is_transient_local_server_error(res: &FetchOutput) -> bool {
             .contains("connection closed before message completed")
             || res.stderr.contains("connection was not ready")
             || res.stderr.contains("Connection reset by peer")
-            || res.stderr.contains("Connection refused"))
+            || res.stderr.contains("Connection refused")
+            || res.stderr.contains("os error 10061"))
 }
 
 pub(crate) fn assert_exit(res: &FetchOutput, code: i32) {


### PR DESCRIPTION
## Summary

- treat Winsock error 10061 as a transient local test-server failure
- compile the standalone DNS resource parser only on Linux, where it is used

## Validation

- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins`
- `cargo test --locked --all-features --test cli --test formatting --test grpc --test har --test http --test install --test network --test terminal --test update --test websocket -- --test-threads=2`