### PR TITLE
chore(deps): upgrade legible to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,9 +1353,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legible"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ec7f7fa1fc97c139420025a96185aa4d1db3a7d2a4270dbb93d0866f7af830"
+checksum = "b1365098e73aae697c4d747782d2fd5b9bfa3d6a82f2a3f6070c2039053146e5"
 dependencies = [
  "html5ever",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ hyper = { version = "=1.11.0", features = ["client", "http1", "http2"] }
 hyper-util = { version = "=0.1.20", features = ["client-legacy", "client-proxy", "client-proxy-system", "http1", "http2", "tokio"] }
 image = { version = "=0.25.10", default-features = false, features = ["jpeg", "png", "tiff", "webp"] }
 ipnet = "=2.12.1"
-legible = "=0.5.0"
+legible = "=0.5.1"
 md-5 = "=0.11.0"
 memchr = "=2.8.3"
 mime = "=0.3.17"


### PR DESCRIPTION
## Summary
- Upgrade the pinned `legible` dependency from 0.5.0 to 0.5.1.
- Refresh the lockfile checksum.

## Validation
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --lib --bins` (1002 passed)