### PR TITLE
test: drain PTY output before assertions

### DIFF
--- a/tests/support/pty.rs
+++ b/tests/support/pty.rs
@@ -117,6 +117,15 @@ impl PtyCapture {
         drop(self.file);
         let _ = self.done.recv_timeout(Duration::from_secs(1));
     }
+
+    /// Closes the PTY and returns all output after the capture thread drains it.
+    pub(crate) fn finish(self) -> String {
+        drop(self.file);
+        self.done
+            .recv_timeout(Duration::from_secs(3))
+            .expect("PTY capture thread did not finish");
+        String::from_utf8_lossy(&self.buffer.lock().unwrap()).into_owned()
+    }
 }
 
 pub(crate) fn configure_pty_child(cmd: &mut Command, slave: &fs::File) {

--- a/tests/support/terminal.rs
+++ b/tests/support/terminal.rs
@@ -285,6 +285,9 @@ pub(crate) fn run_binary_pty_with_custom_body(
     cmd.env("NO_PROXY", "*");
     configure_pty_child(&mut cmd, &pty.slave);
     let mut child = cmd.spawn().expect("spawn fetch under PTY");
+    // Command keeps its configured stdio handles after spawning. Drop it so
+    // the parent does not keep the PTY slave open after the child exits.
+    drop(cmd);
     drop(pty.slave);
     let capture = start_pty_capture(&pty.master);
     let status = wait_child(&mut child, Duration::from_secs(5))

--- a/tests/support/terminal.rs
+++ b/tests/support/terminal.rs
@@ -301,9 +301,8 @@ pub(crate) fn run_binary_pty_with_custom_body(
         "fetch exited with {status}; PTY output:\n{}",
         capture.output()
     );
-    let output = capture.output();
     drop(pty.master);
-    capture.close();
+    let output = capture.finish();
     (
         output,
         fs::read_to_string(less_args).ok(),


### PR DESCRIPTION
## Summary
- add a PTY capture helper that waits for the reader thread to drain output
- use the helper for midstream binary detection output assertions
- prevent the final warning from racing the Linux CI test

## Validation
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --test terminal terminal_stdout_midstream_binary_detection -- --exact` (3 consecutive runs)